### PR TITLE
models allowing immutability

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 History
 -------
 
+v0.3.0 (TBC)
+............
+* immutable models via ``config.allow_mutation = False``, associated cleanup and performance improvement #44
+* ``setatt`` is removed as ``__setattr__`` is not intelligent #44
+* ``raise_exception`` removed, Models now always raise exceptions #44
+* instance method validators removed TODO
+* django-restful-framework benchmarks added #47
+
 v0.2.1 (2017-06-07)
 ...................
 * pypi and travis together messed up the deploy of ``v0.2`` this should fix it

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 v0.3.0 (TBC)
 ............
 * immutable models via ``config.allow_mutation = False``, associated cleanup and performance improvement #44
-* ``setatt`` is removed as ``__setattr__`` is not intelligent #44
+* ``setattr`` is removed as ``__setattr__`` is now intelligent #44
 * ``raise_exception`` removed, Models now always raise exceptions #44
 * instance method validators removed TODO
 * django-restful-framework benchmarks added #47

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,13 +1,14 @@
 import json
 import random
 import string
+import sys
 from datetime import datetime
 from functools import partial
 from pathlib import Path
 from statistics import mean, stdev
 
-from test_trafaret import TestTrafaret
 from test_pydantic import TestPydantic
+from test_trafaret import TestTrafaret
 from test_drf import TestDRF
 
 PUNCTUATION = ' \t\n!"#$%&\'()*+,-./'
@@ -108,7 +109,10 @@ def main():
     else:
         with json_path.open() as f:
             cases = json.load(f)
-    tests = [TestTrafaret, TestDRF, TestPydantic]
+    if 'pydantic-only' in sys.argv:
+        tests = [TestPydantic]
+    else:
+        tests = [TestPydantic, TestTrafaret, TestDRF]
     for test_class in tests:
         times = []
         p = test_class.package

--- a/docs/examples/config.py
+++ b/docs/examples/config.py
@@ -9,7 +9,6 @@ class UserModel(BaseModel):
         max_anystr_length = 2 ** 16  # max length for str & byte types
         min_number_size = -2 ** 64  # min size for numbers
         max_number_size = 2 ** 64  # max size for numbers
-        raise_exception = True  # whether or not to raise an exception if the data is invalid
         validate_all = False  # whether or not to validate field defaults
         ignore_extra = True  # whether to ignore any extra values in input data
         allow_extra = False  # whether or not too allow (and include on the model) any extra values in input data

--- a/docs/examples/config.py
+++ b/docs/examples/config.py
@@ -12,4 +12,5 @@ class UserModel(BaseModel):
         validate_all = False  # whether or not to validate field defaults
         ignore_extra = True  # whether to ignore any extra values in input data
         allow_extra = False  # whether or not too allow (and include on the model) any extra values in input data
+        allow_mutation = True  # whether or not models are faux-immutable, eg. setattr fails on model fields
         fields = None  # extra information on each field, currently just "alias is allowed"

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -2,6 +2,7 @@ aren
 cerberus
 Config
 config
+django
 ints
 jsonmodels
 pydantic

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -47,7 +47,6 @@ class Field:
         self.validators = []
         self.default: Any = default
         self.required: bool = required
-        self.required: bool = required
         self.model_config = model_config
         self.description: str = description
         self.allow_none: bool = allow_none

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -12,7 +12,6 @@ Required: Any = Ellipsis
 class ValidatorSignature(IntEnum):
     JUST_VALUE = 1
     VALUE_KWARGS = 2
-    BOUND_METHOD = 3
 
 
 class Shape(IntEnum):
@@ -23,7 +22,7 @@ class Shape(IntEnum):
 
 
 class Field:
-    __slots__ = ('type_', 'key_type_', 'sub_fields', 'key_field', 'validators', 'default', 'required',
+    __slots__ = ('type_', 'key_type_', 'sub_fields', 'key_field', 'validators', 'default', 'required', 'model_config',
                  'name', 'alias', 'description', 'info', 'validate_always', 'allow_none', 'shape', 'multipart')
 
     def __init__(
@@ -35,6 +34,7 @@ class Field:
             default: Any=None,
             required: bool=False,
             allow_none: bool=False,
+            model_config: Any=None,
             description: str=None):
 
         self.name: str = name
@@ -47,6 +47,8 @@ class Field:
         self.validators = []
         self.default: Any = default
         self.required: bool = required
+        self.required: bool = required
+        self.model_config = model_config
         self.description: str = description
         self.allow_none: bool = allow_none
         self.shape: Shape = Shape.SINGLETON
@@ -55,8 +57,11 @@ class Field:
         self._prepare(class_validators or {})
 
     @classmethod
-    def infer(cls, *, name, value, annotation, class_validators, field_config):
+    def infer(cls, *, name, value, annotation, class_validators, config):
         required = value == Required
+        field_config = config.fields.get(name)
+        if isinstance(field_config, str):
+            field_config = {'alias': field_config}
         return cls(
             name=name,
             type_=annotation,
@@ -64,6 +69,7 @@ class Field:
             class_validators=class_validators,
             default=None if required else value,
             required=required,
+            model_config=config,
             description=field_config and field_config.get('description'),
         )
 
@@ -115,13 +121,14 @@ class Field:
                     self.allow_none = True
                 else:
                     types_.append(type_)
-            self.sub_fields = [Field(
+            self.sub_fields = [self.__class__(
                 type_=t,
                 class_validators=class_validators,
                 default=self.default,
                 required=self.required,
                 allow_none=self.allow_none,
-                name=f'{self.name}_{type_display(t)}'
+                name=f'{self.name}_{type_display(t)}',
+                model_config=self.model_config,
             ) for t in types_]
             self.multipart = True
         elif issubclass(origin, List):
@@ -135,24 +142,26 @@ class Field:
             self.key_type_ = self.type_.__args__[0]
             self.type_ = self.type_.__args__[1]
             self.shape = Shape.MAPPING
-            self.key_field = Field(
+            self.key_field = self.__class__(
                 type_=self.key_type_,
                 class_validators=class_validators,
                 default=self.default,
                 required=self.required,
                 allow_none=self.allow_none,
-                name=f'key_{self.name}'
+                name=f'key_{self.name}',
+                model_config=self.model_config,
             )
 
         if self.sub_fields is None and getattr(self.type_, '__origin__', False):
             self.multipart = True
-            self.sub_fields = [Field(
+            self.sub_fields = [self.__class__(
                 type_=self.type_,
                 class_validators=class_validators,
                 default=self.default,
                 required=self.required,
                 allow_none=self.allow_none,
-                name=f'_{self.name}'
+                name=f'_{self.name}',
+                model_config=self.model_config,
             )]
 
     def _populate_validators(self, class_validators):
@@ -173,29 +182,29 @@ class Field:
                 f,
             ))
 
-    def validate(self, v, model, index=None):
+    def validate(self, v, values, index=None):
         if self.allow_none and v is None:
             return None, None
 
         if self.shape is Shape.SINGLETON:
-            return self._validate_singleton(v, model, index)
+            return self._validate_singleton(v, values, index)
         elif self.shape is Shape.MAPPING:
-            return self._validate_mapping(v, model)
+            return self._validate_mapping(v, values)
         else:
             # list or set
-            result, errors = self._validate_sequence(v, model)
+            result, errors = self._validate_sequence(v, values)
             if not errors and self.shape is Shape.SET:
                 return set(result), errors
             return result, errors
 
-    def _validate_sequence(self, v, model):
+    def _validate_sequence(self, v, values):
         result, errors = [], []
         try:
             v_iter = enumerate(v)
         except TypeError as exc:
             return v, Error(exc, None, None)
         for i, v_ in v_iter:
-            single_result, single_errors = self._validate_singleton(v_, model, i)
+            single_result, single_errors = self._validate_singleton(v_, values, i)
             if single_errors:
                 errors.append(single_errors)
             else:
@@ -205,7 +214,7 @@ class Field:
         else:
             return result, None
 
-    def _validate_mapping(self, v, model):
+    def _validate_mapping(self, v, values):
         if isinstance(v, dict):
             v_iter = v
         else:
@@ -216,11 +225,11 @@ class Field:
 
         result, errors = {}, []
         for k, v_ in v_iter.items():
-            key_result, key_errors = self.key_field.validate(k, model, 'key')
+            key_result, key_errors = self.key_field.validate(k, values, 'key')
             if key_errors:
                 errors.append(key_errors)
                 continue
-            value_result, value_errors = self._validate_singleton(v_, model, k)
+            value_result, value_errors = self._validate_singleton(v_, values, k)
             if value_errors:
                 errors.append(value_errors)
                 continue
@@ -230,11 +239,11 @@ class Field:
         else:
             return result, None
 
-    def _validate_singleton(self, v, model, index):
+    def _validate_singleton(self, v, values, index):
         if self.multipart:
             errors = []
             for field in self.sub_fields:
-                value, error = field.validate(v, model, index)
+                value, error = field.validate(v, values, index)
                 if error:
                     errors.append(error)
                 else:
@@ -245,10 +254,9 @@ class Field:
                 try:
                     if signature is ValidatorSignature.JUST_VALUE:
                         v = validator(v)
-                    elif signature is ValidatorSignature.VALUE_KWARGS:
-                        v = validator(v, model=model, field=self)
                     else:
-                        v = validator(model, v)
+                        # ValidatorSignature.VALUE_KWARGS
+                        v = validator(v, values=values, config=self.model_config, field=self)
                 except (ValueError, TypeError) as exc:
                     return v, Error(exc, self.type_, index)
             return v, None
@@ -274,15 +282,12 @@ def _get_validator_signature(validator):
     # 1. we can deal with it before validation begins
     # 2. (more importantly) it doesn't get confused with a TypeError when executing the validator
     try:
-        if list(signature.parameters)[0] == 'self':
-            signature.bind(object(), 1)
-            return ValidatorSignature.BOUND_METHOD
-        elif len(signature.parameters) == 1:
+        if len(signature.parameters) == 1:
             signature.bind(1)
             return ValidatorSignature.JUST_VALUE
         else:
-            signature.bind(1, model=2, field=3)
+            signature.bind(1, values=2, config=3, field=4)
             return ValidatorSignature.VALUE_KWARGS
     except TypeError as e:
         raise ConfigError(f'Invalid signature for validator {validator}: {signature}, should be: '
-                          f'(value) or (value, *, model, field)') from e
+                          f'(value) or (value, *, values, config, field)') from e

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -159,7 +159,7 @@ class BaseModel(metaclass=MetaModel):
                         value = input_data[field]
                         values[field] = value
                 else:
-                    # self.config.ignore_extra is False
+                    # config.ignore_extra is False
                     for field in sorted(extra):
                         errors[field] = EXTRA_ERROR
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -151,13 +151,12 @@ class BaseModel(metaclass=MetaModel):
             if errors_:
                 errors[field.alias] = errors_
 
-        if not self.config.ignore_extra or self.config.allow_extra:
+        if (not self.config.ignore_extra) or self.config.allow_extra:
             extra = input_data.keys() - {f.alias for f in self.__fields__.values()}
             if extra:
                 if self.config.allow_extra:
                     for field in extra:
-                        value = input_data[field]
-                        values[field] = value
+                        values[field] = input_data[field]
                 else:
                     # config.ignore_extra is False
                     for field in sorted(extra):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -138,7 +138,7 @@ class BaseModel(metaclass=MetaModel):
     def validate(cls, value):
         return cls(**value)
 
-    def _process_values(self, input_data: dict) -> OrderedDict:
+    def _process_values(self, input_data: dict) -> OrderedDict:  # noqa: C901
         values = OrderedDict()
         errors = OrderedDict()
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -120,6 +120,7 @@ class PyObject:
 
 class DSN(str):
     prefix = 'db_'
+    fields = 'driver', 'user', 'password', 'host', 'port', 'name', 'query'
     validate_always = True
 
     @classmethod
@@ -131,8 +132,7 @@ class DSN(str):
     def validate(cls, value, values, **kwarg):
         if value:
             return value
-        fields = 'driver', 'user', 'password', 'host', 'port', 'name', 'query'
-        kwargs = {f: values.get(cls.prefix + f) for f in fields}
+        kwargs = {f: values.get(cls.prefix + f) for f in cls.fields}
         if kwargs['driver'] is None:
             raise ValueError(f'"{cls.prefix}driver" field may not be missing or None')
         return make_dsn(**kwargs)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -128,11 +128,11 @@ class DSN(str):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value, model, **kwarg):
+    def validate(cls, value, values, **kwarg):
         if value:
             return value
-        d = model.__values__
-        kwargs = {f: d.get(cls.prefix + f) for f in ('driver', 'user', 'password', 'host', 'port', 'name', 'query')}
+        fields = 'driver', 'user', 'password', 'host', 'port', 'name', 'query'
+        kwargs = {f: values.get(cls.prefix + f) for f in fields}
         if kwargs['driver'] is None:
             raise ValueError(f'"{cls.prefix}driver" field may not be missing or None')
         return make_dsn(**kwargs)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -48,16 +48,16 @@ def bool_validator(v) -> bool:
     return bool(v)
 
 
-def number_size_validator(v, model, **kwargs):
-    if model.config.min_number_size <= v <= model.config.max_number_size:
+def number_size_validator(v, config, **kwargs):
+    if config.min_number_size <= v <= config.max_number_size:
         return v
-    raise ValueError(f'size not in range {model.config.min_number_size} to {model.config.max_number_size}')
+    raise ValueError(f'size not in range {config.min_number_size} to {config.max_number_size}')
 
 
-def anystr_length_validator(v, model, **kwargs):
-    if v is None or model.config.min_anystr_length <= len(v) <= model.config.max_anystr_length:
+def anystr_length_validator(v, config, **kwargs):
+    if v is None or config.min_anystr_length <= len(v) <= config.max_anystr_length:
         return v
-    raise ValueError(f'length not in range {model.config.max_anystr_length} to {model.config.max_anystr_length}')
+    raise ValueError(f'length not in range {config.max_anystr_length} to {config.max_anystr_length}')
 
 
 def ordered_dict_validator(v) -> OrderedDict:

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.2.1')
+VERSION = StrictVersion('0.3.0a1')

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ filterwarnings = ignore
 
 [flake8]
 max-line-length = 120
-max-complexity = 10
+# set excessively high for _process_values
+max-complexity = 14
 
 [bdist_wheel]
 python-tag = py36

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,7 @@ filterwarnings = ignore
 
 [flake8]
 max-line-length = 120
-# set excessively high for _process_values
-max-complexity = 14
+max-complexity = 10
 
 [bdist_wheel]
 python-tag = py36

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -233,23 +233,24 @@ v:
   invalid literal for int() with base 10: 'foo' (error_type=ValueError track=int index=key)""" == str(exc_info.value)
 
 
-def test_all_model_validator():
-    class OverModel(BaseModel):
-        a: int = ...
-
-        def validate_a_pre(self, v):
-            return f'{v}1'
-
-        def validate_a(self, v):
-            assert isinstance(v, int)
-            return f'{v}_main'
-
-        def validate_a_post(self, v):
-            assert isinstance(v, str)
-            return f'{v}_post'
-
-    m = OverModel(a=1)
-    assert m.a == '11_main_post'
+# TODO re-add when implementing better model validators
+# def test_all_model_validator():
+#     class OverModel(BaseModel):
+#         a: int = ...
+#
+#         def validate_a_pre(self, v):
+#             return f'{v}1'
+#
+#         def validate_a(self, v):
+#             assert isinstance(v, int)
+#             return f'{v}_main'
+#
+#         def validate_a_post(self, v):
+#             assert isinstance(v, str)
+#             return f'{v}_post'
+#
+#     m = OverModel(a=1)
+#     assert m.a == '11_main_post'
 
 
 class SubModel(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -303,3 +303,38 @@ def test_required():
 a:
   field required (error_type=Missing)\
 """ == str(exc_info.value)
+
+
+def test_not_immutability():
+    class TestModel(BaseModel):
+        a: int = 10
+
+        class Config:
+            allow_mutation = True
+            allow_extra = False
+
+    m = TestModel()
+    assert m.a == 10
+    m.a = 11
+    assert m.a == 11
+    with pytest.raises(ValueError) as exc_info:
+        m.b = 11
+    assert '"TestModel" object has no field "b"' in str(exc_info)
+
+
+def test_immutability():
+    class TestModel(BaseModel):
+        a: int = 10
+
+        class Config:
+            allow_mutation = False
+            allow_extra = False
+
+    m = TestModel()
+    assert m.a == 10
+    with pytest.raises(TypeError) as exc_info:
+        m.a = 11
+    assert '"TestModel" is immutable and does not support item assignment' in str(exc_info)
+    with pytest.raises(ValueError) as exc_info:
+        m.b = 11
+    assert '"TestModel" object has no field "b"' in str(exc_info)


### PR DESCRIPTION
ref #38

This should also allow other cleanup including `m.whatever = foobar` updating `__values__`, it's also kind of necessary for #40 and `copy()`,

This also gives a slight (5 - 10%) performance increase instead of 10% decrease as the previous `__setattr__` approach did.

It should also decrease memory footprint as `__slots__` is used and `__values__` is no longer duplicated.