### PR TITLE
stricter str validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,8 @@ v0.3.0 (TBC)
 * instance method validators removed TODO
 * django-restful-framework benchmarks added #47
 * fix inheritance bug #49
-* make str type stricter so list, dict etc are not coerced to strings #52
+* make str type stricter so list, dict etc are not coerced to strings. #52
+* add ``StrictStr`` which only always strings as input #52
 
 v0.2.1 (2017-06-07)
 ...................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ v0.3.0 (TBC)
 * instance method validators removed TODO
 * django-restful-framework benchmarks added #47
 * fix inheritance bug #49
+* make str type stricter so list, dict etc are not coerced to strings #52
 
 v0.2.1 (2017-06-07)
 ...................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -64,6 +64,7 @@ class MetaModel(type):
             for ann_name, ann_type in annotations.items():
                 if ann_name.startswith('_'):
                     continue
+                print(ann_type)
                 fields[ann_name] = Field.infer(
                     name=ann_name,
                     value=...,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -64,7 +64,6 @@ class MetaModel(type):
             for ann_name, ann_type in annotations.items():
                 if ann_name.startswith('_'):
                     continue
-                print(ann_type)
                 fields[ann_name] = Field.infer(
                     name=ann_name,
                     value=...,

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -9,6 +9,7 @@ __all__ = [
     'NoneBytes',
     'StrBytes',
     'NoneStrBytes',
+    'StrictStr',
     'ConstrainedStr',
     'constr',
     'EmailStr',
@@ -25,6 +26,18 @@ NoneStr = Optional[str]
 NoneBytes = Optional[bytes]
 StrBytes = Union[str, bytes]
 NoneStrBytes = Optional[StrBytes]
+
+
+class StrictStr(str):
+    @classmethod
+    def get_validators(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, str):
+            raise ValueError(f'strict string: str expected not {type(v)}')
+        return v
 
 
 class ConstrainedStr(str):

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -21,7 +22,11 @@ def str_validator(v) -> str:
         return v
     elif isinstance(v, bytes):
         return v.decode()
-    return str(v)
+    elif isinstance(v, (float, int, Decimal)):
+        # is there anything else we want to add here?
+        return str(v)
+    else:
+        raise ValueError(f'str type expected not {type(v)}')
 
 
 def bytes_validator(v) -> bytes:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -20,13 +20,13 @@ def not_none_validator(v):
 def str_validator(v) -> str:
     if isinstance(v, (str, NoneType)):
         return v
-    elif isinstance(v, bytes):
+    elif isinstance(v, (bytes, bytearray)):
         return v.decode()
     elif isinstance(v, (float, int, Decimal)):
-        # is there anything else we want to add here?
+        # is there anything else we want to add here? If you think so, create an issue.
         return str(v)
     else:
-        raise ValueError(f'str type expected not {type(v)}')
+        raise ValueError(f'str or byte type expected not {type(v)}')
 
 
 def bytes_validator(v) -> bytes:

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Set, Union
 
@@ -445,3 +446,32 @@ def test_invalid_type():
             x: 43 = 123
 
     assert "error checking inheritance of 43 (type: <class 'int'>)" in str(exc_info)
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('a string', 'a string'),
+    (b'some bytes', 'some bytes'),
+    (123, '123'),
+    (123.45, '123.45'),
+    (Decimal('12.45'), '12.45'),
+    (True, 'True'),
+    (False, 'False'),
+])
+def test_valid_string_types(value, expected):
+    class Model(BaseModel):
+        v: str
+
+    assert Model(v=value).v == expected
+
+
+@pytest.mark.parametrize('value', [
+    {'foo': 'bar'},
+    {'foo', 'bar'},
+    [1, 2, 3],
+])
+def test_invalid_string_types(value):
+    class Model(BaseModel):
+        v: str
+
+    with pytest.raises(ValidationError):
+        Model(v=value)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -341,10 +341,12 @@ def test_recursive_lists():
     assert len(Model.__fields__['v'].sub_fields[0].sub_fields[0].sub_fields) == 2
 
 
+class StrEnum(str, Enum):
+    a = 'a10'
+    b = 'b10'
+
+
 def test_str_enum():
-    class StrEnum(str, Enum):
-        a = 'a10'
-        b = 'b10'
 
     class Model(BaseModel):
         v: StrEnum = ...
@@ -451,11 +453,13 @@ def test_invalid_type():
 @pytest.mark.parametrize('value,expected', [
     ('a string', 'a string'),
     (b'some bytes', 'some bytes'),
+    (bytearray('foobar', encoding='utf8'), 'foobar'),
     (123, '123'),
     (123.45, '123.45'),
     (Decimal('12.45'), '12.45'),
     (True, 'True'),
     (False, 'False'),
+    (StrEnum.a, 'a10'),
 ])
 def test_valid_string_types(value, expected):
     class Model(BaseModel):
@@ -473,5 +477,6 @@ def test_invalid_string_types(value):
     class Model(BaseModel):
         v: str
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
+    assert 'str or byte type expected' in str(exc_info.value)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5,8 +5,8 @@ from enum import Enum, IntEnum
 
 import pytest
 
-from pydantic import (DSN, BaseModel, EmailStr, NameEmail, NegativeInt, PositiveInt, PyObject, ValidationError, conint,
-                      constr)
+from pydantic import (DSN, BaseModel, EmailStr, NameEmail, NegativeInt, PositiveInt, PyObject, StrictStr,
+                      ValidationError, conint, constr)
 
 
 class ConStringModel(BaseModel):
@@ -378,3 +378,15 @@ def test_set():
     assert m.v == {1, 2, 3}
     assert m.values() == {'v': {1, 2, 3}}
     assert SetModel(v={'a', 'b', 'c'}).v == {'a', 'b', 'c'}
+
+
+def test_strict_str():
+    class Model(BaseModel):
+        v: StrictStr
+
+    assert Model(v='foobar').v == 'foobar'
+    with pytest.raises(ValidationError):
+        Model(v=123)
+
+    with pytest.raises(ValidationError):
+        Model(v=b'foobar')


### PR DESCRIPTION
fix #45

In the end, I thought about this and decided whitelisting things which can be coerced to strings made more sense. 

It shouldn't affect performance much as most string-like things will be strings and returned before this logic kicks in.