### PR TITLE
Parse date and time fix

### DIFF
--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -87,6 +87,8 @@ def parse_date(value: StrIntFloat) -> date:
     Raise ValueError if the input is well formatted but not a valid date.
     Raise ValueError if the input isn't well formatted.
     """
+    if isinstance(value, date):
+        return value
     number = get_numeric(value)
     if number:
         return from_unix_seconds(number).date()
@@ -108,6 +110,8 @@ def parse_time(value: StrIntFloat) -> time:
     Raise ValueError if the input is well formatted but not a valid time.
     Raise ValueError if the input isn't well formatted, in particular if it contains an offset.
     """
+    if isinstance(value, time):
+        return value
     match = time_re.match(value)
     if not match:
         raise ValueError('Invalid time format')

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -25,6 +25,7 @@ def create_tz(minutes):
     (1494012444, date(2017, 5, 5)),
     ('2012-04-23', date(2012, 4, 23)),
     ('2012-4-9', date(2012, 4, 9)),
+    (date(2018, 1, 31), date(2018, 1, 31)),
     # Invalid inputs
     ('x20120423', ValueError),
     ('2012-04-56', ValueError),
@@ -43,6 +44,7 @@ def test_date_parsing(value, result):
     ('10:10', time(10, 10)),
     ('10:20:30.400', time(10, 20, 30, 400000)),
     ('4:8:16', time(4, 8, 16)),
+    (time(20, 8, 16), time(20, 8, 16)),
     # Invalid inputs
     ('091500', ValueError),
     ('09:15:90', ValueError),


### PR DESCRIPTION
If you try to pass in a date to a date field or a time field it fails. I update the date and time parsers to be like the datetime parser, and accept arguments that are already the correct type