### PR TITLE
remove use of ordered dict

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ v0.7.0 (2018-02-06)
 * add ``create_model`` method #113 #125
 * **breaking change**: rename ``.config`` to ``.__config__`` on a model
 * **breaking change**: remove deprecated ``.values()`` on a model, use ``.dict()`` instead
+* remove use of `OrderedDict` and use simple dict #126
 
 v0.6.4 (2018-02-01)
 ...................

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,5 +1,4 @@
 import inspect
-from collections import OrderedDict
 from enum import IntEnum
 from typing import Any, Callable, List, Mapping, NamedTuple, Set, Type, Union
 
@@ -110,11 +109,11 @@ class Field:
         self._populate_sub_fields(class_validators)
         self._populate_validators(class_validators)
 
-        self.info = OrderedDict([
-            ('type', type_display(self.type_)),
-            ('default', self.default),
-            ('required', self.required)
-        ])
+        self.info = {
+            'type': type_display(self.type_),
+            'default': self.default,
+            'required': self.required,
+        }
         if self.required:
             self.info.pop('default')
         if self.sub_fields:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,6 +1,5 @@
 import warnings
 from abc import ABCMeta
-from collections import OrderedDict
 from pathlib import Path
 from types import FunctionType
 from typing import Any, Dict, Set, Type, Union
@@ -53,12 +52,9 @@ def _extract_validators(namespace):
 
 
 class MetaModel(ABCMeta):
-    @classmethod
-    def __prepare__(mcs, *args, **kwargs):
-        return OrderedDict()
 
     def __new__(mcs, name, bases, namespace):
-        fields = OrderedDict()
+        fields = {}
         config = BaseConfig
         for base in reversed(bases):
             if issubclass(base, BaseModel) and base != BaseModel:
@@ -226,9 +222,9 @@ class BaseModel(metaclass=MetaModel):
     def validate(cls, value):
         return cls(**value)
 
-    def _process_values(self, input_data: dict) -> OrderedDict:  # noqa: C901 (ignore complexity)
-        values = OrderedDict()
-        errors = OrderedDict()
+    def _process_values(self, input_data: dict) -> Dict[str, Any]:  # noqa: C901 (ignore complexity)
+        values = {}
+        errors = {}
 
         for name, field in self.__fields__.items():
             value = input_data.get(field.alias, MISSING)
@@ -326,7 +322,7 @@ def create_model(
             raise ConfigError('to avoid confusion __config__ and __base__ cannot be used together')
     else:
         __base__ = BaseModel
-        fields = OrderedDict()
+        fields = {}
         validators = {}
 
     config = __config__ or BaseConfig

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -60,13 +60,13 @@ def test_str_bytes_none():
     assert m.v is None
 
     # NOTE not_none_validator removed
-    assert ("OrderedDict(["
-            "('type', 'typing.Union[str, bytes, NoneType]'), "
-            "('required', True), "
-            "('sub_fields', ["
-            "<Field v_str: type='str', required=True, validators=['str_validator', 'anystr_length_validator']>, "
-            "<Field v_bytes: type='bytes', required=True, validators=['bytes_validator', 'anystr_length_validator']>"
-            "])])") == repr(m.fields['v'].info)
+    assert ("{'type': 'typing.Union[str, bytes, NoneType]', "
+            "'required': True, "
+            "'sub_fields': [<Field v_str: type='str', "
+            "required=True, "
+            "validators=['str_validator', 'anystr_length_validator']>, "
+            "<Field v_bytes: type='bytes', required=True, validators=['bytes_validator', "
+            "'anystr_length_validator']>]}") == repr(m.fields['v'].info)
 
 
 def test_union_int_str():


### PR DESCRIPTION
as per https://mail.python.org/pipermail/python-dev/2017-December/151283.html dicts are ordered in python 3.6+. Therefore `OrderedDict` can be removed and marginally improve performance.