### PR TITLE
Make model dump/load symmetric for aliased fields

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -257,6 +257,9 @@ class BaseModel(metaclass=MetaModel):
 
         for name, field in self.__fields__.items():
             value = input_data.get(field.alias, MISSING)
+            if value is MISSING and field.alt_alias:
+                value = input_data.get(field.name, MISSING)
+
             if value is MISSING:
                 if self.__config__.validate_all or field.validate_always:
                     value = field.default

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -276,6 +276,19 @@ def test_alias():
     assert Model(_a='different').dict() == {'a': 'different'}
 
 
+def test_load_by_alias():
+    class Model(BaseModel):
+        a: str
+
+        class Config:
+            fields = {
+                'a': {'alias': '_a'}
+            }
+
+    assert Model(a='different').a == 'different'
+    assert Model(a='different').dict() == {'a': 'different'}
+
+
 def test_field_order():
     class Model(BaseModel):
         c: float


### PR DESCRIPTION
When using field aliases, I expected to be able to dump a model to a `dict` and then load that result back into the same model, but field aliases aren't considered when populating a model. This changes that behavior to allow this; in other words, `MyModel(**MyModel(a="foo").dict())` now works if `a` has an alias.

The field alias is considered first to maintain as much of the existing behavior, but this change does have the potential to break user code, as data that previously failed validation could now pass.

Thanks for this library, @samuelcolvin! It's a very nice tool to have in the toolbox. 😄 