### PR TITLE
fix type annotations for exotic types; re-use type validators in exotic types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ v0.9.1 (2018-XX-XX)
 ...................
 * add ``UUID1``, ``UUID3``, ``UUID4`` and ``UUID5`` types #167
 * modify some inconsistent docstrings and annotations #173
+* fix type annotations for exotic types #171
+* re-use type validators in exotic types #171
 
 v0.9.0 (2018-04-28)
 ...................

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -58,21 +58,37 @@ def bool_validator(v) -> bool:
     return bool(v)
 
 
-def number_size_validator(v, config, **kwargs):
-    if config.min_number_size <= v <= config.max_number_size:
-        return v
-    raise ValueError(f'size not in range {config.min_number_size} to {config.max_number_size}')
+def number_size_validator(v, field, config, **kwargs):
+    min_size = getattr(field.type_, 'gt', config.min_number_size)
+    if min_size is not None and v <= min_size:
+        raise ValueError(f'size less than minimum allowed: {min_size}')
+
+    max_size = getattr(field.type_, 'lt', config.max_number_size)
+    if max_size is not None and v >= max_size:
+        raise ValueError(f'size greater than maximum allowed: {max_size}')
+
+    return v
 
 
-def anystr_length_validator(v, config, **kwargs):
-    if v is None or config.min_anystr_length <= len(v) <= config.max_anystr_length:
-        return v
-    raise ValueError(f'length {len(v)} not in range {config.min_anystr_length} to {config.max_anystr_length}')
+def anystr_length_validator(v, field, config, **kwargs):
+    v_len = len(v)
+
+    min_length = getattr(field.type_, 'min_length', config.min_anystr_length)
+    if min_length is not None and v_len < min_length:
+        raise ValueError(f'length less than minimum allowed: {min_length}')
+
+    max_length = getattr(field.type_, 'max_length', config.max_anystr_length)
+    if max_length is not None and v_len > max_length:
+        raise ValueError(f'length greater than maximum allowed: {max_length}')
+
+    return v
 
 
-def anystr_strip_whitespace(v, config, **kwargs):
-    if v and config.anystr_strip_whitespace:
+def anystr_strip_whitespace(v, field, config, **kwargs):
+    strip_whitespace = getattr(field.type_, 'strip_whitespace', config.anystr_strip_whitespace)
+    if strip_whitespace:
         v = v.strip()
+
     return v
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -169,10 +169,47 @@ def test_default_validators(field, value, result):
         assert CheckModel(**kwargs).dict()[field] == result
 
 
+class StrModel(BaseModel):
+    str_check: str
+
+    class Config:
+        min_anystr_length = 5
+        max_anystr_length = 10
+
+
 def test_string_too_long():
     with pytest.raises(ValidationError) as exc_info:
-        CheckModel(str_check='x' * 150)
-    assert 'length 150 not in range 0 to 10 (error_type=ValueError track=str)' in exc_info.value.display_errors
+        StrModel(str_check='x' * 150)
+    assert 'length greater than maximum allowed: 10 (error_type=ValueError track=str)' in exc_info.value.display_errors
+
+
+def test_string_too_short():
+    with pytest.raises(ValidationError) as exc_info:
+        StrModel(str_check='x')
+    assert 'length less than minimum allowed: 5 (error_type=ValueError track=str)' in exc_info.value.display_errors
+
+
+class NumberModel(BaseModel):
+    int_check: int
+    float_check: float
+
+    class Config:
+        min_number_size = 5
+        max_number_size = 10
+
+
+def test_number_too_big():
+    with pytest.raises(ValidationError) as exc_info:
+        NumberModel(int_check=50, float_check=150)
+    assert 'size greater than maximum allowed: 10 (error_type=ValueError track=int)' in exc_info.value.display_errors
+    assert 'size greater than maximum allowed: 10 (error_type=ValueError track=float)' in exc_info.value.display_errors
+
+
+def test_number_too_small():
+    with pytest.raises(ValidationError) as exc_info:
+        NumberModel(int_check=1, float_check=2.5)
+    assert 'size less than minimum allowed: 5 (error_type=ValueError track=int)' in exc_info.value.display_errors
+    assert 'size less than minimum allowed: 5 (error_type=ValueError track=float)' in exc_info.value.display_errors
 
 
 class DatetimeModel(BaseModel):


### PR DESCRIPTION
Changes:
* fixed type annotations for exotic types due to new release 0.600 of mypy
* also I tried to simplify codebase and re-use type validators in exotic types, less code better to my mind, please let me know what do you think and what I need to improve

To discuss:
* I would like to rename `gt` and `lt` in `ConstrainedInt` and `ConstrainedFloat` because we already have `min_number_size` and `max_number_size` for `int` and `float` and to my mind it looks like kind of inconsistency. And I think we can do this backward compatible by adding new `min_size` and `max_size` without removing `gt` and `lt`. What do you think? 