### PR TITLE
add ``Decimal``, ``ConstrainedDecimal`` and ``condecimal`` types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ v0.9.1 (2018-XX-XX)
 * fix type annotations for exotic types #171
 * re-use type validators in exotic types #171
 * scheduled monthly requirements updates #168
+* add ``Decimal``, ``ConstrainedDecimal`` and ``condecimal`` types #170
 
 v0.9.0 (2018-04-28)
 ...................

--- a/docs/examples/exotic.py
+++ b/docs/examples/exotic.py
@@ -1,9 +1,10 @@
 import uuid
+from decimal import Decimal
 from pathlib import Path
 from uuid import UUID
 
 from pydantic import (DSN, UUID1, UUID3, UUID4, UUID5, BaseModel, EmailStr, NameEmail, NegativeFloat, NegativeInt,
-                      PositiveFloat, PositiveInt, PyObject, confloat, conint, constr)
+                      PositiveFloat, PositiveInt, PyObject, condecimal, confloat, conint, constr)
 
 
 class Model(BaseModel):
@@ -33,6 +34,10 @@ class Model(BaseModel):
     db_driver = 'postgres'
     db_query: dict = None
     dsn: DSN = None
+    decimal: Decimal = None
+    decimal_positive: condecimal(gt=0) = None
+    decimal_negative: condecimal(lt=0) = None
+    decimal_max_digits_and_places: condecimal(max_digits=2, decimal_places=2) = None
     uuid_any: UUID = None
     uuid_v1: UUID1 = None
     uuid_v3: UUID3 = None
@@ -53,6 +58,10 @@ m = Model(
     neg_float=-2.3,
     email_address='Samuel Colvin <s@muelcolvin.com >',
     email_and_name='Samuel Colvin <s@muelcolvin.com >',
+    decimal=Decimal('42.24'),
+    decimal_positive=Decimal('21.12'),
+    decimal_negative=Decimal('-21.12'),
+    decimal_max_digits_and_places=Decimal('0.99'),
     uuid_any=uuid.uuid4(),
     uuid_v1=uuid.uuid1(),
     uuid_v3=uuid.uuid3(uuid.NAMESPACE_DNS, 'python.org'),
@@ -77,6 +86,10 @@ print(m.dict())
     'email_and_name': <NameEmail("Samuel Colvin <s@muelcolvin.com>")>,
     ...
     'dsn': 'postgres://postgres@localhost:5432/foobar',
+    'decimal': Decimal('42.24'),
+    'decimal_positive': Decimal('21.12'),
+    'decimal_negative': Decimal('-21.12'),
+    'decimal_max_digits_and_places': Decimal('0.99'),
     'uuid_any': UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8'),
     'uuid_v1': UUID('c96e505c-4c62-11e8-a27c-dca90496b483'),
     'uuid_v3': UUID('6fa459ea-ee8a-3ca4-894e-db77e160355e'),

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1,10 +1,11 @@
 import re
+from decimal import Decimal
 from typing import Optional, Pattern, Type, Union
 from uuid import UUID
 
 from .utils import import_string, make_dsn, validate_email
-from .validators import (anystr_length_validator, anystr_strip_whitespace, not_none_validator, number_size_validator,
-                         str_validator)
+from .validators import (anystr_length_validator, anystr_strip_whitespace, decimal_validator, not_none_validator,
+                         number_size_validator, str_validator)
 
 try:
     import email_validator
@@ -31,6 +32,8 @@ __all__ = [
     'confloat',
     'PositiveFloat',
     'NegativeFloat',
+    'ConstrainedDecimal',
+    'condecimal',
     'UUID1',
     'UUID3',
     'UUID4',
@@ -216,6 +219,67 @@ class PositiveFloat(ConstrainedFloat):
 
 class NegativeFloat(ConstrainedFloat):
     lt = 0
+
+
+class ConstrainedDecimal(Decimal):
+    gt: Union[None, int, float, Decimal] = None
+    lt: Union[None, int, float, Decimal] = None
+    max_digits: Optional[int] = None
+    decimal_places: Optional[int] = None
+
+    @classmethod
+    def get_validators(cls):
+        yield not_none_validator
+        yield decimal_validator
+        yield number_size_validator
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Decimal) -> Decimal:
+        digit_tuple, exponent = value.as_tuple()[1:]
+        if exponent in {'F', 'n', 'N'}:
+            raise ValueError(f'value is not a valid decimal, got {value}')
+
+        if exponent >= 0:
+            # A positive exponent adds that many trailing zeros.
+            digits = len(digit_tuple) + exponent
+            decimals = 0
+        else:
+            # If the absolute value of the negative exponent is larger than the
+            # number of digits, then it's the same as the number of digits,
+            # because it'll consume all of the digits in digit_tuple and then
+            # add abs(exponent) - len(digit_tuple) leading zeros after the
+            # decimal point.
+            if abs(exponent) > len(digit_tuple):
+                digits = decimals = abs(exponent)
+            else:
+                digits = len(digit_tuple)
+                decimals = abs(exponent)
+        whole_digits = digits - decimals
+
+        if cls.max_digits is not None and digits > cls.max_digits:
+            raise ValueError(f'ensure that there are no more than {cls.max_digits} digits in total')
+
+        if cls.decimal_places is not None and decimals > cls.decimal_places:
+            raise ValueError(f'ensure that there are no more than {cls.decimal_places} decimal places')
+
+        if cls.max_digits is not None and cls.decimal_places is not None:
+            expected = cls.max_digits - cls.decimal_places
+            if whole_digits > expected:
+                raise ValueError(f'ensure that there are no more than {expected} digits before the decimal point')
+
+        return value
+
+
+def condecimal(*, gt=None, lt=None, max_digits=None, decimal_places=None) -> Type[Decimal]:
+    # use kwargs then define conf in a dict to aid with IDE type hinting
+    namespace = dict(
+        gt=gt,
+        lt=lt,
+        max_digits=max_digits,
+        decimal_places=decimal_places
+    )
+    return type('ConstrainedDecimalValue', (ConstrainedDecimal,), namespace)
 
 
 class UUID1(UUID):


### PR DESCRIPTION
This is a port of decimal type validation from Django project.

@samuelcolvin please review and I need your advise about error messages, I think we can write something better, but I don't know what to write. And please don't merge this PR until #174 is done, I want to use `min` and `max` instead of `gt` and `lt` in new type.