### PR TITLE
Errors format

### DIFF
--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -19,7 +19,7 @@ def type_display(type_: type):
         return str(type_)
 
 
-Error = namedtuple('Error', ['exc', 'track', 'index'])
+Error = namedtuple('Error', ['exc', 'index'])
 
 
 class ErrorDict(dict):
@@ -29,8 +29,6 @@ class ErrorDict(dict):
 def pretty_errors(e):
     if isinstance(e, Error):
         d = ErrorDict(error_type=e.exc.__class__.__name__)
-        if e.track is not None:
-            d['track'] = type_display(e.track)
         if e.index is not None:
             d['index'] = e.index
         if isinstance(e.exc, ValidationError):
@@ -49,7 +47,7 @@ def pretty_errors(e):
         raise TypeError(f'Unknown error object: {e}')
 
 
-E_KEYS = 'error_type', 'track', 'index'
+E_KEYS = 'error_type', 'index'
 
 
 def _render_errors(e, indent=0):

--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -14,9 +14,13 @@ __all__ = (
 
 
 class Error:
+    __slots__ = (
+        'exc_info',
+        'loc',
+    )
+
     def __init__(self, exc: Exception, *, loc: Union[str, int] = None) -> None:
         self.exc_info = exc
-        self.exc_type = type(exc)
         self.loc = loc
 
     @property
@@ -26,7 +30,7 @@ class Error:
     @property
     def type_(self) -> str:
         bases = []
-        for b in inspect.getmro(self.exc_type):
+        for b in inspect.getmro(type(self.exc_info)):
             bases.append(b.__name__)
             if b in (ValueError, TypeError):
                 break
@@ -35,6 +39,11 @@ class Error:
 
 
 class ValidationError(ValueError):
+    __slots__ = (
+        'errors',
+        'message',
+    )
+
     def __init__(self, errors):
         self.errors = errors
         self.message = 'validation errors'

--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -1,6 +1,6 @@
 import inspect
 import json
-from typing import Union
+from typing import Tuple, Union
 
 from .utils import to_snake_case
 
@@ -19,9 +19,9 @@ class Error:
         'loc',
     )
 
-    def __init__(self, exc: Exception, *, loc: Union[str, int] = None) -> None:
+    def __init__(self, exc: Exception, *, loc: Union[Tuple[str], str]) -> None:
         self.exc_info = exc
-        self.loc = loc
+        self.loc = loc if isinstance(loc, tuple) else (loc,)
 
     @property
     def msg(self) -> str:
@@ -82,7 +82,7 @@ def display_errors(errors):
 
     for error in errors:
         display.extend([
-            error['loc'],
+            ' -> '.join(error['loc']),
             f'  {error["msg"]} (type={error["type"]})',
         ])
 
@@ -98,7 +98,7 @@ def flatten_errors(errors, *, loc=None):
                 flat.extend(flatten_errors(error.exc_info.errors, loc=error.loc))
             else:
                 flat.append({
-                    'loc': error.loc if loc is None else f'{loc}.{error.loc}',
+                    'loc': error.loc if loc is None else loc + error.loc,
                     'msg': error.msg,
                     'type': error.type_,
                 })

--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -11,14 +11,6 @@ __all__ = (
 )
 
 
-def type_display(type_: type):
-    try:
-        return type_.__name__
-    except AttributeError:
-        # happens with unions
-        return str(type_)
-
-
 Error = namedtuple('Error', ['exc', 'index'])
 
 

--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -43,17 +43,17 @@ class ValidationError(ValueError):
 
     @property
     def display_errors(self):
-        return display_errors(self.flatten_errors)
+        return display_errors(self.flat_errors)
 
     @property
-    def flatten_errors(self):
+    def flat_errors(self):
         return flatten_errors(self.errors)
 
     def __str__(self):
         return f'{self.message}\n{self.display_errors}'
 
     def json(self, *, indent=2):
-        return json.dumps(self.flatten_errors, indent=indent, sort_keys=True)
+        return json.dumps(self.flat_errors, indent=indent, sort_keys=True)
 
 
 class ConfigError(RuntimeError):
@@ -81,21 +81,21 @@ def display_errors(errors):
 
 
 def flatten_errors(errors, *, loc=None):
-    flatten = []
+    flat = []
 
     for error in errors:
         if isinstance(error, Error):
             if isinstance(error.exc_info, ValidationError):
-                flatten.extend(flatten_errors(error.exc_info.errors, loc=error.loc))
+                flat.extend(flatten_errors(error.exc_info.errors, loc=error.loc))
             else:
-                flatten.append({
+                flat.append({
                     'loc': error.loc if loc is None else f'{loc}.{error.loc}',
                     'msg': error.msg,
                     'type': error.type_,
                 })
         elif isinstance(error, list):
-            flatten.extend(flatten_errors(error))
+            flat.extend(flatten_errors(error))
         else:
             raise TypeError(f'Unknown error object: {error}')
 
-    return flatten
+    return flat

--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -14,12 +14,12 @@ __all__ = (
 class Error:
     __slots__ = (
         'exc',
-        'index',
+        'loc',
     )
 
-    def __init__(self, exc: Exception, *, index: Union[str, int] = None) -> None:
+    def __init__(self, exc: Exception, *, loc: Union[str, int] = None) -> None:
         self.exc = exc
-        self.index = index
+        self.loc = loc
 
 
 class ErrorDict(dict):
@@ -29,8 +29,8 @@ class ErrorDict(dict):
 def pretty_errors(e):
     if isinstance(e, Error):
         d = ErrorDict(error_type=e.exc.__class__.__name__)
-        if e.index is not None:
-            d['index'] = e.index
+        if e.loc is not None:
+            d['loc'] = e.loc
         if isinstance(e.exc, ValidationError):
             d.update(
                 error_msg=e.exc.message,
@@ -47,7 +47,7 @@ def pretty_errors(e):
         raise TypeError(f'Unknown error object: {e}')
 
 
-E_KEYS = 'error_type', 'index'
+E_KEYS = 'error_type', 'loc'
 
 
 def _render_errors(e, indent=0):

--- a/pydantic/exceptions.py
+++ b/pydantic/exceptions.py
@@ -1,6 +1,6 @@
 import json
-from collections import namedtuple
 from itertools import chain
+from typing import Union
 
 __all__ = (
     'Error',
@@ -11,7 +11,15 @@ __all__ = (
 )
 
 
-Error = namedtuple('Error', ['exc', 'index'])
+class Error:
+    __slots__ = (
+        'exc',
+        'index',
+    )
+
+    def __init__(self, exc: Exception, *, index: Union[str, int] = None) -> None:
+        self.exc = exc
+        self.index = index
 
 
 class ErrorDict(dict):

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -289,7 +289,7 @@ class Field:
                     errors.append(error)
                 else:
                     return value, None
-            return v, errors[0] if len(self.sub_fields) == 1 else errors
+            return v, errors
         else:
             return self._apply_validators(v, values, loc, cls, self.validators)
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -301,7 +301,7 @@ class Field:
                     # ValidatorSignature.CLS_VALUE_KWARGS
                     v = validator(cls, v, values=values, config=self.model_config, field=self)
             except (ValueError, TypeError) as exc:
-                return v, Error(exc, index=index)
+                return v, Error(exc, loc=index)
         return v, None
 
     def __repr__(self):

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -240,7 +240,8 @@ class Field:
         except TypeError as exc:
             return v, Error(exc, loc=loc)
         for i, v_ in v_iter:
-            single_result, single_errors = self._validate_singleton(v_, values, f'{loc}.{i}', cls)
+            v_loc = loc, str(i)
+            single_result, single_errors = self._validate_singleton(v_, values, v_loc, cls)
             if single_errors:
                 errors.append(single_errors)
             else:
@@ -261,14 +262,18 @@ class Field:
 
         result, errors = {}, []
         for k, v_ in v_iter.items():
-            key_result, key_errors = self.key_field.validate(k, values, loc=f'{loc}.key', cls=cls)
+            v_loc = loc, '__key__'
+            key_result, key_errors = self.key_field.validate(k, values, loc=v_loc, cls=cls)
             if key_errors:
                 errors.append(key_errors)
                 continue
-            value_result, value_errors = self._validate_singleton(v_, values, f'{loc}.{k}', cls)
+
+            v_loc = loc, k
+            value_result, value_errors = self._validate_singleton(v_, values, v_loc, cls)
             if value_errors:
                 errors.append(value_errors)
                 continue
+
             result[key_result] = value_result
         if errors:
             return v, errors

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -2,7 +2,8 @@ import inspect
 from enum import IntEnum
 from typing import Any, Callable, List, Mapping, NamedTuple, Set, Type, Union
 
-from .exceptions import ConfigError, Error, type_display
+from .exceptions import ConfigError, Error
+from .utils import display_as_type
 from .validators import NoneType, find_validators, not_none_validator
 
 Required: Any = Ellipsis
@@ -113,7 +114,7 @@ class Field:
         self._populate_validators()
 
         self.info = {
-            'type': type_display(self.type_),
+            'type': display_as_type(self.type_),
             'default': self.default,
             'required': self.required,
         }
@@ -148,7 +149,7 @@ class Field:
                 default=self.default,
                 required=self.required,
                 allow_none=self.allow_none,
-                name=f'{self.name}_{type_display(t)}',
+                name=f'{self.name}_{display_as_type(t)}',
                 model_config=self.model_config,
             ) for t in types_]
         elif issubclass(origin, List):
@@ -256,7 +257,7 @@ class Field:
             try:
                 v_iter = dict(v)
             except TypeError:
-                return v, Error(TypeError(f'value is not a valid dict, got {type_display(type(v))}'), None)
+                return v, Error(TypeError(f'value is not a valid dict, got {display_as_type(v)}'), None)
 
         result, errors = {}, []
         for k, v_ in v_iter.items():

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -237,7 +237,7 @@ class Field:
         try:
             v_iter = enumerate(v)
         except TypeError as exc:
-            return v, Error(exc, None, None)
+            return v, Error(exc, None)
         for i, v_ in v_iter:
             single_result, single_errors = self._validate_singleton(v_, values, i, cls)
             if single_errors:
@@ -256,7 +256,7 @@ class Field:
             try:
                 v_iter = dict(v)
             except TypeError:
-                return v, Error(TypeError(f'value is not a valid dict, got {type_display(type(v))}'), None, None)
+                return v, Error(TypeError(f'value is not a valid dict, got {type_display(type(v))}'), None)
 
         result, errors = {}, []
         for k, v_ in v_iter.items():
@@ -300,7 +300,7 @@ class Field:
                     # ValidatorSignature.CLS_VALUE_KWARGS
                     v = validator(cls, v, values=values, config=self.model_config, field=self)
             except (ValueError, TypeError) as exc:
-                return v, Error(exc, self.type_, index)
+                return v, Error(exc, index)
         return v, None
 
     def __repr__(self):

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -238,7 +238,7 @@ class Field:
         try:
             v_iter = enumerate(v)
         except TypeError as exc:
-            return v, Error(exc, None)
+            return v, Error(exc)
         for i, v_ in v_iter:
             single_result, single_errors = self._validate_singleton(v_, values, i, cls)
             if single_errors:
@@ -257,7 +257,7 @@ class Field:
             try:
                 v_iter = dict(v)
             except TypeError:
-                return v, Error(TypeError(f'value is not a valid dict, got {display_as_type(v)}'), None)
+                return v, Error(TypeError(f'value is not a valid dict, got {display_as_type(v)}'))
 
         result, errors = {}, []
         for k, v_ in v_iter.items():
@@ -301,7 +301,7 @@ class Field:
                     # ValidatorSignature.CLS_VALUE_KWARGS
                     v = validator(cls, v, values=values, config=self.model_config, field=self)
             except (ValueError, TypeError) as exc:
-                return v, Error(exc, index)
+                return v, Error(exc, index=index)
         return v, None
 
     def __repr__(self):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -137,8 +137,7 @@ class MetaModel(ABCMeta):
 
 
 MISSING = Missing('field required')
-MISSING_ERROR = Error(MISSING)
-EXTRA_ERROR = Error(Extra('extra fields not permitted'))
+EXTRA = Extra('extra fields not permitted')
 
 
 class BaseModel(metaclass=MetaModel):
@@ -164,9 +163,9 @@ class BaseModel(metaclass=MetaModel):
         elif not self.__config__.allow_mutation:
             raise TypeError(f'"{self.__class__.__name__}" is immutable and does not support item assignment')
         elif self.__config__.validate_assignment:
-            value_, error_ = self.fields[name].validate(value, self.dict(exclude={name}))
+            value_, error_ = self.fields[name].validate(value, self.dict(exclude={name}), loc=name)
             if error_:
-                raise ValidationError({name: error_})
+                raise ValidationError([error_])
             else:
                 self.__values__[name] = value_
         else:
@@ -262,7 +261,7 @@ class BaseModel(metaclass=MetaModel):
 
     def _process_values(self, input_data: dict) -> Dict[str, Any]:  # noqa: C901 (ignore complexity)
         values = {}
-        errors = {}
+        errors = []
 
         for name, field in self.__fields__.items():
             value = input_data.get(field.alias, MISSING)
@@ -271,14 +270,16 @@ class BaseModel(metaclass=MetaModel):
                     value = field.default
                 else:
                     if field.required:
-                        errors[field.alias] = MISSING_ERROR
+                        errors.append(Error(MISSING, loc=field.alias))
                     else:
                         values[name] = field.default
                     continue
 
-            v_, errors_ = field.validate(value, values, cls=self.__class__)
-            if errors_:
-                errors[field.alias] = errors_
+            v_, errors_ = field.validate(value, values, loc=field.alias, cls=self.__class__)
+            if isinstance(errors_, Error):
+                errors.append(errors_)
+            elif isinstance(errors_, list):
+                errors.extend(errors_)
             else:
                 values[name] = v_
 
@@ -291,7 +292,7 @@ class BaseModel(metaclass=MetaModel):
                 else:
                     # config.ignore_extra is False
                     for field in sorted(extra):
-                        errors[field] = EXTRA_ERROR
+                        errors.append(Error(EXTRA, loc=field))
 
         if errors:
             raise ValidationError(errors)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -137,8 +137,8 @@ class MetaModel(ABCMeta):
 
 
 MISSING = Missing('field required')
-MISSING_ERROR = Error(MISSING, None)
-EXTRA_ERROR = Error(Extra('extra fields not permitted'), None)
+MISSING_ERROR = Error(MISSING)
+EXTRA_ERROR = Error(Extra('extra fields not permitted'))
 
 
 class BaseModel(metaclass=MetaModel):
@@ -191,7 +191,7 @@ class BaseModel(metaclass=MetaModel):
     def parse_obj(cls, obj):
         if not isinstance(obj, dict):
             exc = TypeError(f'{cls.__name__} expected dict not {type(obj).__name__}')
-            raise ValidationError([Error(exc, None)])
+            raise ValidationError([Error(exc)])
         return cls(**obj)
 
     @classmethod
@@ -204,7 +204,7 @@ class BaseModel(metaclass=MetaModel):
             obj = load_str_bytes(b, proto=proto, content_type=content_type, encoding=encoding,
                                  allow_pickle=allow_pickle)
         except (ValueError, TypeError, UnicodeDecodeError) as e:
-            raise ValidationError([Error(e, None)])
+            raise ValidationError([Error(e)])
         return cls.parse_obj(obj)
 
     @classmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -190,7 +190,7 @@ class BaseModel(metaclass=MetaModel):
     def parse_obj(cls, obj):
         if not isinstance(obj, dict):
             exc = TypeError(f'{cls.__name__} expected dict not {type(obj).__name__}')
-            raise ValidationError([Error(exc)])
+            raise ValidationError([Error(exc, loc='__obj__')])
         return cls(**obj)
 
     @classmethod
@@ -203,7 +203,7 @@ class BaseModel(metaclass=MetaModel):
             obj = load_str_bytes(b, proto=proto, content_type=content_type, encoding=encoding,
                                  allow_pickle=allow_pickle)
         except (ValueError, TypeError, UnicodeDecodeError) as e:
-            raise ValidationError([Error(e)])
+            raise ValidationError([Error(e, loc='__obj__')])
         return cls.parse_obj(obj)
 
     @classmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -137,8 +137,8 @@ class MetaModel(ABCMeta):
 
 
 MISSING = Missing('field required')
-MISSING_ERROR = Error(MISSING, None, None)
-EXTRA_ERROR = Error(Extra('extra fields not permitted'), None, None)
+MISSING_ERROR = Error(MISSING, None)
+EXTRA_ERROR = Error(Extra('extra fields not permitted'), None)
 
 
 class BaseModel(metaclass=MetaModel):
@@ -191,7 +191,7 @@ class BaseModel(metaclass=MetaModel):
     def parse_obj(cls, obj):
         if not isinstance(obj, dict):
             exc = TypeError(f'{cls.__name__} expected dict not {type(obj).__name__}')
-            raise ValidationError([Error(exc, None, None)])
+            raise ValidationError([Error(exc, None)])
         return cls(**obj)
 
     @classmethod
@@ -204,7 +204,7 @@ class BaseModel(metaclass=MetaModel):
             obj = load_str_bytes(b, proto=proto, content_type=content_type, encoding=encoding,
                                  allow_pickle=allow_pickle)
         except (ValueError, TypeError, UnicodeDecodeError) as e:
-            raise ValidationError([Error(e, None, None)])
+            raise ValidationError([Error(e, None)])
         return cls.parse_obj(obj)
 
     @classmethod

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -113,3 +113,7 @@ def display_as_type(v):
     except AttributeError:
         # happens with unions
         return str(v)
+
+
+def to_snake_case(v: str) -> str:
+    return re.sub(r'([a-z])([A-Z])', r'\1_\2', v).lower()

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -1,6 +1,6 @@
 import re
 from importlib import import_module
-from typing import Tuple
+from typing import Tuple, _TypingBase
 
 try:
     import email_validator
@@ -102,3 +102,14 @@ def truncate(v, *, max_len=80):
     if len(v) > max_len:
         v = v[:max_len - 1] + '…'
     return v
+
+
+def display_as_type(v):
+    if not isinstance(v, _TypingBase) and not isinstance(v, type):
+        v = type(v)
+
+    try:
+        return v.__name__
+    except AttributeError:
+        # happens with unions
+        return str(v)

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -116,4 +116,7 @@ def display_as_type(v):
 
 
 def to_snake_case(v: str) -> str:
-    return re.sub(r'([a-z])([A-Z])', r'\1_\2', v).lower()
+    v = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1_\2', v)
+    v = re.sub(r'([a-z\d])([A-Z])', r'\1_\2', v)
+
+    return v.replace('-', '_').lower()

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -7,13 +7,10 @@ from typing import Any
 from uuid import UUID
 
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
-from .exceptions import ConfigError, type_display
+from .exceptions import ConfigError
+from .utils import display_as_type
 
 NoneType = type(None)
-
-
-def display_as_type(v):
-    return type_display(type(v))
 
 
 def not_none_validator(v):

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -34,11 +34,11 @@ def test_str_bytes():
 {
   "v": [
     {
-      "error_msg": "None is not an allow value",
+      "msg": "None is not an allow value",
       "type": "type_error"
     },
     {
-      "error_msg": "None is not an allow value",
+      "msg": "None is not an allow value",
       "type": "type_error"
     }
   ]
@@ -92,11 +92,11 @@ def test_union_int_str():
 {
   "v": [
     {
-      "error_msg": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
+      "msg": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
       "type": "type_error"
     },
     {
-      "error_msg": "None is not an allow value",
+      "msg": "None is not an allow value",
       "type": "type_error"
     }
   ]
@@ -128,13 +128,13 @@ def test_typed_list():
 {
   "v": [
     {
-      "error_msg": "invalid literal for int() with base 10: 'x'",
       "loc": 1,
+      "msg": "invalid literal for int() with base 10: 'x'",
       "type": "value_error"
     },
     {
-      "error_msg": "invalid literal for int() with base 10: 'y'",
       "loc": 2,
+      "msg": "invalid literal for int() with base 10: 'y'",
       "type": "value_error"
     }
   ]
@@ -146,7 +146,7 @@ def test_typed_list():
     assert """\
 {
   "v": {
-    "error_msg": "'int' object is not iterable",
+    "msg": "'int' object is not iterable",
     "type": "type_error"
   }
 }""" == exc_info.value.json(2)
@@ -286,12 +286,12 @@ v:
     {
       "error_details": {
         "name": {
-          "error_msg": "field required",
+          "msg": "field required",
           "type": "value_error.missing"
         }
       },
-      "error_msg": "error validating input",
       "loc": 0,
+      "msg": "error validating input",
       "type": "value_error.validation_error"
     }
   ]
@@ -530,7 +530,7 @@ def test_dict_list_error():
     assert {
         'v': {
             'type': 'type_error',
-            'error_msg': 'value is not a valid dict, got list',
+            'msg': 'value is not a valid dict, got list',
         }
     } == dict(exc_info.value.errors_dict)
 

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -28,7 +28,7 @@ def test_str_bytes():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('v',),
             'msg': 'None is not an allow value',
@@ -84,7 +84,7 @@ def test_union_int_str():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('v',),
             'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
@@ -118,14 +118,14 @@ def test_typed_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 'x', 'y'])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
-            'loc': ('v', '1'),
+            'loc': ('v', 1),
             'msg': 'invalid literal for int() with base 10: \'x\'',
             'type': 'value_error',
         },
         {
-            'loc': ('v', '2'),
+            'loc': ('v', 2),
             'msg': 'invalid literal for int() with base 10: \'y\'',
             'type': 'value_error',
         },
@@ -133,7 +133,7 @@ def test_typed_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=1)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('v',),
             'msg': '\'int\' object is not iterable',
@@ -151,9 +151,9 @@ def test_typed_set():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 'x'])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
-            'loc': ('v', '1'),
+            'loc': ('v', 1),
             'msg': 'invalid literal for int() with base 10: \'x\'',
             'type': 'value_error',
         },
@@ -217,7 +217,7 @@ def test_typed_dict_error(value, errors):
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
-    assert exc_info.value.flat_errors == errors
+    assert exc_info.value.flatten_errors() == errors
 
 
 def test_dict_key_error():
@@ -228,7 +228,7 @@ def test_dict_key_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v={'foo': 2, '3': '4'})
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('v', '__key__'),
             'msg': 'invalid literal for int() with base 10: \'foo\'',
@@ -276,9 +276,9 @@ def test_recursive_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=['x'])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
-            'loc': ('v', '0'),
+            'loc': ('v', 0),
             'msg': 'dictionary update sequence element #0 has length 1; 2 is required',
             'type': 'value_error',
         },
@@ -295,9 +295,9 @@ def test_recursive_list_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[{}])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
-            'loc': ('v', '0', 'name'),
+            'loc': ('v', 0, 'name'),
             'msg': 'field required',
             'type': 'value_error.missing',
         },
@@ -312,14 +312,14 @@ def test_list_unions():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
-            'loc': ('v', '2'),
+            'loc': ('v', 2),
             'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
             'type': 'type_error',
         },
         {
-            'loc': ('v', '2'),
+            'loc': ('v', 2),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
@@ -387,7 +387,7 @@ def test_alias_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(_a='foo')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('_a',),
             'msg': 'invalid literal for int() with base 10: \'foo\'',
@@ -497,7 +497,7 @@ def test_invalid_string_types(value, errors):
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
-    assert exc_info.value.flat_errors == errors
+    assert exc_info.value.flatten_errors() == errors
 
 
 def test_inheritance_config():
@@ -547,7 +547,7 @@ def test_string_none():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=None)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'None is not an allow value',

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -35,11 +35,11 @@ def test_str_bytes():
   "v": [
     {
       "error_msg": "None is not an allow value",
-      "error_type": "TypeError"
+      "type": "type_error"
     },
     {
       "error_msg": "None is not an allow value",
-      "error_type": "TypeError"
+      "type": "type_error"
     }
   ]
 }""" == exc_info.value.json(2)
@@ -93,11 +93,11 @@ def test_union_int_str():
   "v": [
     {
       "error_msg": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
-      "error_type": "TypeError"
+      "type": "type_error"
     },
     {
       "error_msg": "None is not an allow value",
-      "error_type": "TypeError"
+      "type": "type_error"
     }
   ]
 }""" == exc_info.value.json(2)
@@ -129,13 +129,13 @@ def test_typed_list():
   "v": [
     {
       "error_msg": "invalid literal for int() with base 10: 'x'",
-      "error_type": "ValueError",
-      "loc": 1
+      "loc": 1,
+      "type": "value_error"
     },
     {
       "error_msg": "invalid literal for int() with base 10: 'y'",
-      "error_type": "ValueError",
-      "loc": 2
+      "loc": 2,
+      "type": "value_error"
     }
   ]
 }""" == exc_info.value.json(2)
@@ -147,7 +147,7 @@ def test_typed_list():
 {
   "v": {
     "error_msg": "'int' object is not iterable",
-    "error_type": "TypeError"
+    "type": "type_error"
   }
 }""" == exc_info.value.json(2)
 
@@ -163,7 +163,7 @@ def test_typed_set():
     assert """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError loc=1)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'x' (type=value_error loc=1)""" == str(exc_info.value)
 
 
 class DictModel(BaseModel):
@@ -189,21 +189,21 @@ def test_typed_dict(value, result):
         """\
 error validating input
 v:
-  value is not a valid dict, got int (error_type=TypeError)"""
+  value is not a valid dict, got int (type=type_error)"""
     ),
     (
         {'a': 'b'},
         """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'b' (error_type=ValueError loc=a)"""
+  invalid literal for int() with base 10: 'b' (type=value_error loc=a)"""
     ),
     (
         [1, 2, 3],
         """\
 error validating input
 v:
-  value is not a valid dict, got list (error_type=TypeError)""",
+  value is not a valid dict, got list (type=type_error)""",
     )
 ])
 def test_typed_dict_error(value, error):
@@ -221,7 +221,7 @@ def test_dict_key_error():
     assert """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'foo' (error_type=ValueError loc=key)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'foo' (type=value_error loc=key)""" == str(exc_info.value)
 
 
 # TODO re-add when implementing better model validators
@@ -276,9 +276,9 @@ def test_recursive_list_error():
     assert """\
 error validating input
 v:
-  error validating input (error_type=ValidationError)
+  error validating input (type=value_error.validation_error)
     name:
-      field required (error_type=Missing)\
+      field required (type=value_error.missing)\
 """ == str(exc_info.value)
     assert """\
 {
@@ -287,12 +287,12 @@ v:
       "error_details": {
         "name": {
           "error_msg": "field required",
-          "error_type": "Missing"
+          "type": "value_error.missing"
         }
       },
       "error_msg": "error validating input",
-      "error_type": "ValidationError",
-      "loc": 0
+      "loc": 0,
+      "type": "value_error.validation_error"
     }
   ]
 }""" == exc_info.value.json(2)
@@ -310,8 +310,8 @@ def test_list_unions():
 error validating input
 v:
   int() argument must be a string, a bytes-like object or a number, not 'NoneType' \
-(error_type=TypeError loc=2)
-  None is not an allow value (error_type=TypeError loc=2)\
+(type=type_error loc=2)
+  None is not an allow value (type=type_error loc=2)\
 """ == str(exc_info.value)
 
 
@@ -378,7 +378,7 @@ def test_alias_error():
     assert """\
 error validating input
 _a:
-  invalid literal for int() with base 10: 'foo' (error_type=ValueError)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'foo' (type=value_error)""" == str(exc_info.value)
 
 
 def test_annotation_config():
@@ -529,7 +529,7 @@ def test_dict_list_error():
         assert DictModel(v=[1, 2, 3])
     assert {
         'v': {
-            'error_type': 'TypeError',
+            'type': 'type_error',
             'error_msg': 'value is not a valid dict, got list',
         }
     } == dict(exc_info.value.errors_dict)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -28,7 +28,7 @@ def test_str_bytes():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v',
             'msg': 'None is not an allow value',
@@ -84,7 +84,7 @@ def test_union_int_str():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v',
             'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
@@ -118,7 +118,7 @@ def test_typed_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 'x', 'y'])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v.1',
             'msg': 'invalid literal for int() with base 10: \'x\'',
@@ -133,7 +133,7 @@ def test_typed_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=1)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v',
             'msg': '\'int\' object is not iterable',
@@ -151,7 +151,7 @@ def test_typed_set():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 'x'])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v.1',
             'msg': 'invalid literal for int() with base 10: \'x\'',
@@ -217,7 +217,7 @@ def test_typed_dict_error(value, errors):
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
-    assert exc_info.value.flatten_errors == errors
+    assert exc_info.value.flat_errors == errors
 
 
 def test_dict_key_error():
@@ -228,7 +228,7 @@ def test_dict_key_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v={'foo': 2, '3': '4'})
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v.key',
             'msg': 'invalid literal for int() with base 10: \'foo\'',
@@ -276,7 +276,7 @@ def test_recursive_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=['x'])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v.0',
             'msg': 'dictionary update sequence element #0 has length 1; 2 is required',
@@ -295,7 +295,7 @@ def test_recursive_list_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[{}])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v.0.name',
             'msg': 'field required',
@@ -312,7 +312,7 @@ def test_list_unions():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v.2',
             'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
@@ -387,7 +387,7 @@ def test_alias_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(_a='foo')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': '_a',
             'msg': 'invalid literal for int() with base 10: \'foo\'',
@@ -497,7 +497,7 @@ def test_invalid_string_types(value, errors):
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
-    assert exc_info.value.flatten_errors == errors
+    assert exc_info.value.flat_errors == errors
 
 
 def test_inheritance_config():
@@ -547,7 +547,7 @@ def test_string_none():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=None)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'None is not an allow value',

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -35,13 +35,11 @@ def test_str_bytes():
   "v": [
     {
       "error_msg": "None is not an allow value",
-      "error_type": "TypeError",
-      "track": "str"
+      "error_type": "TypeError"
     },
     {
       "error_msg": "None is not an allow value",
-      "error_type": "TypeError",
-      "track": "bytes"
+      "error_type": "TypeError"
     }
   ]
 }""" == exc_info.value.json(2)
@@ -95,13 +93,11 @@ def test_union_int_str():
   "v": [
     {
       "error_msg": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
-      "error_type": "TypeError",
-      "track": "int"
+      "error_type": "TypeError"
     },
     {
       "error_msg": "None is not an allow value",
-      "error_type": "TypeError",
-      "track": "str"
+      "error_type": "TypeError"
     }
   ]
 }""" == exc_info.value.json(2)
@@ -134,14 +130,12 @@ def test_typed_list():
     {
       "error_msg": "invalid literal for int() with base 10: 'x'",
       "error_type": "ValueError",
-      "index": 1,
-      "track": "int"
+      "index": 1
     },
     {
       "error_msg": "invalid literal for int() with base 10: 'y'",
       "error_type": "ValueError",
-      "index": 2,
-      "track": "int"
+      "index": 2
     }
   ]
 }""" == exc_info.value.json(2)
@@ -169,7 +163,7 @@ def test_typed_set():
     assert """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError track=int index=1)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'x' (error_type=ValueError index=1)""" == str(exc_info.value)
 
 
 class DictModel(BaseModel):
@@ -202,7 +196,7 @@ v:
         """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'b' (error_type=ValueError track=int index=a)"""
+  invalid literal for int() with base 10: 'b' (error_type=ValueError index=a)"""
     ),
     (
         [1, 2, 3],
@@ -227,7 +221,7 @@ def test_dict_key_error():
     assert """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'foo' (error_type=ValueError track=int index=key)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'foo' (error_type=ValueError index=key)""" == str(exc_info.value)
 
 
 # TODO re-add when implementing better model validators
@@ -282,7 +276,7 @@ def test_recursive_list_error():
     assert """\
 error validating input
 v:
-  error validating input (error_type=ValidationError track=SubModel)
+  error validating input (error_type=ValidationError)
     name:
       field required (error_type=Missing)\
 """ == str(exc_info.value)
@@ -298,8 +292,7 @@ v:
       },
       "error_msg": "error validating input",
       "error_type": "ValidationError",
-      "index": 0,
-      "track": "SubModel"
+      "index": 0
     }
   ]
 }""" == exc_info.value.json(2)
@@ -317,8 +310,8 @@ def test_list_unions():
 error validating input
 v:
   int() argument must be a string, a bytes-like object or a number, not 'NoneType' \
-(error_type=TypeError track=int index=2)
-  None is not an allow value (error_type=TypeError track=str index=2)\
+(error_type=TypeError index=2)
+  None is not an allow value (error_type=TypeError index=2)\
 """ == str(exc_info.value)
 
 
@@ -385,7 +378,7 @@ def test_alias_error():
     assert """\
 error validating input
 _a:
-  invalid literal for int() with base 10: 'foo' (error_type=ValueError track=int)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'foo' (error_type=ValueError)""" == str(exc_info.value)
 
 
 def test_annotation_config():

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -30,12 +30,12 @@ def test_str_bytes():
         Model(v=None)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
@@ -86,12 +86,12 @@ def test_union_int_str():
         Model(v=None)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
             'type': 'type_error',
         },
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
@@ -120,12 +120,12 @@ def test_typed_list():
         Model(v=[1, 'x', 'y'])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v.1',
+            'loc': ('v', '1'),
             'msg': 'invalid literal for int() with base 10: \'x\'',
             'type': 'value_error',
         },
         {
-            'loc': 'v.2',
+            'loc': ('v', '2'),
             'msg': 'invalid literal for int() with base 10: \'y\'',
             'type': 'value_error',
         },
@@ -135,7 +135,7 @@ def test_typed_list():
         Model(v=1)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': '\'int\' object is not iterable',
             'type': 'type_error',
         },
@@ -153,7 +153,7 @@ def test_typed_set():
         Model(v=[1, 'x'])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v.1',
+            'loc': ('v', '1'),
             'msg': 'invalid literal for int() with base 10: \'x\'',
             'type': 'value_error',
         },
@@ -184,7 +184,7 @@ def test_typed_dict(value, result):
         1,
         [
             {
-                'loc': 'v',
+                'loc': ('v',),
                 'msg': 'value is not a valid dict, got int',
                 'type': 'type_error',
             },
@@ -194,7 +194,7 @@ def test_typed_dict(value, result):
         {'a': 'b'},
         [
             {
-                'loc': 'v.a',
+                'loc': ('v', 'a'),
                 'msg': 'invalid literal for int() with base 10: \'b\'',
                 'type': 'value_error',
             },
@@ -204,7 +204,7 @@ def test_typed_dict(value, result):
         [1, 2, 3],
         [
             {
-                'loc': 'v',
+                'loc': ('v',),
                 'msg': 'value is not a valid dict, got list',
                 'type': 'type_error',
             },
@@ -230,7 +230,7 @@ def test_dict_key_error():
         Model(v={'foo': 2, '3': '4'})
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v.key',
+            'loc': ('v', '__key__'),
             'msg': 'invalid literal for int() with base 10: \'foo\'',
             'type': 'value_error',
         },
@@ -278,7 +278,7 @@ def test_recursive_list():
         Model(v=['x'])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v.0',
+            'loc': ('v', '0'),
             'msg': 'dictionary update sequence element #0 has length 1; 2 is required',
             'type': 'value_error',
         },
@@ -297,7 +297,7 @@ def test_recursive_list_error():
         Model(v=[{}])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v.0.name',
+            'loc': ('v', '0', 'name'),
             'msg': 'field required',
             'type': 'value_error.missing',
         },
@@ -314,12 +314,12 @@ def test_list_unions():
         Model(v=[1, 2, None])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v.2',
+            'loc': ('v', '2'),
             'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
             'type': 'type_error',
         },
         {
-            'loc': 'v.2',
+            'loc': ('v', '2'),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
@@ -389,7 +389,7 @@ def test_alias_error():
         Model(_a='foo')
     assert exc_info.value.flat_errors == [
         {
-            'loc': '_a',
+            'loc': ('_a',),
             'msg': 'invalid literal for int() with base 10: \'foo\'',
             'type': 'value_error',
         },
@@ -474,7 +474,7 @@ def test_valid_string_types(value, expected):
         {'foo': 'bar'},
         [
             {
-                'loc': 'v',
+                'loc': ('v',),
                 'msg': 'str or byte type expected not dict',
                 'type': 'type_error',
             },
@@ -484,7 +484,7 @@ def test_valid_string_types(value, expected):
         [1, 2, 3],
         [
             {
-                'loc': 'v',
+                'loc': ('v',),
                 'msg': 'str or byte type expected not list',
                 'type': 'type_error',
             },
@@ -549,7 +549,7 @@ def test_string_none():
         Model(a=None)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -130,12 +130,12 @@ def test_typed_list():
     {
       "error_msg": "invalid literal for int() with base 10: 'x'",
       "error_type": "ValueError",
-      "index": 1
+      "loc": 1
     },
     {
       "error_msg": "invalid literal for int() with base 10: 'y'",
       "error_type": "ValueError",
-      "index": 2
+      "loc": 2
     }
   ]
 }""" == exc_info.value.json(2)
@@ -163,7 +163,7 @@ def test_typed_set():
     assert """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError index=1)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'x' (error_type=ValueError loc=1)""" == str(exc_info.value)
 
 
 class DictModel(BaseModel):
@@ -196,7 +196,7 @@ v:
         """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'b' (error_type=ValueError index=a)"""
+  invalid literal for int() with base 10: 'b' (error_type=ValueError loc=a)"""
     ),
     (
         [1, 2, 3],
@@ -221,7 +221,7 @@ def test_dict_key_error():
     assert """\
 error validating input
 v:
-  invalid literal for int() with base 10: 'foo' (error_type=ValueError index=key)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'foo' (error_type=ValueError loc=key)""" == str(exc_info.value)
 
 
 # TODO re-add when implementing better model validators
@@ -292,7 +292,7 @@ v:
       },
       "error_msg": "error validating input",
       "error_type": "ValidationError",
-      "index": 0
+      "loc": 0
     }
   ]
 }""" == exc_info.value.json(2)
@@ -310,8 +310,8 @@ def test_list_unions():
 error validating input
 v:
   int() argument must be a string, a bytes-like object or a number, not 'NoneType' \
-(error_type=TypeError index=2)
-  None is not an allow value (error_type=TypeError index=2)\
+(error_type=TypeError loc=2)
+  None is not an allow value (error_type=TypeError loc=2)\
 """ == str(exc_info.value)
 
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -91,7 +91,7 @@ def test_funky_name():
     assert m.dict() == {'this-is-funky': 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('this-is-funky',),
             'msg': 'field required',

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -93,7 +93,7 @@ def test_funky_name():
         model()
     assert exc_info.value.errors_dict == {
         'this-is-funky': {
-            'error_msg': 'field required',
+            'msg': 'field required',
             'type': 'value_error.missing',
         },
     }

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -91,12 +91,13 @@ def test_funky_name():
     assert m.dict() == {'this-is-funky': 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
-    assert exc_info.value.errors_dict == {
-        'this-is-funky': {
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'this-is-funky',
             'msg': 'field required',
             'type': 'value_error.missing',
         },
-    }
+    ]
 
 
 def test_repeat_base_usage():

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -91,7 +91,12 @@ def test_funky_name():
     assert m.dict() == {'this-is-funky': 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
-    assert exc_info.value.errors_dict == {'this-is-funky': {'error_msg': 'field required', 'error_type': 'Missing'}}
+    assert exc_info.value.errors_dict == {
+        'this-is-funky': {
+            'error_msg': 'field required',
+            'type': 'value_error.missing',
+        },
+    }
 
 
 def test_repeat_base_usage():

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -93,7 +93,7 @@ def test_funky_name():
         model()
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'this-is-funky',
+            'loc': ('this-is-funky',),
             'msg': 'field required',
             'type': 'value_error.missing',
         },

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -91,7 +91,7 @@ def test_funky_name():
     assert m.dict() == {'this-is-funky': 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'this-is-funky',
             'msg': 'field required',

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,304 @@
+from typing import Dict, List, Union
+from uuid import UUID
+
+import pytest
+
+from pydantic import BaseModel
+from pydantic.exceptions import ValidationError, flatten_errors
+
+
+class SubModel(BaseModel):
+    x: int
+    y: int
+    z: str
+
+
+class Model(BaseModel):
+    a: int
+    b: SubModel
+    c: List[SubModel]
+    d: Union[int, UUID]
+    e: Dict[int, str]
+    f: List[Union[int, str]]
+
+
+def test_validation_error_display_errors():
+    with pytest.raises(ValidationError) as exc_info:
+        Model.parse_obj({
+            'a': 'not_int',
+            'b': {
+                'y': 42,
+            },
+            'c': [
+                {
+                    'x': 'not_int',
+                    'y': 42,
+                    'z': 'string',
+                },
+            ],
+            'd': 'string',
+            'e': {
+                'not_int': 'string',
+            },
+            'f': [
+                None,
+            ],
+        })
+    assert exc_info.value.display_errors == """a
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+b -> x
+  field required (type=value_error.missing)
+b -> z
+  field required (type=value_error.missing)
+c -> 0 -> x
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+d
+  invalid literal for int() with base 10: 'string' (type=value_error)
+d
+  badly formed hexadecimal UUID string (type=value_error)
+e -> __key__
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+f -> 0
+  int() argument must be a string, a bytes-like object or a number, not 'NoneType' (type=type_error)
+f -> 0
+  None is not an allow value (type=type_error)"""
+
+
+def test_validation_error_flat_errors():
+    with pytest.raises(ValidationError) as exc_info:
+        Model.parse_obj({
+            'a': 'not_int',
+            'b': {
+                'y': 42,
+            },
+            'c': [
+                {
+                    'x': 'not_int',
+                    'y': 42,
+                    'z': 'string',
+                },
+            ],
+            'd': 'string',
+            'e': {
+                'not_int': 'string',
+            },
+            'f': [
+                None,
+            ],
+        })
+    assert exc_info.value.flat_errors == [
+        {
+            'loc': (
+                'a',
+            ),
+            'msg': 'invalid literal for int() with base 10: \'not_int\'',
+            'type': 'value_error',
+        },
+        {
+            'loc': (
+                'b',
+                'x',
+            ),
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        },
+        {
+            'loc': (
+                'b',
+                'z',
+            ),
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        },
+        {
+            'loc': (
+                'c',
+                '0',
+                'x',
+            ),
+            'msg': 'invalid literal for int() with base 10: \'not_int\'',
+            'type': 'value_error',
+        },
+        {
+            'loc': (
+                'd',
+            ),
+            'msg': 'invalid literal for int() with base 10: \'string\'',
+            'type': 'value_error',
+        },
+        {
+            'loc': (
+                'd',
+            ),
+            'msg': 'badly formed hexadecimal UUID string',
+            'type': 'value_error',
+        },
+        {
+            'loc': (
+                'e',
+                '__key__',
+            ),
+            'msg': 'invalid literal for int() with base 10: \'not_int\'',
+            'type': 'value_error',
+        },
+        {
+            'loc': (
+                'f',
+                '0',
+            ),
+            'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
+            'type': 'type_error',
+        },
+        {
+            'loc': (
+                'f',
+                '0',
+            ),
+            'msg': 'None is not an allow value',
+            'type': 'type_error',
+        },
+    ]
+
+
+def test_validation_error_json():
+    with pytest.raises(ValidationError) as exc_info:
+        Model.parse_obj({
+            'a': 'not_int',
+            'b': {
+                'y': 42,
+            },
+            'c': [
+                {
+                    'x': 'not_int',
+                    'y': 42,
+                    'z': 'string',
+                },
+            ],
+            'd': 'string',
+            'e': {
+                'not_int': 'string',
+            },
+            'f': [
+                None,
+            ],
+        })
+    assert exc_info.value.json() == """[
+  {
+    "loc": [
+      "a"
+    ],
+    "msg": "invalid literal for int() with base 10: 'not_int'",
+    "type": "value_error"
+  },
+  {
+    "loc": [
+      "b",
+      "x"
+    ],
+    "msg": "field required",
+    "type": "value_error.missing"
+  },
+  {
+    "loc": [
+      "b",
+      "z"
+    ],
+    "msg": "field required",
+    "type": "value_error.missing"
+  },
+  {
+    "loc": [
+      "c",
+      "0",
+      "x"
+    ],
+    "msg": "invalid literal for int() with base 10: 'not_int'",
+    "type": "value_error"
+  },
+  {
+    "loc": [
+      "d"
+    ],
+    "msg": "invalid literal for int() with base 10: 'string'",
+    "type": "value_error"
+  },
+  {
+    "loc": [
+      "d"
+    ],
+    "msg": "badly formed hexadecimal UUID string",
+    "type": "value_error"
+  },
+  {
+    "loc": [
+      "e",
+      "__key__"
+    ],
+    "msg": "invalid literal for int() with base 10: 'not_int'",
+    "type": "value_error"
+  },
+  {
+    "loc": [
+      "f",
+      "0"
+    ],
+    "msg": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
+    "type": "type_error"
+  },
+  {
+    "loc": [
+      "f",
+      "0"
+    ],
+    "msg": "None is not an allow value",
+    "type": "type_error"
+  }
+]"""
+
+
+def test_validation_error_str():
+    with pytest.raises(ValidationError) as exc_info:
+        Model.parse_obj({
+            'a': 'not_int',
+            'b': {
+                'y': 42,
+            },
+            'c': [
+                {
+                    'x': 'not_int',
+                    'y': 42,
+                    'z': 'string',
+                },
+            ],
+            'd': 'string',
+            'e': {
+                'not_int': 'string',
+            },
+            'f': [
+                None,
+            ],
+        })
+    assert str(exc_info.value) == """validation errors
+a
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+b -> x
+  field required (type=value_error.missing)
+b -> z
+  field required (type=value_error.missing)
+c -> 0 -> x
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+d
+  invalid literal for int() with base 10: 'string' (type=value_error)
+d
+  badly formed hexadecimal UUID string (type=value_error)
+e -> __key__
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+f -> 0
+  int() argument must be a string, a bytes-like object or a number, not 'NoneType' (type=type_error)
+f -> 0
+  None is not an allow value (type=type_error)"""
+
+
+def test_flatten_errors_unknown_error_object():
+    with pytest.raises(TypeError):
+        flatten_errors([object])

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -250,4 +250,4 @@ def test_validation_error(result, expected):
 
 def test_flatten_errors_unknown_error_object():
     with pytest.raises(RuntimeError):
-        flatten_errors([object])
+        list(flatten_errors([object]))

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,44 +7,11 @@ from pydantic import BaseModel
 from pydantic.exceptions import ValidationError, flatten_errors
 
 
-class SubModel(BaseModel):
-    x: int
-    y: int
-    z: str
-
-
-class Model(BaseModel):
-    a: int
-    b: SubModel
-    c: List[SubModel]
-    d: Union[int, UUID]
-    e: Dict[int, str]
-    f: List[Union[int, str]]
-
-
-def test_validation_error_display_errors():
-    with pytest.raises(ValidationError) as exc_info:
-        Model.parse_obj({
-            'a': 'not_int',
-            'b': {
-                'y': 42,
-            },
-            'c': [
-                {
-                    'x': 'not_int',
-                    'y': 42,
-                    'z': 'string',
-                },
-            ],
-            'd': 'string',
-            'e': {
-                'not_int': 'string',
-            },
-            'f': [
-                None,
-            ],
-        })
-    assert exc_info.value.display_errors == """a
+@pytest.mark.parametrize('result,expected', (
+    (
+        'display_errors',
+        """\
+a
   invalid literal for int() with base 10: 'not_int' (type=value_error)
 b -> x
   field required (type=value_error.missing)
@@ -61,128 +28,87 @@ e -> __key__
 f -> 0
   int() argument must be a string, a bytes-like object or a number, not 'NoneType' (type=type_error)
 f -> 0
-  None is not an allow value (type=type_error)"""
-
-
-def test_validation_error_flat_errors():
-    with pytest.raises(ValidationError) as exc_info:
-        Model.parse_obj({
-            'a': 'not_int',
-            'b': {
-                'y': 42,
+  None is not an allow value (type=type_error)""",
+    ),
+    (
+        'flatten_errors',
+        [
+            {
+                'loc': (
+                    'a',
+                ),
+                'msg': 'invalid literal for int() with base 10: \'not_int\'',
+                'type': 'value_error',
             },
-            'c': [
-                {
-                    'x': 'not_int',
-                    'y': 42,
-                    'z': 'string',
-                },
-            ],
-            'd': 'string',
-            'e': {
-                'not_int': 'string',
+            {
+                'loc': (
+                    'b',
+                    'x',
+                ),
+                'msg': 'field required',
+                'type': 'value_error.missing',
             },
-            'f': [
-                None,
-            ],
-        })
-    assert exc_info.value.flat_errors == [
-        {
-            'loc': (
-                'a',
-            ),
-            'msg': 'invalid literal for int() with base 10: \'not_int\'',
-            'type': 'value_error',
-        },
-        {
-            'loc': (
-                'b',
-                'x',
-            ),
-            'msg': 'field required',
-            'type': 'value_error.missing',
-        },
-        {
-            'loc': (
-                'b',
-                'z',
-            ),
-            'msg': 'field required',
-            'type': 'value_error.missing',
-        },
-        {
-            'loc': (
-                'c',
-                '0',
-                'x',
-            ),
-            'msg': 'invalid literal for int() with base 10: \'not_int\'',
-            'type': 'value_error',
-        },
-        {
-            'loc': (
-                'd',
-            ),
-            'msg': 'invalid literal for int() with base 10: \'string\'',
-            'type': 'value_error',
-        },
-        {
-            'loc': (
-                'd',
-            ),
-            'msg': 'badly formed hexadecimal UUID string',
-            'type': 'value_error',
-        },
-        {
-            'loc': (
-                'e',
-                '__key__',
-            ),
-            'msg': 'invalid literal for int() with base 10: \'not_int\'',
-            'type': 'value_error',
-        },
-        {
-            'loc': (
-                'f',
-                '0',
-            ),
-            'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
-            'type': 'type_error',
-        },
-        {
-            'loc': (
-                'f',
-                '0',
-            ),
-            'msg': 'None is not an allow value',
-            'type': 'type_error',
-        },
-    ]
-
-
-def test_validation_error_json():
-    with pytest.raises(ValidationError) as exc_info:
-        Model.parse_obj({
-            'a': 'not_int',
-            'b': {
-                'y': 42,
+            {
+                'loc': (
+                    'b',
+                    'z',
+                ),
+                'msg': 'field required',
+                'type': 'value_error.missing',
             },
-            'c': [
-                {
-                    'x': 'not_int',
-                    'y': 42,
-                    'z': 'string',
-                },
-            ],
-            'd': 'string',
-            'e': {
-                'not_int': 'string',
+            {
+                'loc': (
+                    'c',
+                    0,
+                    'x',
+                ),
+                'msg': 'invalid literal for int() with base 10: \'not_int\'',
+                'type': 'value_error',
             },
-            'f': [
-                None,
-            ],
-        })
-    assert exc_info.value.json() == """[
+            {
+                'loc': (
+                    'd',
+                ),
+                'msg': 'invalid literal for int() with base 10: \'string\'',
+                'type': 'value_error',
+            },
+            {
+                'loc': (
+                    'd',
+                ),
+                'msg': 'badly formed hexadecimal UUID string',
+                'type': 'value_error',
+            },
+            {
+                'loc': (
+                    'e',
+                    '__key__',
+                ),
+                'msg': 'invalid literal for int() with base 10: \'not_int\'',
+                'type': 'value_error',
+            },
+            {
+                'loc': (
+                    'f',
+                    0,
+                ),
+                'msg': 'int() argument must be a string, a bytes-like object or a number, not \'NoneType\'',
+                'type': 'type_error',
+            },
+            {
+                'loc': (
+                    'f',
+                    0,
+                ),
+                'msg': 'None is not an allow value',
+                'type': 'type_error',
+            },
+        ],
+    ),
+    (
+        'json',
+        """\
+[
   {
     "loc": [
       "a"
@@ -209,7 +135,7 @@ def test_validation_error_json():
   {
     "loc": [
       "c",
-      "0",
+      0,
       "x"
     ],
     "msg": "invalid literal for int() with base 10: 'not_int'",
@@ -240,7 +166,7 @@ def test_validation_error_json():
   {
     "loc": [
       "f",
-      "0"
+      0
     ],
     "msg": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
     "type": "type_error"
@@ -248,15 +174,51 @@ def test_validation_error_json():
   {
     "loc": [
       "f",
-      "0"
+      0
     ],
     "msg": "None is not an allow value",
     "type": "type_error"
   }
 ]"""
+    ),
+    (
+        '__str__',
+        """\
+validation errors
+a
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+b -> x
+  field required (type=value_error.missing)
+b -> z
+  field required (type=value_error.missing)
+c -> 0 -> x
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+d
+  invalid literal for int() with base 10: 'string' (type=value_error)
+d
+  badly formed hexadecimal UUID string (type=value_error)
+e -> __key__
+  invalid literal for int() with base 10: 'not_int' (type=value_error)
+f -> 0
+  int() argument must be a string, a bytes-like object or a number, not 'NoneType' (type=type_error)
+f -> 0
+  None is not an allow value (type=type_error)"""
+    ),
+))
+def test_validation_error(result, expected):
+    class SubModel(BaseModel):
+        x: int
+        y: int
+        z: str
 
+    class Model(BaseModel):
+        a: int
+        b: SubModel
+        c: List[SubModel]
+        d: Union[int, UUID]
+        e: Dict[int, str]
+        f: List[Union[int, str]]
 
-def test_validation_error_str():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_obj({
             'a': 'not_int',
@@ -278,27 +240,14 @@ def test_validation_error_str():
                 None,
             ],
         })
-    assert str(exc_info.value) == """validation errors
-a
-  invalid literal for int() with base 10: 'not_int' (type=value_error)
-b -> x
-  field required (type=value_error.missing)
-b -> z
-  field required (type=value_error.missing)
-c -> 0 -> x
-  invalid literal for int() with base 10: 'not_int' (type=value_error)
-d
-  invalid literal for int() with base 10: 'string' (type=value_error)
-d
-  badly formed hexadecimal UUID string (type=value_error)
-e -> __key__
-  invalid literal for int() with base 10: 'not_int' (type=value_error)
-f -> 0
-  int() argument must be a string, a bytes-like object or a number, not 'NoneType' (type=type_error)
-f -> 0
-  None is not an allow value (type=type_error)"""
+
+    result = getattr(exc_info.value, result)
+    if callable(result):
+        result = result()
+
+    assert result == expected
 
 
 def test_flatten_errors_unknown_error_object():
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         flatten_errors([object])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,9 +39,9 @@ def test_ultra_simple_failed():
     assert """\
 2 errors validating input
 a:
-  could not convert string to float: 'x' (error_type=ValueError track=float)
+  could not convert string to float: 'x' (error_type=ValueError)
 b:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError track=int)\
+  invalid literal for int() with base 10: 'x' (error_type=ValueError)\
 """ == str(exc_info.value)
 
 
@@ -121,13 +121,11 @@ def test_nullable_strings_fails():
 {
   "required_bytes_value": {
     "error_msg": "None is not an allow value",
-    "error_type": "TypeError",
-    "track": "bytes"
+    "error_type": "TypeError"
   },
   "required_str_value": {
     "error_msg": "None is not an allow value",
-    "error_type": "TypeError",
-    "track": "str"
+    "error_type": "TypeError"
   }
 }""" == json.dumps(pretty_errors(e.errors_raw), indent=2, sort_keys=True)
 
@@ -364,12 +362,12 @@ def test_validating_assignment_fail():
         p.a = 'b'
     assert """error validating input
 a:
-  invalid literal for int() with base 10: 'b' (error_type=ValueError track=int)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'b' (error_type=ValueError)""" == str(exc_info.value)
     with pytest.raises(ValidationError) as exc_info:
         p.b = ''
     assert """error validating input
 b:
-  length less than minimum allowed: 1 (error_type=ValueError track=ConstrainedStrValue)""" == str(exc_info.value)
+  length less than minimum allowed: 1 (error_type=ValueError)""" == str(exc_info.value)
 
 
 def test_enum_values():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,7 +25,7 @@ class UltraSimpleModel(BaseModel):
 def test_ultra_simple_missing():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel()
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'field required',
@@ -37,7 +37,7 @@ def test_ultra_simple_missing():
 def test_ultra_simple_failed():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel(a='x', b='x')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'could not convert string to float: \'x\'',
@@ -123,7 +123,7 @@ def test_nullable_strings_fails():
             required_bytes_value=None,
             required_bytes_none_value=None,
         )
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'required_str_value',
             'msg': 'None is not an allow value',
@@ -173,7 +173,7 @@ def test_prevent_extra_success():
 def test_prevent_extra_fails():
     with pytest.raises(ValidationError) as exc_info:
         PreventExtraModel(foo='ok', bar='wrong', spam='xx')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'bar',
             'msg': 'extra fields not permitted',
@@ -314,7 +314,7 @@ def test_required():
 
     with pytest.raises(ValidationError) as exc_info:
         Model()
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'field required',
@@ -381,7 +381,7 @@ def test_validating_assignment_fail():
 
     with pytest.raises(ValidationError) as exc_info:
         p.a = 'b'
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'invalid literal for int() with base 10: \'b\'',
@@ -391,7 +391,7 @@ def test_validating_assignment_fail():
 
     with pytest.raises(ValidationError) as exc_info:
         p.b = ''
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'b',
             'msg': 'length less than minimum allowed: 1',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ def test_ultra_simple_missing():
         UltraSimpleModel()
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'field required',
             'type': 'value_error.missing',
         },
@@ -39,12 +39,12 @@ def test_ultra_simple_failed():
         UltraSimpleModel(a='x', b='x')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'could not convert string to float: \'x\'',
             'type': 'value_error',
         },
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'invalid literal for int() with base 10: \'x\'',
             'type': 'value_error',
         },
@@ -125,12 +125,12 @@ def test_nullable_strings_fails():
         )
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'required_str_value',
+            'loc': ('required_str_value',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
         {
-            'loc': 'required_bytes_value',
+            'loc': ('required_bytes_value',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
@@ -175,12 +175,12 @@ def test_prevent_extra_fails():
         PreventExtraModel(foo='ok', bar='wrong', spam='xx')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'bar',
+            'loc': ('bar',),
             'msg': 'extra fields not permitted',
             'type': 'value_error.extra',
         },
         {
-            'loc': 'spam',
+            'loc': ('spam',),
             'msg': 'extra fields not permitted',
             'type': 'value_error.extra',
         },
@@ -316,7 +316,7 @@ def test_required():
         Model()
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'field required',
             'type': 'value_error.missing',
         },
@@ -383,7 +383,7 @@ def test_validating_assignment_fail():
         p.a = 'b'
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'invalid literal for int() with base 10: \'b\'',
             'type': 'value_error',
         },
@@ -393,7 +393,7 @@ def test_validating_assignment_fail():
         p.b = ''
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'length less than minimum allowed: 1',
             'type': 'value_error',
         },

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,9 @@
-import json
 from enum import Enum
 from typing import Any
 
 import pytest
 
 from pydantic import BaseModel, ConfigError, NoneBytes, NoneStr, Required, ValidationError, constr
-from pydantic.exceptions import pretty_errors
 
 
 def test_success():
@@ -27,22 +25,30 @@ class UltraSimpleModel(BaseModel):
 def test_ultra_simple_missing():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel()
-    assert """\
-error validating input
-a:
-  field required (type=value_error.missing)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        },
+    ]
 
 
 def test_ultra_simple_failed():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel(a='x', b='x')
-    assert """\
-2 errors validating input
-a:
-  could not convert string to float: 'x' (type=value_error)
-b:
-  invalid literal for int() with base 10: 'x' (type=value_error)\
-""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'could not convert string to float: \'x\'',
+            'type': 'value_error',
+        },
+        {
+            'loc': 'b',
+            'msg': 'invalid literal for int() with base 10: \'x\'',
+            'type': 'value_error',
+        },
+    ]
 
 
 def test_ultra_simple_repr():
@@ -59,6 +65,7 @@ def test_str_truncate():
         s2: str
         b1: bytes
         b2: bytes
+
     m = Model(s1='132', s2='x' * 100, b1='123', b2='x' * 100)
     print(repr(m.to_string()))
     assert m.to_string() == ("Model s1='132' "
@@ -109,25 +116,25 @@ def test_nullable_strings_fails():
         required_bytes_value: bytes = ...
         required_bytes_none_value: NoneBytes = ...
 
-    try:
+    with pytest.raises(ValidationError) as exc_info:
         NoneCheckModel(
             required_str_value=None,
             required_str_none_value=None,
             required_bytes_value=None,
             required_bytes_none_value=None,
         )
-    except ValidationError as e:
-        assert """\
-{
-  "required_bytes_value": {
-    "msg": "None is not an allow value",
-    "type": "type_error"
-  },
-  "required_str_value": {
-    "msg": "None is not an allow value",
-    "type": "type_error"
-  }
-}""" == json.dumps(pretty_errors(e.errors_raw), indent=2, sort_keys=True)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'required_str_value',
+            'msg': 'None is not an allow value',
+            'type': 'type_error',
+        },
+        {
+            'loc': 'required_bytes_value',
+            'msg': 'None is not an allow value',
+            'type': 'type_error',
+        },
+    ]
 
 
 class RecursiveModel(BaseModel):
@@ -158,6 +165,7 @@ class PreventExtraModel(BaseModel):
 def test_prevent_extra_success():
     m = PreventExtraModel()
     assert m.foo == 'whatever'
+
     m = PreventExtraModel(foo=1)
     assert m.foo == '1'
 
@@ -165,12 +173,18 @@ def test_prevent_extra_success():
 def test_prevent_extra_fails():
     with pytest.raises(ValidationError) as exc_info:
         PreventExtraModel(foo='ok', bar='wrong', spam='xx')
-    assert exc_info.value.message == '2 errors validating input'
-    assert """\
-bar:
-  extra fields not permitted (type=value_error.extra)
-spam:
-  extra fields not permitted (type=value_error.extra)""" == exc_info.value.display_errors
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'bar',
+            'msg': 'extra fields not permitted',
+            'type': 'value_error.extra',
+        },
+        {
+            'loc': 'spam',
+            'msg': 'extra fields not permitted',
+            'type': 'value_error.extra',
+        },
+    ]
 
 
 class InvalidValidator:
@@ -207,6 +221,7 @@ def test_unable_to_infer():
 def test_not_required():
     class Model(BaseModel):
         a: float = None
+
     assert Model(a=12.2).a == 12.2
     assert Model().a is None
     assert Model(a=None).a is None
@@ -217,6 +232,7 @@ def test_infer_type():
         a = False
         b = ''
         c = 0
+
     assert Model().a is False
     assert Model().b == ''
     assert Model().c == 0
@@ -235,17 +251,19 @@ def test_allow_extra():
 def test_set_attr():
     m = UltraSimpleModel(a=10.2)
     assert m.dict() == {'a': 10.2, 'b': 10}
+
     m.b = 20
     assert m.dict() == {'a': 10.2, 'b': 20}
 
 
 def test_set_attr_invalid():
-
     class UltraSimpleModel(BaseModel):
         a: float = ...
         b: int = 10
+
     m = UltraSimpleModel(a=10.2)
     assert m.dict() == {'a': 10.2, 'b': 10}
+
     with pytest.raises(ValueError) as exc_info:
         m.c = 20
     assert '"UltraSimpleModel" object has no field "c"' in str(exc_info)
@@ -296,11 +314,13 @@ def test_required():
 
     with pytest.raises(ValidationError) as exc_info:
         Model()
-    assert """\
-error validating input
-a:
-  field required (type=value_error.missing)\
-""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        },
+    ]
 
 
 def test_not_immutability():
@@ -358,16 +378,26 @@ def test_validating_assignment_pass():
 
 def test_validating_assignment_fail():
     p = ValidateAssignmentModel(a=5, b='hello')
+
     with pytest.raises(ValidationError) as exc_info:
         p.a = 'b'
-    assert """error validating input
-a:
-  invalid literal for int() with base 10: 'b' (type=value_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'invalid literal for int() with base 10: \'b\'',
+            'type': 'value_error',
+        },
+    ]
+
     with pytest.raises(ValidationError) as exc_info:
         p.b = ''
-    assert """error validating input
-b:
-  length less than minimum allowed: 1 (type=value_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'b',
+            'msg': 'length less than minimum allowed: 1',
+            'type': 'value_error',
+        },
+    ]
 
 
 def test_enum_values():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,7 +25,7 @@ class UltraSimpleModel(BaseModel):
 def test_ultra_simple_missing():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel()
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'field required',
@@ -37,7 +37,7 @@ def test_ultra_simple_missing():
 def test_ultra_simple_failed():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel(a='x', b='x')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'could not convert string to float: \'x\'',
@@ -123,7 +123,7 @@ def test_nullable_strings_fails():
             required_bytes_value=None,
             required_bytes_none_value=None,
         )
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('required_str_value',),
             'msg': 'None is not an allow value',
@@ -173,7 +173,7 @@ def test_prevent_extra_success():
 def test_prevent_extra_fails():
     with pytest.raises(ValidationError) as exc_info:
         PreventExtraModel(foo='ok', bar='wrong', spam='xx')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('bar',),
             'msg': 'extra fields not permitted',
@@ -314,7 +314,7 @@ def test_required():
 
     with pytest.raises(ValidationError) as exc_info:
         Model()
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'field required',
@@ -381,7 +381,7 @@ def test_validating_assignment_fail():
 
     with pytest.raises(ValidationError) as exc_info:
         p.a = 'b'
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'invalid literal for int() with base 10: \'b\'',
@@ -391,7 +391,7 @@ def test_validating_assignment_fail():
 
     with pytest.raises(ValidationError) as exc_info:
         p.b = ''
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('b',),
             'msg': 'length less than minimum allowed: 1',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,7 @@ def test_ultra_simple_missing():
     assert """\
 error validating input
 a:
-  field required (error_type=Missing)""" == str(exc_info.value)
+  field required (type=value_error.missing)""" == str(exc_info.value)
 
 
 def test_ultra_simple_failed():
@@ -39,9 +39,9 @@ def test_ultra_simple_failed():
     assert """\
 2 errors validating input
 a:
-  could not convert string to float: 'x' (error_type=ValueError)
+  could not convert string to float: 'x' (type=value_error)
 b:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError)\
+  invalid literal for int() with base 10: 'x' (type=value_error)\
 """ == str(exc_info.value)
 
 
@@ -121,11 +121,11 @@ def test_nullable_strings_fails():
 {
   "required_bytes_value": {
     "error_msg": "None is not an allow value",
-    "error_type": "TypeError"
+    "type": "type_error"
   },
   "required_str_value": {
     "error_msg": "None is not an allow value",
-    "error_type": "TypeError"
+    "type": "type_error"
   }
 }""" == json.dumps(pretty_errors(e.errors_raw), indent=2, sort_keys=True)
 
@@ -168,9 +168,9 @@ def test_prevent_extra_fails():
     assert exc_info.value.message == '2 errors validating input'
     assert """\
 bar:
-  extra fields not permitted (error_type=Extra)
+  extra fields not permitted (type=value_error.extra)
 spam:
-  extra fields not permitted (error_type=Extra)""" == exc_info.value.display_errors
+  extra fields not permitted (type=value_error.extra)""" == exc_info.value.display_errors
 
 
 class InvalidValidator:
@@ -299,7 +299,7 @@ def test_required():
     assert """\
 error validating input
 a:
-  field required (error_type=Missing)\
+  field required (type=value_error.missing)\
 """ == str(exc_info.value)
 
 
@@ -362,12 +362,12 @@ def test_validating_assignment_fail():
         p.a = 'b'
     assert """error validating input
 a:
-  invalid literal for int() with base 10: 'b' (error_type=ValueError)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'b' (type=value_error)""" == str(exc_info.value)
     with pytest.raises(ValidationError) as exc_info:
         p.b = ''
     assert """error validating input
 b:
-  length less than minimum allowed: 1 (error_type=ValueError)""" == str(exc_info.value)
+  length less than minimum allowed: 1 (type=value_error)""" == str(exc_info.value)
 
 
 def test_enum_values():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,11 +120,11 @@ def test_nullable_strings_fails():
         assert """\
 {
   "required_bytes_value": {
-    "error_msg": "None is not an allow value",
+    "msg": "None is not an allow value",
     "type": "type_error"
   },
   "required_str_value": {
-    "error_msg": "None is not an allow value",
+    "msg": "None is not an allow value",
     "type": "type_error"
   }
 }""" == json.dumps(pretty_errors(e.errors_raw), indent=2, sort_keys=True)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -23,7 +23,7 @@ def test_obj():
 def test_fails():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_obj([1, 2, 3])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': None,
             'msg': 'Model expected dict not list',
@@ -62,7 +62,7 @@ def test_msgpack_not_installed_proto(mocker):
 def test_msgpack_not_installed_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw(b'\x82\xa1a\x0c\xa1b\x08', content_type='application/msgpack')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': None,
             'msg': 'Unknown content-type: application/msgpack',
@@ -90,7 +90,7 @@ def test_pickle_not_allowed():
 def test_bad_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': None,
             'msg': 'Unknown content-type: application/missing',
@@ -102,7 +102,7 @@ def test_bad_ct():
 def test_bad_proto():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': None,
             'msg': 'Unknown protocol: foobar',

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -25,7 +25,7 @@ def test_fails():
         Model.parse_obj([1, 2, 3])
     assert """\
 error validating input
-Model expected dict not list (error_type=TypeError)""" == str(exc_info.value)
+Model expected dict not list (type=type_error)""" == str(exc_info.value)
 
 
 def test_json():
@@ -60,7 +60,7 @@ def test_msgpack_not_installed_ct():
         Model.parse_raw(b'\x82\xa1a\x0c\xa1b\x08', content_type='application/msgpack')
     assert """\
 error validating input
-Unknown content-type: application/msgpack (error_type=TypeError)""" == str(exc_info.value)
+Unknown content-type: application/msgpack (type=type_error)""" == str(exc_info.value)
 
 
 def test_pickle_ct():
@@ -84,7 +84,7 @@ def test_bad_ct():
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
     assert """\
 error validating input
-Unknown content-type: application/missing (error_type=TypeError)""" == str(exc_info.value)
+Unknown content-type: application/missing (type=type_error)""" == str(exc_info.value)
 
 
 def test_bad_proto():
@@ -92,7 +92,7 @@ def test_bad_proto():
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
     assert """\
 error validating input
-Unknown protocol: foobar (error_type=TypeError)""" == str(exc_info.value)
+Unknown protocol: foobar (type=type_error)""" == str(exc_info.value)
 
 
 def test_file_json(tmpdir):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -25,7 +25,7 @@ def test_fails():
         Model.parse_obj([1, 2, 3])
     assert exc_info.value.flat_errors == [
         {
-            'loc': None,
+            'loc': ('__obj__',),
             'msg': 'Model expected dict not list',
             'type': 'type_error',
         },
@@ -64,7 +64,7 @@ def test_msgpack_not_installed_ct():
         Model.parse_raw(b'\x82\xa1a\x0c\xa1b\x08', content_type='application/msgpack')
     assert exc_info.value.flat_errors == [
         {
-            'loc': None,
+            'loc': ('__obj__',),
             'msg': 'Unknown content-type: application/msgpack',
             'type': 'type_error',
         },
@@ -92,7 +92,7 @@ def test_bad_ct():
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
     assert exc_info.value.flat_errors == [
         {
-            'loc': None,
+            'loc': ('__obj__',),
             'msg': 'Unknown content-type: application/missing',
             'type': 'type_error',
         },
@@ -104,7 +104,7 @@ def test_bad_proto():
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
     assert exc_info.value.flat_errors == [
         {
-            'loc': None,
+            'loc': ('__obj__',),
             'msg': 'Unknown protocol: foobar',
             'type': 'type_error',
         },

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -23,9 +23,13 @@ def test_obj():
 def test_fails():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_obj([1, 2, 3])
-    assert """\
-error validating input
-Model expected dict not list (type=type_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': None,
+            'msg': 'Model expected dict not list',
+            'type': 'type_error',
+        },
+    ]
 
 
 def test_json():
@@ -58,9 +62,13 @@ def test_msgpack_not_installed_proto(mocker):
 def test_msgpack_not_installed_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw(b'\x82\xa1a\x0c\xa1b\x08', content_type='application/msgpack')
-    assert """\
-error validating input
-Unknown content-type: application/msgpack (type=type_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': None,
+            'msg': 'Unknown content-type: application/msgpack',
+            'type': 'type_error',
+        },
+    ]
 
 
 def test_pickle_ct():
@@ -82,17 +90,25 @@ def test_pickle_not_allowed():
 def test_bad_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
-    assert """\
-error validating input
-Unknown content-type: application/missing (type=type_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': None,
+            'msg': 'Unknown content-type: application/missing',
+            'type': 'type_error',
+        },
+    ]
 
 
 def test_bad_proto():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
-    assert """\
-error validating input
-Unknown protocol: foobar (type=type_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': None,
+            'msg': 'Unknown protocol: foobar',
+            'type': 'type_error',
+        },
+    ]
 
 
 def test_file_json(tmpdir):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -23,7 +23,7 @@ def test_obj():
 def test_fails():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_obj([1, 2, 3])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Model expected dict not list',
@@ -62,7 +62,7 @@ def test_msgpack_not_installed_proto(mocker):
 def test_msgpack_not_installed_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw(b'\x82\xa1a\x0c\xa1b\x08', content_type='application/msgpack')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Unknown content-type: application/msgpack',
@@ -90,7 +90,7 @@ def test_pickle_not_allowed():
 def test_bad_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Unknown content-type: application/missing',
@@ -102,7 +102,7 @@ def test_bad_ct():
 def test_bad_proto():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Unknown protocol: foobar',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,7 +27,7 @@ def test_sub_env_missing():
         SimpleSettings()
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'apple',
+            'loc': ('apple',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,7 +28,7 @@ def test_sub_env_missing():
     assert """\
 error validating input
 apple:
-  None is not an allow value (error_type=TypeError track=str)\
+  None is not an allow value (error_type=TypeError)\
 """ == str(exc_info.value)
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,11 +25,13 @@ def test_sub_env_override(env):
 def test_sub_env_missing():
     with pytest.raises(ValidationError) as exc_info:
         SimpleSettings()
-    assert """\
-error validating input
-apple:
-  None is not an allow value (type=type_error)\
-""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'apple',
+            'msg': 'None is not an allow value',
+            'type': 'type_error',
+        },
+    ]
 
 
 def test_other_setting(env):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ def test_sub_env_override(env):
 def test_sub_env_missing():
     with pytest.raises(ValidationError) as exc_info:
         SimpleSettings()
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('apple',),
             'msg': 'None is not an allow value',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,7 +28,7 @@ def test_sub_env_missing():
     assert """\
 error validating input
 apple:
-  None is not an allow value (error_type=TypeError)\
+  None is not an allow value (type=type_error)\
 """ == str(exc_info.value)
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ def test_sub_env_override(env):
 def test_sub_env_missing():
     with pytest.raises(ValidationError) as exc_info:
         SimpleSettings()
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'apple',
             'msg': 'None is not an allow value',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,8 +39,7 @@ def test_constrained_str_too_long():
 {
   "v": {
     "error_msg": "length greater than maximum allowed: 10",
-    "error_type": "ValueError",
-    "track": "ConstrainedStrValue"
+    "error_type": "ValueError"
   }
 }""" == exc_info.value.json(2)
 
@@ -191,13 +190,13 @@ class StrModel(BaseModel):
 def test_string_too_long():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x' * 150)
-    assert 'length greater than maximum allowed: 10 (error_type=ValueError track=str)' in exc_info.value.display_errors
+    assert 'length greater than maximum allowed: 10 (error_type=ValueError)' in exc_info.value.display_errors
 
 
 def test_string_too_short():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x')
-    assert 'length less than minimum allowed: 5 (error_type=ValueError track=str)' in exc_info.value.display_errors
+    assert 'length less than minimum allowed: 5 (error_type=ValueError)' in exc_info.value.display_errors
 
 
 class NumberModel(BaseModel):
@@ -212,15 +211,15 @@ class NumberModel(BaseModel):
 def test_number_too_big():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=50, float_check=150)
-    assert 'size greater than maximum allowed: 10 (error_type=ValueError track=int)' in exc_info.value.display_errors
-    assert 'size greater than maximum allowed: 10 (error_type=ValueError track=float)' in exc_info.value.display_errors
+    assert 'size greater than maximum allowed: 10 (error_type=ValueError)' in exc_info.value.display_errors
+    assert 'size greater than maximum allowed: 10 (error_type=ValueError)' in exc_info.value.display_errors
 
 
 def test_number_too_small():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=1, float_check=2.5)
-    assert 'size less than minimum allowed: 5 (error_type=ValueError track=int)' in exc_info.value.display_errors
-    assert 'size less than minimum allowed: 5 (error_type=ValueError track=float)' in exc_info.value.display_errors
+    assert 'size less than minimum allowed: 5 (error_type=ValueError)' in exc_info.value.display_errors
+    assert 'size less than minimum allowed: 5 (error_type=ValueError)' in exc_info.value.display_errors
 
 
 class DatetimeModel(BaseModel):
@@ -256,23 +255,19 @@ def test_datetime_errors():
 {
   "date_": {
     "error_msg": "Invalid date format",
-    "error_type": "ValueError",
-    "track": "date"
+    "error_type": "ValueError"
   },
   "dt": {
     "error_msg": "month must be in 1..12",
-    "error_type": "ValueError",
-    "track": "datetime"
+    "error_type": "ValueError"
   },
   "duration": {
     "error_msg": "Invalid duration format",
-    "error_type": "ValueError",
-    "track": "timedelta"
+    "error_type": "ValueError"
   },
   "time_": {
     "error_msg": "hour must be in 0..23",
-    "error_type": "ValueError",
-    "track": "time"
+    "error_type": "ValueError"
   }
 }""" == exc_info.value.json(2)
 
@@ -307,8 +302,7 @@ def test_enum_fails():
 {
   "tool": {
     "error_msg": "3 is not a valid ToolEnum",
-    "error_type": "ValueError",
-    "track": "ToolEnum"
+    "error_type": "ValueError"
   }
 }""" == exc_info.value.json(2)
 
@@ -363,23 +357,19 @@ def test_string_fails():
 {
   "name_email": {
     "error_msg": "The email address contains invalid characters before the @-sign:  .",
-    "error_type": "EmailSyntaxError",
-    "track": "NameEmail"
+    "error_type": "EmailSyntaxError"
   },
   "str_email": {
     "error_msg": "The email address contains invalid characters before the @-sign: <.",
-    "error_type": "EmailSyntaxError",
-    "track": "EmailStr"
+    "error_type": "EmailSyntaxError"
   },
   "str_min_length": {
     "error_msg": "length less than minimum allowed: 5",
-    "error_type": "ValueError",
-    "track": "ConstrainedStrValue"
+    "error_type": "ValueError"
   },
   "str_regex": {
     "error_msg": "string does not match regex \\"^xxx\\\\d{3}$\\"",
-    "error_type": "ValueError",
-    "track": "ConstrainedStrValue"
+    "error_type": "ValueError"
   }
 }""" == exc_info.value.json(2)
 
@@ -504,7 +494,7 @@ def test_uuid_error():
     assert """\
 error validating input
 v:
-  badly formed hexadecimal UUID string (error_type=ValueError track=UUID)""" == str(exc_info.value)
+  badly formed hexadecimal UUID string (error_type=ValueError)""" == str(exc_info.value)
 
     with pytest.raises(ValidationError):
         Model(v=None)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,7 +39,7 @@ def test_constrained_str_too_long():
 {
   "v": {
     "error_msg": "length greater than maximum allowed: 10",
-    "error_type": "ValueError"
+    "type": "value_error"
   }
 }""" == exc_info.value.json(2)
 
@@ -190,13 +190,13 @@ class StrModel(BaseModel):
 def test_string_too_long():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x' * 150)
-    assert 'length greater than maximum allowed: 10 (error_type=ValueError)' in exc_info.value.display_errors
+    assert 'length greater than maximum allowed: 10 (type=value_error)' in exc_info.value.display_errors
 
 
 def test_string_too_short():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x')
-    assert 'length less than minimum allowed: 5 (error_type=ValueError)' in exc_info.value.display_errors
+    assert 'length less than minimum allowed: 5 (type=value_error)' in exc_info.value.display_errors
 
 
 class NumberModel(BaseModel):
@@ -211,15 +211,15 @@ class NumberModel(BaseModel):
 def test_number_too_big():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=50, float_check=150)
-    assert 'size greater than maximum allowed: 10 (error_type=ValueError)' in exc_info.value.display_errors
-    assert 'size greater than maximum allowed: 10 (error_type=ValueError)' in exc_info.value.display_errors
+    assert 'size greater than maximum allowed: 10 (type=value_error)' in exc_info.value.display_errors
+    assert 'size greater than maximum allowed: 10 (type=value_error)' in exc_info.value.display_errors
 
 
 def test_number_too_small():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=1, float_check=2.5)
-    assert 'size less than minimum allowed: 5 (error_type=ValueError)' in exc_info.value.display_errors
-    assert 'size less than minimum allowed: 5 (error_type=ValueError)' in exc_info.value.display_errors
+    assert 'size less than minimum allowed: 5 (type=value_error)' in exc_info.value.display_errors
+    assert 'size less than minimum allowed: 5 (type=value_error)' in exc_info.value.display_errors
 
 
 class DatetimeModel(BaseModel):
@@ -255,19 +255,19 @@ def test_datetime_errors():
 {
   "date_": {
     "error_msg": "Invalid date format",
-    "error_type": "ValueError"
+    "type": "value_error"
   },
   "dt": {
     "error_msg": "month must be in 1..12",
-    "error_type": "ValueError"
+    "type": "value_error"
   },
   "duration": {
     "error_msg": "Invalid duration format",
-    "error_type": "ValueError"
+    "type": "value_error"
   },
   "time_": {
     "error_msg": "hour must be in 0..23",
-    "error_type": "ValueError"
+    "type": "value_error"
   }
 }""" == exc_info.value.json(2)
 
@@ -302,7 +302,7 @@ def test_enum_fails():
 {
   "tool": {
     "error_msg": "3 is not a valid ToolEnum",
-    "error_type": "ValueError"
+    "type": "value_error"
   }
 }""" == exc_info.value.json(2)
 
@@ -357,19 +357,19 @@ def test_string_fails():
 {
   "name_email": {
     "error_msg": "The email address contains invalid characters before the @-sign:  .",
-    "error_type": "EmailSyntaxError"
+    "type": "value_error.email_not_valid_error.email_syntax_error"
   },
   "str_email": {
     "error_msg": "The email address contains invalid characters before the @-sign: <.",
-    "error_type": "EmailSyntaxError"
+    "type": "value_error.email_not_valid_error.email_syntax_error"
   },
   "str_min_length": {
     "error_msg": "length less than minimum allowed: 5",
-    "error_type": "ValueError"
+    "type": "value_error"
   },
   "str_regex": {
     "error_msg": "string does not match regex \\"^xxx\\\\d{3}$\\"",
-    "error_type": "ValueError"
+    "type": "value_error"
   }
 }""" == exc_info.value.json(2)
 
@@ -494,7 +494,7 @@ def test_uuid_error():
     assert """\
 error validating input
 v:
-  badly formed hexadecimal UUID string (error_type=ValueError)""" == str(exc_info.value)
+  badly formed hexadecimal UUID string (type=value_error)""" == str(exc_info.value)
 
     with pytest.raises(ValidationError):
         Model(v=None)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -38,7 +38,7 @@ def test_constrained_str_too_long():
     assert """\
 {
   "v": {
-    "error_msg": "length greater than maximum allowed: 10",
+    "msg": "length greater than maximum allowed: 10",
     "type": "value_error"
   }
 }""" == exc_info.value.json(2)
@@ -254,19 +254,19 @@ def test_datetime_errors():
     assert """\
 {
   "date_": {
-    "error_msg": "Invalid date format",
+    "msg": "Invalid date format",
     "type": "value_error"
   },
   "dt": {
-    "error_msg": "month must be in 1..12",
+    "msg": "month must be in 1..12",
     "type": "value_error"
   },
   "duration": {
-    "error_msg": "Invalid duration format",
+    "msg": "Invalid duration format",
     "type": "value_error"
   },
   "time_": {
-    "error_msg": "hour must be in 0..23",
+    "msg": "hour must be in 0..23",
     "type": "value_error"
   }
 }""" == exc_info.value.json(2)
@@ -301,7 +301,7 @@ def test_enum_fails():
     assert """\
 {
   "tool": {
-    "error_msg": "3 is not a valid ToolEnum",
+    "msg": "3 is not a valid ToolEnum",
     "type": "value_error"
   }
 }""" == exc_info.value.json(2)
@@ -356,19 +356,19 @@ def test_string_fails():
     assert """\
 {
   "name_email": {
-    "error_msg": "The email address contains invalid characters before the @-sign:  .",
+    "msg": "The email address contains invalid characters before the @-sign:  .",
     "type": "value_error.email_not_valid_error.email_syntax_error"
   },
   "str_email": {
-    "error_msg": "The email address contains invalid characters before the @-sign: <.",
+    "msg": "The email address contains invalid characters before the @-sign: <.",
     "type": "value_error.email_not_valid_error.email_syntax_error"
   },
   "str_min_length": {
-    "error_msg": "length less than minimum allowed: 5",
+    "msg": "length less than minimum allowed: 5",
     "type": "value_error"
   },
   "str_regex": {
-    "error_msg": "string does not match regex \\"^xxx\\\\d{3}$\\"",
+    "msg": "string does not match regex \\"^xxx\\\\d{3}$\\"",
     "type": "value_error"
   }
 }""" == exc_info.value.json(2)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -35,7 +35,7 @@ def test_constrained_str_default():
 def test_constrained_str_too_long():
     with pytest.raises(ValidationError) as exc_info:
         ConStringModel(v='this is too long')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('v',),
             'msg': 'length greater than maximum allowed: 10',
@@ -73,7 +73,7 @@ def test_dsn_pw_host():
 def test_dsn_no_driver():
     with pytest.raises(ValidationError) as exc_info:
         DsnModel(db_driver=None)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('db_driver',),
             'msg': 'None is not an allow value',
@@ -96,7 +96,7 @@ def test_module_import():
     assert m.module == os.path
     with pytest.raises(ValidationError) as exc_info:
         PyObjectModel(module='foobar')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('module',),
             'msg': '"foobar" doesn\'t look like a module path',
@@ -207,7 +207,7 @@ class StrModel(BaseModel):
 def test_string_too_long():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x' * 150)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('str_check',),
             'msg': 'length greater than maximum allowed: 10',
@@ -219,7 +219,7 @@ def test_string_too_long():
 def test_string_too_short():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('str_check',),
             'msg': 'length less than minimum allowed: 5',
@@ -240,7 +240,7 @@ class NumberModel(BaseModel):
 def test_number_too_big():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=50, float_check=150)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('int_check',),
             'msg': 'size greater than maximum allowed: 10',
@@ -257,7 +257,7 @@ def test_number_too_big():
 def test_number_too_small():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=1, float_check=2.5)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('int_check',),
             'msg': 'size less than minimum allowed: 5',
@@ -299,7 +299,7 @@ def test_datetime_errors():
             time_='25:20:30.400',
             duration='15:30.0001 broken',
         )
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('dt',),
             'msg': 'month must be in 1..12',
@@ -348,7 +348,7 @@ def test_enum_successful():
 def test_enum_fails():
     with pytest.raises(ValueError) as exc_info:
         CookingModel(tool=3)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('tool',),
             'msg': '3 is not a valid ToolEnum',
@@ -402,7 +402,7 @@ def test_string_fails():
             str_email='foobar<@example.com',
             name_email='foobar @example.com',
         )
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('str_regex',),
             'msg': 'string does not match regex "^xxx\\d{3}$"',
@@ -453,7 +453,7 @@ def test_dict():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(a=[1, 2, 3])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'value is not a valid dict, got list',
@@ -471,7 +471,7 @@ def test_list():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(b=1)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('b',),
             'msg': '\'int\' object is not iterable',
@@ -487,7 +487,7 @@ def test_ordered_dict():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(c=[1, 2, 3])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('c',),
             'msg': '\'int\' object is not iterable',
@@ -506,7 +506,7 @@ def test_tuple():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(d=1)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('d',),
             'msg': '\'int\' object is not iterable',
@@ -527,7 +527,7 @@ def test_int_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         IntModel(a=-5, b=5, c=-5)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'size less than minimum allowed: 0',
@@ -558,7 +558,7 @@ def test_float_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         FloatModel(a=-5.1, b=5.2, c=-5.3)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'size less than minimum allowed: 0',
@@ -606,7 +606,7 @@ def test_uuid_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v='ebcdab58-6eb8-46fb-a190-d07a3')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('v',),
             'msg': 'badly formed hexadecimal UUID string',
@@ -641,7 +641,7 @@ def test_uuid_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         UUIDModel(a=d, b=c, c=b, d=a)
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'uuid version 1 expected, not 5',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,7 +37,7 @@ def test_constrained_str_too_long():
         ConStringModel(v='this is too long')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': 'length greater than maximum allowed: 10',
             'type': 'value_error',
         },
@@ -75,12 +75,12 @@ def test_dsn_no_driver():
         DsnModel(db_driver=None)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'db_driver',
+            'loc': ('db_driver',),
             'msg': 'None is not an allow value',
             'type': 'type_error',
         },
         {
-            'loc': 'dsn',
+            'loc': ('dsn',),
             'msg': '"db_driver" field may not be missing or None',
             'type': 'value_error',
         },
@@ -98,7 +98,7 @@ def test_module_import():
         PyObjectModel(module='foobar')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'module',
+            'loc': ('module',),
             'msg': '"foobar" doesn\'t look like a module path',
             'type': 'value_error',
         },
@@ -209,7 +209,7 @@ def test_string_too_long():
         StrModel(str_check='x' * 150)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'str_check',
+            'loc': ('str_check',),
             'msg': 'length greater than maximum allowed: 10',
             'type': 'value_error',
         },
@@ -221,7 +221,7 @@ def test_string_too_short():
         StrModel(str_check='x')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'str_check',
+            'loc': ('str_check',),
             'msg': 'length less than minimum allowed: 5',
             'type': 'value_error',
         },
@@ -242,12 +242,12 @@ def test_number_too_big():
         NumberModel(int_check=50, float_check=150)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'int_check',
+            'loc': ('int_check',),
             'msg': 'size greater than maximum allowed: 10',
             'type': 'value_error',
         },
         {
-            'loc': 'float_check',
+            'loc': ('float_check',),
             'msg': 'size greater than maximum allowed: 10',
             'type': 'value_error',
         },
@@ -259,12 +259,12 @@ def test_number_too_small():
         NumberModel(int_check=1, float_check=2.5)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'int_check',
+            'loc': ('int_check',),
             'msg': 'size less than minimum allowed: 5',
             'type': 'value_error',
         },
         {
-            'loc': 'float_check',
+            'loc': ('float_check',),
             'msg': 'size less than minimum allowed: 5',
             'type': 'value_error',
         },
@@ -301,22 +301,22 @@ def test_datetime_errors():
         )
     assert exc_info.value.flat_errors == [
         {
-            'loc': "dt",
+            'loc': ('dt',),
             'msg': 'month must be in 1..12',
             'type': 'value_error',
         },
         {
-            'loc': 'date_',
+            'loc': ('date_',),
             'msg': 'Invalid date format',
             'type': 'value_error',
         },
         {
-            'loc': 'time_',
+            'loc': ('time_',),
             'msg': 'hour must be in 0..23',
             'type': 'value_error',
         },
         {
-            'loc': 'duration',
+            'loc': ('duration',),
             'msg': 'Invalid duration format',
             'type': 'value_error',
         },
@@ -350,7 +350,7 @@ def test_enum_fails():
         CookingModel(tool=3)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'tool',
+            'loc': ('tool',),
             'msg': '3 is not a valid ToolEnum',
             'type': 'value_error',
         }
@@ -404,22 +404,22 @@ def test_string_fails():
         )
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'str_regex',
+            'loc': ('str_regex',),
             'msg': 'string does not match regex "^xxx\\d{3}$"',
             'type': 'value_error',
         },
         {
-            'loc': 'str_min_length',
+            'loc': ('str_min_length',),
             'msg': 'length less than minimum allowed: 5',
             'type': 'value_error',
         },
         {
-            'loc': 'str_email',
+            'loc': ('str_email',),
             'msg': 'The email address contains invalid characters before the @-sign: <.',
             'type': 'value_error.email_not_valid_error.email_syntax_error',
         },
         {
-            'loc': 'name_email',
+            'loc': ('name_email',),
             'msg': 'The email address contains invalid characters before the @-sign:  .',
             'type': 'value_error.email_not_valid_error.email_syntax_error',
         },
@@ -455,7 +455,7 @@ def test_dict():
         ListDictTupleModel(a=[1, 2, 3])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'value is not a valid dict, got list',
             'type': 'type_error',
         },
@@ -473,7 +473,7 @@ def test_list():
         ListDictTupleModel(b=1)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': '\'int\' object is not iterable',
             'type': 'type_error',
         },
@@ -489,7 +489,7 @@ def test_ordered_dict():
         ListDictTupleModel(c=[1, 2, 3])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'c',
+            'loc': ('c',),
             'msg': '\'int\' object is not iterable',
             'type': 'type_error',
         },
@@ -508,7 +508,7 @@ def test_tuple():
         ListDictTupleModel(d=1)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'd',
+            'loc': ('d',),
             'msg': '\'int\' object is not iterable',
             'type': 'type_error',
         },
@@ -529,17 +529,17 @@ def test_int_validation():
         IntModel(a=-5, b=5, c=-5)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'size less than minimum allowed: 0',
             'type': 'value_error',
         },
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'size greater than maximum allowed: 0',
             'type': 'value_error',
         },
         {
-            'loc': 'c',
+            'loc': ('c',),
             'msg': 'size less than minimum allowed: 4',
             'type': 'value_error',
         },
@@ -560,17 +560,17 @@ def test_float_validation():
         FloatModel(a=-5.1, b=5.2, c=-5.3)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'size less than minimum allowed: 0',
             'type': 'value_error',
         },
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'size greater than maximum allowed: 0',
             'type': 'value_error',
         },
         {
-            'loc': 'c',
+            'loc': ('c',),
             'msg': 'size less than minimum allowed: 4',
             'type': 'value_error',
         },
@@ -608,7 +608,7 @@ def test_uuid_error():
         Model(v='ebcdab58-6eb8-46fb-a190-d07a3')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'v',
+            'loc': ('v',),
             'msg': 'badly formed hexadecimal UUID string',
             'type': 'value_error',
         },
@@ -643,22 +643,22 @@ def test_uuid_validation():
         UUIDModel(a=d, b=c, c=b, d=a)
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'uuid version 1 expected, not 5',
             'type': 'value_error',
         },
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'uuid version 3 expected, not 4',
             'type': 'value_error',
         },
         {
-            'loc': 'c',
+            'loc': ('c',),
             'msg': 'uuid version 4 expected, not 3',
             'type': 'value_error',
         },
         {
-            'loc': 'd',
+            'loc': ('d',),
             'msg': 'uuid version 5 expected, not 1',
             'type': 'value_error',
         },

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -35,7 +35,7 @@ def test_constrained_str_default():
 def test_constrained_str_too_long():
     with pytest.raises(ValidationError) as exc_info:
         ConStringModel(v='this is too long')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v',
             'msg': 'length greater than maximum allowed: 10',
@@ -73,7 +73,7 @@ def test_dsn_pw_host():
 def test_dsn_no_driver():
     with pytest.raises(ValidationError) as exc_info:
         DsnModel(db_driver=None)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'db_driver',
             'msg': 'None is not an allow value',
@@ -96,7 +96,7 @@ def test_module_import():
     assert m.module == os.path
     with pytest.raises(ValidationError) as exc_info:
         PyObjectModel(module='foobar')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'module',
             'msg': '"foobar" doesn\'t look like a module path',
@@ -207,7 +207,7 @@ class StrModel(BaseModel):
 def test_string_too_long():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x' * 150)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'str_check',
             'msg': 'length greater than maximum allowed: 10',
@@ -219,7 +219,7 @@ def test_string_too_long():
 def test_string_too_short():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'str_check',
             'msg': 'length less than minimum allowed: 5',
@@ -240,7 +240,7 @@ class NumberModel(BaseModel):
 def test_number_too_big():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=50, float_check=150)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'int_check',
             'msg': 'size greater than maximum allowed: 10',
@@ -257,7 +257,7 @@ def test_number_too_big():
 def test_number_too_small():
     with pytest.raises(ValidationError) as exc_info:
         NumberModel(int_check=1, float_check=2.5)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'int_check',
             'msg': 'size less than minimum allowed: 5',
@@ -299,7 +299,7 @@ def test_datetime_errors():
             time_='25:20:30.400',
             duration='15:30.0001 broken',
         )
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': "dt",
             'msg': 'month must be in 1..12',
@@ -348,7 +348,7 @@ def test_enum_successful():
 def test_enum_fails():
     with pytest.raises(ValueError) as exc_info:
         CookingModel(tool=3)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'tool',
             'msg': '3 is not a valid ToolEnum',
@@ -402,7 +402,7 @@ def test_string_fails():
             str_email='foobar<@example.com',
             name_email='foobar @example.com',
         )
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'str_regex',
             'msg': 'string does not match regex "^xxx\\d{3}$"',
@@ -453,7 +453,7 @@ def test_dict():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(a=[1, 2, 3])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'value is not a valid dict, got list',
@@ -471,7 +471,7 @@ def test_list():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(b=1)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'b',
             'msg': '\'int\' object is not iterable',
@@ -487,7 +487,7 @@ def test_ordered_dict():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(c=[1, 2, 3])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'c',
             'msg': '\'int\' object is not iterable',
@@ -506,7 +506,7 @@ def test_tuple():
 
     with pytest.raises(ValidationError) as exc_info:
         ListDictTupleModel(d=1)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'd',
             'msg': '\'int\' object is not iterable',
@@ -527,7 +527,7 @@ def test_int_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         IntModel(a=-5, b=5, c=-5)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'size less than minimum allowed: 0',
@@ -558,7 +558,7 @@ def test_float_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         FloatModel(a=-5.1, b=5.2, c=-5.3)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'size less than minimum allowed: 0',
@@ -606,7 +606,7 @@ def test_uuid_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v='ebcdab58-6eb8-46fb-a190-d07a3')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'v',
             'msg': 'badly formed hexadecimal UUID string',
@@ -641,7 +641,7 @@ def test_uuid_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         UUIDModel(a=d, b=c, c=b, d=a)
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'uuid version 1 expected, not 5',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
 import os
+from typing import Union
 
 import pytest
 
-from pydantic.utils import import_string, make_dsn, validate_email
+from pydantic.utils import display_as_type, import_string, make_dsn, to_snake_case, validate_email
 
 try:
     import email_validator
@@ -92,3 +93,25 @@ def test_import_no_attr():
     with pytest.raises(ImportError) as exc_info:
         import_string('os.foobar')
     assert exc_info.value.args[0] == 'Module "os" does not define a "foobar" attribute'
+
+
+@pytest.mark.parametrize('value,expected', (
+    (str, 'str'),
+    ('string', 'str'),
+    (Union[str, int], 'typing.Union[str, int]'),
+))
+def test_display_as_type(value, expected):
+    assert display_as_type(value) == expected
+
+
+@pytest.mark.parametrize('value,expected', (
+    ('Foo', 'foo'),
+    ('FooBar', 'foo_bar'),
+    ('Foo42Bar', 'foo42_bar'),
+    ('FOOBar', 'foo_bar'),
+    ('FOOBarFoo', 'foo_bar_foo'),
+    ('FooBAR', 'foo_bar'),
+    ('FOO', 'foo'),
+))
+def test_to_snake_case(value, expected):
+    assert to_snake_case(value) == expected

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -120,7 +120,7 @@ def test_validating_assignment_dict():
     assert """\
 error validating input
 a:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'x' (type=value_error)""" == str(exc_info.value)
 
 
 def test_validate_multiple():
@@ -141,9 +141,9 @@ def test_validate_multiple():
     assert """\
 2 errors validating input
 a:
-  a is too short (error_type=TypeError)
+  a is too short (type=type_error)
 b:
-  b is too short (error_type=TypeError)""" == str(exc_info.value)
+  b is too short (type=type_error)""" == str(exc_info.value)
 
 
 def test_classmethod():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -120,7 +120,7 @@ def test_validating_assignment_dict():
     assert """\
 error validating input
 a:
-  invalid literal for int() with base 10: 'x' (error_type=ValueError track=int)""" == str(exc_info.value)
+  invalid literal for int() with base 10: 'x' (error_type=ValueError)""" == str(exc_info.value)
 
 
 def test_validate_multiple():
@@ -141,9 +141,9 @@ def test_validate_multiple():
     assert """\
 2 errors validating input
 a:
-  a is too short (error_type=TypeError track=str)
+  a is too short (error_type=TypeError)
 b:
-  b is too short (error_type=TypeError track=str)""" == str(exc_info.value)
+  b is too short (error_type=TypeError)""" == str(exc_info.value)
 
 
 def test_classmethod():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -19,7 +19,7 @@ def test_simple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': '"foobar" not found in a',
@@ -84,7 +84,7 @@ def test_validate_whole_error():
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[1, 3])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'a1 broken',
@@ -96,7 +96,7 @@ def test_validate_whole_error():
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[5, 10])
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'a2 broken',
@@ -137,7 +137,7 @@ def test_validating_assignment_fail():
 def test_validating_assignment_dict():
     with pytest.raises(ValidationError) as exc_info:
         ValidateAssignmentModel(a='x', b='xx')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'invalid literal for int() with base 10: \'x\'',
@@ -162,7 +162,7 @@ def test_validate_multiple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='x', b='x')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': 'a is too short',
@@ -305,7 +305,7 @@ def test_wildcard_validator_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.flat_errors == [
+    assert exc_info.value.flatten_errors() == [
         {
             'loc': ('a',),
             'msg': '"foobar" not found in a',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -16,9 +16,16 @@ def test_simple():
             return v
 
     assert Model(a='this is foobar good').a == 'this is foobar good'
+
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert '"foobar" not found in a' in str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': '"foobar" not found in a',
+            'type': 'value_error',
+        },
+    ]
 
 
 def test_validate_whole():
@@ -73,16 +80,29 @@ def test_validate_whole_error():
 
     assert Model(a=[3, 8]).a == [4, 8]
     assert calls == ['check_a1 [3, 8]', 'check_a2 [4, 8]']
+
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[1, 3])
-    assert 'a1 broken' in str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'a1 broken',
+            'type': 'value_error',
+        },
+    ]
     assert calls == ['check_a1 [1, 3]']
 
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[5, 10])
-    assert 'a2 broken' in str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'a2 broken',
+            'type': 'value_error',
+        },
+    ]
     assert calls == ['check_a1 [5, 10]', 'check_a2 [6, 10]']
 
 
@@ -117,10 +137,13 @@ def test_validating_assignment_fail():
 def test_validating_assignment_dict():
     with pytest.raises(ValidationError) as exc_info:
         ValidateAssignmentModel(a='x', b='xx')
-    assert """\
-error validating input
-a:
-  invalid literal for int() with base 10: 'x' (type=value_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'invalid literal for int() with base 10: \'x\'',
+            'type': 'value_error',
+        },
+    ]
 
 
 def test_validate_multiple():
@@ -136,14 +159,21 @@ def test_validate_multiple():
             return v + 'x'
 
     assert Model(a='1234', b='5678').dict() == {'a': '1234x', 'b': '5678x'}
+
     with pytest.raises(ValidationError) as exc_info:
         Model(a='x', b='x')
-    assert """\
-2 errors validating input
-a:
-  a is too short (type=type_error)
-b:
-  b is too short (type=type_error)""" == str(exc_info.value)
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': 'a is too short',
+            'type': 'type_error',
+        },
+        {
+            'loc': 'b',
+            'msg': 'b is too short',
+            'type': 'type_error',
+        },
+    ]
 
 
 def test_classmethod():
@@ -275,8 +305,18 @@ def test_wildcard_validator_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert '"foobar" not found in a' in str(exc_info.value)
-    assert len(exc_info.value.errors_dict) == 2
+    assert exc_info.value.flatten_errors == [
+        {
+            'loc': 'a',
+            'msg': '"foobar" not found in a',
+            'type': 'value_error',
+        },
+        {
+            'loc': 'b',
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        },
+    ]
 
 
 def test_invalid_field():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -21,7 +21,7 @@ def test_simple():
         Model(a='snap')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': '"foobar" not found in a',
             'type': 'value_error',
         },
@@ -86,7 +86,7 @@ def test_validate_whole_error():
         Model(a=[1, 3])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'a1 broken',
             'type': 'value_error',
         },
@@ -98,7 +98,7 @@ def test_validate_whole_error():
         Model(a=[5, 10])
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'a2 broken',
             'type': 'value_error',
         },
@@ -139,7 +139,7 @@ def test_validating_assignment_dict():
         ValidateAssignmentModel(a='x', b='xx')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'invalid literal for int() with base 10: \'x\'',
             'type': 'value_error',
         },
@@ -164,12 +164,12 @@ def test_validate_multiple():
         Model(a='x', b='x')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': 'a is too short',
             'type': 'type_error',
         },
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'b is too short',
             'type': 'type_error',
         },
@@ -307,12 +307,12 @@ def test_wildcard_validator_error():
         Model(a='snap')
     assert exc_info.value.flat_errors == [
         {
-            'loc': 'a',
+            'loc': ('a',),
             'msg': '"foobar" not found in a',
             'type': 'value_error',
         },
         {
-            'loc': 'b',
+            'loc': ('b',),
             'msg': 'field required',
             'type': 'value_error.missing',
         },

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -19,7 +19,7 @@ def test_simple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': '"foobar" not found in a',
@@ -84,7 +84,7 @@ def test_validate_whole_error():
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[1, 3])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'a1 broken',
@@ -96,7 +96,7 @@ def test_validate_whole_error():
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[5, 10])
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'a2 broken',
@@ -137,7 +137,7 @@ def test_validating_assignment_fail():
 def test_validating_assignment_dict():
     with pytest.raises(ValidationError) as exc_info:
         ValidateAssignmentModel(a='x', b='xx')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'invalid literal for int() with base 10: \'x\'',
@@ -162,7 +162,7 @@ def test_validate_multiple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='x', b='x')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': 'a is too short',
@@ -305,7 +305,7 @@ def test_wildcard_validator_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.flatten_errors == [
+    assert exc_info.value.flat_errors == [
         {
             'loc': 'a',
             'msg': '"foobar" not found in a',


### PR DESCRIPTION
Hi!

This is my first try to improve errors format (discussion can be found in #162). I'd like to get review on changes and discuss some points.

At first here are simple example which will be used to show new errors format:

```py
from typing import Dict, List, Union
from uuid import UUID

from pydantic import BaseModel, ValidationError


class TestDict(BaseModel):
    x: int
    y: int
    z: str


class TestModel(BaseModel):
    a: List[TestDict]
    b: int
    c: TestDict
    d: Union[int, UUID]
    e: Dict[int, int]
    f: List[Union[int, UUID]]


try:
    TestModel.parse_obj({
        'a': [
            {
                'x': 'not_int',
                'y': 42,
                'z': 'string',
            },
        ],
        'b': 'string',
        'c': {
            'y': 42,
        },
        'd': 'string',
        'e': {
            'foo': 'bar',
        },
        'f': [
            'string',
        ],
    })
except ValidationError as e:
    print(e.json())
```

And errors output:
```py
[
  {
    "loc": "a.0.x",
    "msg": "invalid literal for int() with base 10: 'not_int'",
    "type": "value_error"
  },
  {
    "loc": "b",
    "msg": "invalid literal for int() with base 10: 'string'",
    "type": "value_error"
  },
  {
    "loc": "c.x",
    "msg": "field required",
    "type": "value_error.missing"
  },
  {
    "loc": "c.z",
    "msg": "field required",
    "type": "value_error.missing"
  },
  {
    "loc": "d",
    "msg": "invalid literal for int() with base 10: 'string'",
    "type": "value_error"
  },
  {
    "loc": "d",
    "msg": "badly formed hexadecimal UUID string",
    "type": "value_error"
  },
  {
    "loc": "e.key",
    "msg": "invalid literal for int() with base 10: 'foo'",
    "type": "value_error"
  },
  {
    "loc": "f.0",
    "msg": "invalid literal for int() with base 10: 'string'",
    "type": "value_error"
  },
  {
    "loc": "f.0",
    "msg": "badly formed hexadecimal UUID string",
    "type": "value_error"
  }
]
```

Questions:
1. Is this format good to go (`msg` kept for backward compatibility and can be removed, `context` can be easily added)?
2. As you can see we are using `key` postfix if error occurred in dictionary key, is it okay?
3. As you can see there are two errors for field `d` (and `f.0`) because they are complex and contains sub fields, I think we need to expose this information in `loc`, maybe by using postfix, something like `d.sub.0` and `d.sub.1`. Any ideas?
4. Big question how to display errors in plain text? For now it's very simple:
```
a.0.x
  invalid literal for int() with base 10: 'not_int' (type=value_error)
b
  invalid literal for int() with base 10: 'string' (type=value_error)
c.x
  field required (type=value_error.missing)
c.z
  field required (type=value_error.missing)
d
  invalid literal for int() with base 10: 'string' (type=value_error)
d
  badly formed hexadecimal UUID string (type=value_error)
e.key
  invalid literal for int() with base 10: 'foo' (type=value_error)
f.0
  invalid literal for int() with base 10: 'string' (type=value_error)
f.0
  badly formed hexadecimal UUID string (type=value_error)
```

TODO:
- [x] Discuss all questions
- [x] Write tests for `exceptions.py` module
- [x] Write tests for new functions in `utils.py` module