### PR TITLE
improve docs on error handling

### DIFF
--- a/docs/examples/config.py
+++ b/docs/examples/config.py
@@ -16,7 +16,7 @@ try:
 except ValidationError as e:
     print(e)
 """
-validation errors
+1 validation error
 v
   max_length:10 (type=value_error.any_str.max_length; limit_value=10)
 """

--- a/docs/examples/errors1.py
+++ b/docs/examples/errors1.py
@@ -24,7 +24,7 @@ try:
 except ValidationError as e:
     print(e)
 """
-validation errors
+5 validation errors
 list_of_ints -> 2
   value is not a valid integer (type=type_error.integer)
 a_float

--- a/docs/examples/errors2.py
+++ b/docs/examples/errors2.py
@@ -1,16 +1,14 @@
 from pydantic import BaseModel, ValidationError, validator
 
-
 class Model(BaseModel):
     foo: str
 
     @validator('foo')
     def name_must_contain_space(cls, v):
         if v != 'bar':
-            raise ValueError('value must be a "bar"')
+            raise ValueError('value must be "bar"')
 
         return v
-
 
 try:
     Model(foo='ber')
@@ -19,10 +17,8 @@ except ValidationError as e:
 """
 [
   {
-    "loc": [
-      "foo"
-    ],
-    "msg": "value must be a \"bar\"",
+    "loc": ["foo"],
+    "msg": "value must be \"bar\"",
     "type": "value_error"
   }
 ]

--- a/docs/examples/errors3.py
+++ b/docs/examples/errors3.py
@@ -1,13 +1,8 @@
 from pydantic import BaseModel, PydanticValueError, ValidationError, validator
 
-
 class NotABarError(PydanticValueError):
     code = 'not_a_bar'
-    msg_template = 'value is not a "bar", got "{wrong_value}"'
-
-    def __init__(self, *, wrong_value: int) -> None:
-        super().__init__(wrong_value=wrong_value)
-
+    msg_template = 'value is not "bar", got "{wrong_value}"'
 
 class Model(BaseModel):
     foo: str
@@ -16,9 +11,7 @@ class Model(BaseModel):
     def name_must_contain_space(cls, v):
         if v != 'bar':
             raise NotABarError(wrong_value=v)
-
         return v
-
 
 try:
     Model(foo='ber')
@@ -27,14 +20,12 @@ except ValidationError as e:
 """
 [
   {
+    "loc": ["foo"],
+    "msg": "value is not \"bar\", got \"ber\"",
+    "type": "value_error.not_a_bar",
     "ctx": {
       "wrong_value": "ber"
-    },
-    "loc": [
-      "foo"
-    ],
-    "msg": "value is not a \"bar\", got \"ber\"",
-    "type": "value_error.not_a_bar"
+    }
   }
 ]
 """

--- a/docs/examples/validators_pre_whole.py
+++ b/docs/examples/validators_pre_whole.py
@@ -38,7 +38,7 @@ try:
 except ValidationError as e:
     print(e)
 """
-validation errors
+1 validation error
 numbers -> 2
   number to large 5 > 4 (type=value_error)
 """
@@ -48,7 +48,7 @@ try:
 except ValidationError as e:
     print(e)
 """
-validation errors
+1 validation error
 numbers
   sum of numbers greater than 8 (type=value_error)
 """

--- a/docs/examples/validators_simple.py
+++ b/docs/examples/validators_simple.py
@@ -27,7 +27,7 @@ try:
 except ValidationError as e:
     print(e)
 """
-validation errors
+2 validation errors
 name
   must contain a space (type=value_error)
 password2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -210,10 +210,9 @@ contain information about all the errors and how they happened.
 
 You can access these errors in a several ways:
 
-:flatten_errors: method will return list of errors found in the input data.
-:display_errors: property will give a string representation of ``flatten_errors``
-   (this is by used the ``__str__`` method of ``ValidationError``).
-:json: method will return a JSON representation of ``flatten_errors`` method.
+:errors: method will return list of errors found in the input data.
+:json: method will return a JSON representation of ``errors``.
+:__str__: method will return a human readable representation of the errors.
 
 Each error object contains:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,7 @@ On class creation validators are checked to confirm that the fields they specify
 Occasionally however this is not wanted: when you define a validator to validate fields on inheriting models.
 In this case you should set ``check_fields=False`` on the validator.
 
+.. _recursive_models:
 
 Recursive Models
 ................
@@ -197,24 +198,40 @@ The ellipsis ``...`` just means "Required" same as annotation only declarations 
 Error Handling
 ..............
 
-*Pydantic* comes with ``ValidationError`` which should be used to catch any validation error. You can access errors in a several ways:
+*Pydantic* will raise ``ValidationError`` whenever it finds an error in the data it's validating.
 
-:display_errors: property will return to you a string representation of validation errors.
-:flatten_errors: method will return list of errors for each field.
-:json: same as ``flatten_errors`` method, but list of errors will be serialized as JSON.
+.. note::
+
+   Validation code should not raise ``ValidationError`` itself, but rather raise ``ValueError`` or ``TypeError``
+   (or subclasses thereof) which will be caught and used to populate ``ValidationError``.
+
+One exception will be raised regardless of the number of errors found, that ``ValidationError`` will
+contain information about all the errors and how they happened.
+
+You can access these errors in a several ways:
+
+:flatten_errors: method will return list of errors found in the input data.
+:display_errors: property will give a string representation of ``flatten_errors``
+   (this is by used the ``__str__`` method of ``ValidationError``).
+:json: method will return a JSON representation of ``flatten_errors`` method.
 
 Each error object contains:
 
-:loc: the error's location.
+:loc: the error's location as a list, the first item in the list will be the field where the error occurred,
+   subsequent items will represent the field where the error occurred
+   in :ref:`sub models <recursive_models>` when they're used.
 :type: a unique identifier of the error readable by a computer.
 :msg: a human readable explanation of the error.
 :ctx: an optional object which contains values required to render the error message.
 
+To demonstrate that:
+
 .. literalinclude:: examples/errors1.py
 
-(This script is complete, it should run "as is")
+(This script is complete, it should run "as is". ``json()`` has ``indent=2`` set by default, but I've tweaked the
+JSON here and below to make it slightly more concise.)
 
-In your custom data types or in validators you should use ``TypeError`` and ``ValueError`` to raise errors:
+In your custom data types or validators you should use ``TypeError`` and ``ValueError`` to raise errors:
 
 .. literalinclude:: examples/errors2.py
 

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -48,14 +48,14 @@ class ErrorWrapper:
 
 
 class ValidationError(ValueError):
-    __slots__ = '_raw_errors',
+    __slots__ = 'raw_errors',
 
     def __init__(self, errors):
-        self._raw_errors = errors
+        self.raw_errors = errors
 
     @lru_cache()
     def errors(self):
-        return list(flatten_errors(self._raw_errors))
+        return list(flatten_errors(self.raw_errors))
 
     def json(self, *, indent=2):
         return json.dumps(self.errors(), indent=indent)
@@ -92,7 +92,7 @@ def flatten_errors(errors, *, loc=None):
     for error in errors:
         if isinstance(error, ErrorWrapper):
             if isinstance(error.exc, ValidationError):
-                yield from flatten_errors(error.exc._raw_errors, loc=error.loc)
+                yield from flatten_errors(error.exc.raw_errors, loc=error.loc)
             else:
                 yield error.dict(loc_prefix=loc)
         elif isinstance(error, list):

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -48,26 +48,23 @@ class ErrorWrapper:
 
 
 class ValidationError(ValueError):
-    __slots__ = 'errors', 'message'
+    __slots__ = '_raw_errors',
 
     def __init__(self, errors):
-        self.errors = errors
-        self.message = 'validation errors'
+        self._raw_errors = errors
 
-        super().__init__(self.message)
-
-    @property
-    def display_errors(self):
-        return display_errors(self.flatten_errors())
-
-    def __str__(self):
-        return f'{self.message}\n{self.display_errors}'
-
-    def flatten_errors(self):
-        return list(flatten_errors(self.errors))
+    @lru_cache()
+    def errors(self):
+        return list(flatten_errors(self._raw_errors))
 
     def json(self, *, indent=2):
-        return json.dumps(self.flatten_errors(), indent=indent, sort_keys=True)
+        return json.dumps(self.errors(), indent=indent)
+
+    def __str__(self):
+        errors = self.errors()
+        no_errors = len(errors)
+        e_suffix = '' if no_errors == 1 else 's'
+        return f'{no_errors} validation error{e_suffix}\n{display_errors(errors)}'
 
 
 def display_errors(errors):
@@ -96,7 +93,7 @@ def flatten_errors(errors, *, loc=None):
     for error in errors:
         if isinstance(error, ErrorWrapper):
             if isinstance(error.exc, ValidationError):
-                yield from flatten_errors(error.exc.errors, loc=error.loc)
+                yield from flatten_errors(error.exc._raw_errors, loc=error.loc)
             else:
                 yield error.dict(loc_prefix=loc)
         elif isinstance(error, list):

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -78,14 +78,12 @@ def _display_error_loc(error):
 
 
 def _display_error_type_and_ctx(error):
-    display = f'type={error["type"]}'
-
+    t = 'type=' + error['type']
     ctx = error.get('ctx')
     if ctx:
-        ctx = '; '.join(f'{k}={v}' for k, v in ctx.items())
-        display = f'{display}; {ctx}'
-
-    return display
+        return t + ''.join(f'; {k}={v}' for k, v in ctx.items())
+    else:
+        return t
 
 
 def flatten_errors(errors, *, loc=None):

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -63,8 +63,7 @@ class ValidationError(ValueError):
     def __str__(self):
         errors = self.errors()
         no_errors = len(errors)
-        e_suffix = '' if no_errors == 1 else 's'
-        return f'{no_errors} validation error{e_suffix}\n{display_errors(errors)}'
+        return f'{no_errors} validation error{"" if no_errors == 1 else "s"}\n{display_errors(errors)}'
 
 
 def display_errors(errors):

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -28,7 +28,7 @@ def test_str_bytes():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'none is not an allow value',
@@ -84,7 +84,7 @@ def test_union_int_str():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid integer',
@@ -118,7 +118,7 @@ def test_typed_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 'x', 'y'])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v', 1),
             'msg': 'value is not a valid integer',
@@ -133,7 +133,7 @@ def test_typed_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=1)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid sequence',
@@ -151,7 +151,7 @@ def test_typed_set():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 'x'])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v', 1),
             'msg': 'value is not a valid integer',
@@ -217,7 +217,7 @@ def test_typed_dict_error(value, errors):
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
-    assert exc_info.value.flatten_errors() == errors
+    assert exc_info.value.errors() == errors
 
 
 def test_dict_key_error():
@@ -228,7 +228,7 @@ def test_dict_key_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v={'foo': 2, '3': '4'})
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v', '__key__'),
             'msg': 'value is not a valid integer',
@@ -276,7 +276,7 @@ def test_recursive_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=['x'])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v', 0),
             'msg': 'value is not a valid dict',
@@ -295,7 +295,7 @@ def test_recursive_list_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[{}])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v', 0, 'name'),
             'msg': 'field required',
@@ -312,7 +312,7 @@ def test_list_unions():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v', 2),
             'msg': 'value is not a valid integer',
@@ -387,7 +387,7 @@ def test_alias_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(_a='foo')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('_a',),
             'msg': 'value is not a valid integer',
@@ -497,7 +497,7 @@ def test_invalid_string_types(value, errors):
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
-    assert exc_info.value.flatten_errors() == errors
+    assert exc_info.value.errors() == errors
 
 
 def test_inheritance_config():
@@ -547,7 +547,7 @@ def test_string_none():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=None)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'none is not an allow value',

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -91,7 +91,7 @@ def test_funky_name():
     assert m.dict() == {'this-is-funky': 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('this-is-funky',),
             'msg': 'field required',

--- a/tests/test_error_wrappers.py
+++ b/tests/test_error_wrappers.py
@@ -272,9 +272,7 @@ def test_validation_error(result, expected):
             'h': 21,
         })
 
-    result = getattr(exc_info.value, result)()
-    print(result)
-    assert result == expected
+    assert getattr(exc_info.value, result)() == expected
 
 
 def test_errors_unknown_error_object():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,7 +25,7 @@ class UltraSimpleModel(BaseModel):
 def test_ultra_simple_missing():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel()
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'field required',
@@ -37,7 +37,7 @@ def test_ultra_simple_missing():
 def test_ultra_simple_failed():
     with pytest.raises(ValidationError) as exc_info:
         UltraSimpleModel(a='x', b='x')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'value is not a valid float',
@@ -123,7 +123,7 @@ def test_nullable_strings_fails():
             required_bytes_value=None,
             required_bytes_none_value=None,
         )
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('required_str_value',),
             'msg': 'none is not an allow value',
@@ -173,7 +173,7 @@ def test_prevent_extra_success():
 def test_prevent_extra_fails():
     with pytest.raises(ValidationError) as exc_info:
         PreventExtraModel(foo='ok', bar='wrong', spam='xx')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('bar',),
             'msg': 'extra fields not permitted',
@@ -328,7 +328,7 @@ def test_required():
 
     with pytest.raises(ValidationError) as exc_info:
         Model()
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'field required',
@@ -395,7 +395,7 @@ def test_validating_assignment_fail():
 
     with pytest.raises(ValidationError) as exc_info:
         p.a = 'b'
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'value is not a valid integer',
@@ -405,7 +405,7 @@ def test_validating_assignment_fail():
 
     with pytest.raises(ValidationError) as exc_info:
         p.b = ''
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('b',),
             'msg': 'ensure this value has at least 1 characters',

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -23,7 +23,7 @@ def test_obj():
 def test_fails():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_obj([1, 2, 3])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Model expected dict not list',
@@ -62,7 +62,7 @@ def test_msgpack_not_installed_proto(mocker):
 def test_msgpack_not_installed_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw(b'\x82\xa1a\x0c\xa1b\x08', content_type='application/msgpack')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Unknown content-type: application/msgpack',
@@ -90,7 +90,7 @@ def test_pickle_not_allowed():
 def test_bad_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Unknown content-type: application/missing',
@@ -102,7 +102,7 @@ def test_bad_ct():
 def test_bad_proto():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('__obj__',),
             'msg': 'Unknown protocol: foobar',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ def test_sub_env_override(env):
 def test_sub_env_missing():
     with pytest.raises(ValidationError) as exc_info:
         SimpleSettings()
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('apple',),
             'msg': 'none is not an allow value',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -36,7 +36,7 @@ def test_constrained_str_default():
 def test_constrained_str_too_long():
     with pytest.raises(ValidationError) as exc_info:
         ConStringModel(v='this is too long')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'ensure this value has at most 10 characters',
@@ -77,7 +77,7 @@ def test_dsn_pw_host():
 def test_dsn_no_driver():
     with pytest.raises(ValidationError) as exc_info:
         DsnModel(db_driver=None)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('db_driver',),
             'msg': 'none is not an allow value',
@@ -100,7 +100,7 @@ def test_module_import():
     assert m.module == os.path
     with pytest.raises(ValidationError) as exc_info:
         PyObjectModel(module='foobar')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('module',),
             'msg': 'ensure this value contains valid import path',
@@ -208,7 +208,7 @@ class StrModel(BaseModel):
 def test_string_too_long():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x' * 150)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('str_check',),
             'msg': 'ensure this value has at most 10 characters',
@@ -223,7 +223,7 @@ def test_string_too_long():
 def test_string_too_short():
     with pytest.raises(ValidationError) as exc_info:
         StrModel(str_check='x')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('str_check',),
             'msg': 'ensure this value has at least 5 characters',
@@ -263,7 +263,7 @@ def test_datetime_errors():
             time_='25:20:30.400',
             duration='15:30.0001 broken',
         )
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('dt',),
             'msg': 'invalid datetime format',
@@ -312,7 +312,7 @@ def test_enum_successful():
 def test_enum_fails():
     with pytest.raises(ValueError) as exc_info:
         CookingModel(tool=3)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('tool',),
             'msg': 'value is not a valid enumeration member',
@@ -366,7 +366,7 @@ def test_string_fails():
             str_email='foobar<@example.com',
             name_email='foobar @example.com',
         )
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('str_regex',),
             'msg': 'string does not match regex "^xxx\\d{3}$"',
@@ -419,7 +419,7 @@ def test_dict():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, 3])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid dict',
@@ -438,7 +438,7 @@ def test_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=1)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid list',
@@ -457,7 +457,7 @@ def test_ordered_dict():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, 3])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid dict',
@@ -476,7 +476,7 @@ def test_tuple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=1)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid tuple',
@@ -495,7 +495,7 @@ def test_set():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=1)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid set',
@@ -516,7 +516,7 @@ def test_int_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=-5, b=5, c=-5, d=11)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'ensure this value is greater than 0',
@@ -564,7 +564,7 @@ def test_float_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=-5.1, b=5.2, c=-5.3, d=9.91)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'ensure this value is greater than 0',
@@ -619,7 +619,7 @@ def test_uuid_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v='ebcdab58-6eb8-46fb-a190-d07a3')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('v',),
             'msg': 'value is not a valid uuid',
@@ -654,7 +654,7 @@ def test_uuid_validation():
 
     with pytest.raises(ValidationError) as exc_info:
         UUIDModel(a=d, b=c, c=b, d=a)
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'uuid version 1 expected',
@@ -852,7 +852,7 @@ def test_decimal_validation(type_, value, result):
     if not isinstance(result, Decimal):
         with pytest.raises(ValidationError) as exc_info:
             model(foo=value)
-        assert exc_info.value.flatten_errors() == result
+        assert exc_info.value.errors() == result
     else:
         assert model(foo=value).foo == result
 
@@ -875,7 +875,7 @@ def test_path_validation(value, result):
     if not isinstance(result, Path):
         with pytest.raises(ValidationError) as exc_info:
             Model(foo=value)
-        assert exc_info.value.flatten_errors() == result
+        assert exc_info.value.errors() == result
     else:
         assert Model(foo=value).foo == result
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -19,7 +19,7 @@ def test_simple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': '"foobar" not found in a',
@@ -84,7 +84,7 @@ def test_validate_whole_error():
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[1, 3])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'a1 broken',
@@ -96,7 +96,7 @@ def test_validate_whole_error():
     calls = []
     with pytest.raises(ValidationError) as exc_info:
         Model(a=[5, 10])
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'a2 broken',
@@ -137,7 +137,7 @@ def test_validating_assignment_fail():
 def test_validating_assignment_dict():
     with pytest.raises(ValidationError) as exc_info:
         ValidateAssignmentModel(a='x', b='xx')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'value is not a valid integer',
@@ -162,7 +162,7 @@ def test_validate_multiple():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='x', b='x')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': 'a is too short',
@@ -305,7 +305,7 @@ def test_wildcard_validator_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.flatten_errors() == [
+    assert exc_info.value.errors() == [
         {
             'loc': ('a',),
             'msg': '"foobar" not found in a',


### PR DESCRIPTION
As discussed, here's the cleanup for #189.

I've also changed the signature for `ValidationError` to just `errors()`, `json()` and `__str__()` which I think is simpler.

@Gr1N, let me know if you're ok with this.