### PR TITLE
remove msgpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ install:
 script:
 - make lint
 
-# test with and without msgpack and ujson then combine coverage
+# test with and without ujson and email-validator then combine coverage
 - make test && mv .coverage .coverage.extra
-- pip uninstall -y msgpack-python ujson email-validator
+- pip uninstall -y ujson email-validator
 - make test && mv .coverage .coverage.no-extra
 - coverage combine
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,9 +3,10 @@
 History
 -------
 
-v0.10.1 (2018-xx-xx)
+v0.11.0 (2018-XX-XX)
 ....................
 * make ``list``, ``tuple`` and ``set`` types stricter #86
+* **breaking change**: remove msgpack parsing #201
 
 v0.10.0 (2018-06-11)
 ....................

--- a/docs/examples/parse.py
+++ b/docs/examples/parse.py
@@ -1,7 +1,5 @@
 import pickle
-from pathlib import Path
 from datetime import datetime
-import msgpack
 from pydantic import BaseModel, ValidationError
 
 class User(BaseModel):
@@ -24,20 +22,7 @@ m = User.parse_raw('{"id": 123, "name": "James"}')  # assumes json as no content
 print(m)
 # > User id=123 name='James' signup_ts=None
 
-msgpack_data = msgpack.packb({'id': 123, 'name': 'James', 'signup_ts': 1500000000})
-m = User.parse_raw(msgpack_data, content_type='application/msgpack')
-print(m)
-# > User id=123 name='James' signup_ts=datetime.datetime(2017, 7, 14, 2, 40, tzinfo=datetime.timezone.utc)
-
-
 pickle_data = pickle.dumps({'id': 123, 'name': 'James', 'signup_ts': datetime(2017, 7, 14)})
 m = User.parse_raw(pickle_data, content_type='application/pickle', allow_pickle=True)
 print(m)
 # > User id=123 name='James' signup_ts=datetime.datetime(2017, 7, 14, 0, 0)
-
-
-Path('/tmp/data.mp').write_bytes(msgpack_data)
-# data.json: {"id": 123, "name": "James"}
-m = User.parse_file('/tmp/data.mp')
-print(m)
-# > User id=123 name='James' signup_ts=datetime.datetime(2017, 7, 14, 2, 40, tzinfo=datetime.timezone.utc)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,19 +77,17 @@ Just::
 *pydantic* has no required dependencies except python 3.6+. If you've got python 3.6 and ``pip`` installed -
 you're good to go.
 
-If you want *pydantic* to parse msgpack you can add `msgpack-python <https://pypi.python.org/pypi/msgpack-python>`_
-as an optional dependency, same goes for reading json faster with `ujson <https://pypi.python.org/pypi/ujson>`_.
+If you want *pydantic* to parse json faster you can add `ujson <https://pypi.python.org/pypi/ujson>`_
+as an optional dependency.
 
 Similarly if *pydantic's* email validation relies on
 `email-validator <https://github.com/JoshData/python-email-validator>`_ ::
 
-    pip install pydantic[msgpack]
-    # or
     pip install pydantic[ujson]
     # or
     pip install pydantic[email]
     # or just
-    pip install pydantic[msgpack,ujson,email]
+    pip install pydantic[ujson,email]
 
 Of course you can also install these requirements manually with ``pip install ...``.
 
@@ -268,7 +266,7 @@ Helper Functions
 
 :parse_obj: this is almost identical to the ``__init__`` method of the model except if the object passed is not
   a dict ``ValidationError`` will be raised (rather than python raising a ``TypeError``).
-:parse_raw: takes a *str* or *bytes* parses it as *json*, *msgpack* or *pickle* data and then passes
+:parse_raw: takes a *str* or *bytes* parses it as *json*, or *pickle* data and then passes
   the result to ``parse_obj``. The data type is inferred from the ``content_type`` argument,
   otherwise *json* is assumed.
 :parse_file: reads a file and passes the contents to ``parse_raw``, if ``content_type`` is omitted it is inferred
@@ -276,7 +274,7 @@ Helper Functions
 
 .. literalinclude:: examples/parse.py
 
-(This script is complete, it should run "as is" provided ``msgpack-python`` is installed)
+(This script is complete, it should run "as is")
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,9 +78,7 @@ Just::
 you're good to go.
 
 If you want *pydantic* to parse json faster you can add `ujson <https://pypi.python.org/pypi/ujson>`_
-as an optional dependency.
-
-Similarly if *pydantic's* email validation relies on
+as an optional dependency. Similarly if *pydantic's* email validation relies on
 `email-validator <https://github.com/JoshData/python-email-validator>`_ ::
 
     pip install pydantic[ujson]

--- a/pydantic/parse.py
+++ b/pydantic/parse.py
@@ -10,15 +10,9 @@ try:
 except ImportError:
     import json
 
-try:
-    import msgpack
-except ImportError:
-    msgpack = None
-
 
 class Protocol(str, Enum):
     json = 'json'
-    msgpack = 'msgpack'
     pickle = 'pickle'
 
 
@@ -30,8 +24,6 @@ def load_str_bytes(b: StrBytes, *,  # noqa: C901 (ignore complexity)
     if proto is None and content_type:
         if content_type.endswith(('json', 'javascript')):
             pass
-        elif msgpack and content_type.endswith('msgpack'):
-            proto = Protocol.msgpack
         elif allow_pickle and content_type.endswith('pickle'):
             proto = Protocol.pickle
         else:
@@ -43,10 +35,6 @@ def load_str_bytes(b: StrBytes, *,  # noqa: C901 (ignore complexity)
         if isinstance(b, bytes):
             b = b.decode(encoding)
         return json.loads(b)
-    elif proto == Protocol.msgpack:
-        if msgpack is None:
-            raise ImportError("msgpack not installed, can't parse data")
-        return msgpack.unpackb(b, encoding=encoding)
     elif proto == Protocol.pickle:
         if not allow_pickle:
             raise RuntimeError('Trying to decode with pickle with allow_pickle=False')
@@ -65,8 +53,6 @@ def load_file(path: Union[str, Path], *,
     if content_type is None:
         if path.suffix in ('.js', '.json'):
             proto = Protocol.json
-        elif path.suffix in ('.mp', '.msgpack'):
-            proto = Protocol.msgpack
         elif path.suffix == '.pkl':
             proto = Protocol.pickle
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@
 -r docs/requirements.txt
 -r tests/requirements.txt
 
-msgpack-python==0.5.6
 ujson==1.35
 email-validator==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     python_requires='>=3.6',
     zip_safe=True,
     extras_require={
-        'msgpack': ['msgpack-python>=0.4.8'],
         'ujson': ['ujson>=1.35'],
         'email': ['email-validator>=1.0.3'],
     }


### PR DESCRIPTION
adding specific msgpack parsing was a mistake by me.

I'm a big fan of `msgpack`, and of course it's still "supported", you just need to parse the data yourself, then pass the result to pydantic.