### PR TITLE
implement timedelta ISO8601 duration format encoder

### DIFF
--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -13,11 +13,22 @@ def isoformat(o):
     return o.isoformat()
 
 
+def iso8601_duration(value):
+    seconds = value.total_seconds()
+    minutes, seconds = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    days, hours, minutes = map(int, (days, hours, minutes))
+    seconds = round(seconds, 6)
+    return f'P{days}DT{hours}H{minutes}M{seconds}S'
+
+
 ENCODERS_BY_TYPE = {
     UUID: str,
     datetime.datetime: isoformat,
     datetime.date: isoformat,
     datetime.time: isoformat,
+    datetime.timedelta: iso8601_duration,
     set: list,
     frozenset: list,
     GeneratorType: list,

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -28,7 +28,7 @@ ENCODERS_BY_TYPE = {
     datetime.datetime: isoformat,
     datetime.date: isoformat,
     datetime.time: isoformat,
-    datetime.timedelta: iso8601_duration,
+    datetime.timedelta: lambda td: f'{td.total_seconds():0.6f}',
     set: list,
     frozenset: list,
     GeneratorType: list,

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -13,16 +13,6 @@ def isoformat(o):
     return o.isoformat()
 
 
-def iso8601_duration(value):
-    seconds = value.total_seconds()
-    minutes, seconds = divmod(seconds, 60)
-    hours, minutes = divmod(minutes, 60)
-    days, hours = divmod(hours, 24)
-    days, hours, minutes = map(int, (days, hours, minutes))
-    seconds = round(seconds, 6)
-    return f'P{days}DT{hours}H{minutes}M{seconds}S'
-
-
 ENCODERS_BY_TYPE = {
     UUID: str,
     datetime.datetime: isoformat,
@@ -42,6 +32,8 @@ def pydantic_encoder(obj):
         return obj.dict()
     elif isinstance(obj, Enum):
         return obj.value
+    elif hasattr(obj, "json") and callable(obj.json):
+        return obj.json()
 
     try:
         encoder = ENCODERS_BY_TYPE[type(obj)]

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -196,7 +196,8 @@ class BaseModel(metaclass=MetaModel):
         as per `json.dumps()`.
         """
         from .json import pydantic_encoder
-        return json.dumps(self.dict(include=include, exclude=exclude), default=pydantic_encoder, **dumps_kwargs)
+        dumps_kwargs.setdefault('default', pydantic_encoder)
+        return json.dumps(self.dict(include=include, exclude=exclude), **dumps_kwargs)
 
     @classmethod
     def parse_obj(cls, obj):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -15,13 +15,26 @@ class MyEnum(Enum):
     snap = 'crackle'
 
 
+class IsoTimeDelta(datetime.timedelta):
+    def json(self):
+        """ Returns ISO 8601 encoding """
+        seconds = self.total_seconds()
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        days, hours = divmod(hours, 24)
+        days, hours, minutes = map(int, (days, hours, minutes))
+        seconds = round(seconds, 6)
+        return f'P{days}DT{hours}H{minutes}M{seconds}S'
+
+
 @pytest.mark.parametrize('input,output', [
     (UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8'), '"ebcdab58-6eb8-46fb-a190-d07a33e9eac8"'),
     (datetime.datetime(2032, 1, 1, 1, 1), '"2032-01-01T01:01:00"'),
     (datetime.datetime(2032, 1, 1, 1, 1, tzinfo=datetime.timezone.utc), '"2032-01-01T01:01:00+00:00"'),
     (datetime.datetime(2032, 1, 1), '"2032-01-01T00:00:00"'),
     (datetime.time(12, 34, 56), '"12:34:56"'),
-    (datetime.timedelta(12, 34, 56), '"P12DT0H0M34.000056S"'),
+    (datetime.timedelta(12, 34, 56), '"1036834.000056"'),
+    (IsoTimeDelta(12, 34, 56), '"P12DT0H0M34.000056S"'),
     ({1, 2, 3}, '[1, 2, 3]'),
     (frozenset([1, 2, 3]), '[1, 2, 3]'),
     ((v for v in range(4)), '[0, 1, 2, 3]'),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -21,6 +21,7 @@ class MyEnum(Enum):
     (datetime.datetime(2032, 1, 1, 1, 1, tzinfo=datetime.timezone.utc), '"2032-01-01T01:01:00+00:00"'),
     (datetime.datetime(2032, 1, 1), '"2032-01-01T00:00:00"'),
     (datetime.time(12, 34, 56), '"12:34:56"'),
+    (datetime.timedelta(12, 34, 56), '"P12DT0H0M34.000056S"'),
     ({1, 2, 3}, '[1, 2, 3]'),
     (frozenset([1, 2, 3]), '[1, 2, 3]'),
     ((v for v in range(4)), '[0, 1, 2, 3]'),


### PR DESCRIPTION
Add JSON serialization support for `datetime.timedelta` objects

Based on https://stackoverflow.com/questions/27168175/convert-a-datetime-timedelta-into-iso-8601-duration-in-python