### PR TITLE
timedelta json encoding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-v0.12.2 (XXXX-XX-XX)
+v0.13.0 (XXXX-XX-XX)
 ....................
 * raise an exception if a field's name shadows an existing ``BaseModel`` attribute #242
 * add ``UrlStr`` and ``urlstr`` types #236

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.12.2 (XXXX-XX-XX)
 * raise an exception if a field's name shadows an existing ``BaseModel`` attribute #242
 * add ``UrlStr`` and ``urlstr`` types #236
 * timedelta json encoding ISO8601 and total seconds, custom json encoders #247, by @cfkanesan and @samuelcolvin
+* allow ``timedelta`` objects as values for properties of type ``timedelta`` (matches ``datetime`` etc. behavior) #247
 
 v0.12.1 (2018-07-31)
 ....................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.12.2 (XXXX-XX-XX)
 ....................
 * raise an exception if a field's name shadows an existing ``BaseModel`` attribute #242
 * add ``UrlStr`` and ``urlstr`` types #236
+* timedelta json encoding ISO8601 and total seconds, custom json encoders #247, by @cfkanesan and @samuelcolvin
 
 v0.12.1 (2018-07-31)
 ....................

--- a/docs/examples/copy_dict.py
+++ b/docs/examples/copy_dict.py
@@ -1,25 +1,18 @@
 from pydantic import BaseModel
 
-
 class BarModel(BaseModel):
     whatever: int
-
 
 class FooBarModel(BaseModel):
     banana: float
     foo: str
     bar: BarModel
 
-
 m = FooBarModel(banana=3.14, foo='hello', bar={'whatever': 123})
 
 print(m.dict())
 # (returns a dictionary)
 # > {'banana': 3.14, 'foo': 'hello', 'bar': {'whatever': 123}}
-
-print(m.json())
-# (returns a str)
-# > {"banana": 3.14, "foo": "hello", "bar": {"whatever": 123}}
 
 print(m.dict(include={'foo', 'bar'}))
 # > {'foo': 'hello', 'bar': {'whatever': 123}}

--- a/docs/examples/errors2.py
+++ b/docs/examples/errors2.py
@@ -13,13 +13,14 @@ class Model(BaseModel):
 try:
     Model(foo='ber')
 except ValidationError as e:
-    print(e.json())
+    print(e.errors())
+
 """
 [
-  {
-    "loc": ["foo"],
-    "msg": "value must be \"bar\"",
-    "type": "value_error"
-  }
+    {
+        'loc': ('foo',),
+        'msg': 'value must be "bar"',
+        'type': 'value_error',
+    },
 ]
 """

--- a/docs/examples/ex_json.py
+++ b/docs/examples/ex_json.py
@@ -1,51 +1,30 @@
-from typing import List
+from datetime import datetime, timedelta
+from pydantic import BaseModel
+from pydantic.json import timedelta_isoformat
 
-from pydantic import BaseModel, Json, ValidationError
+class BarModel(BaseModel):
+    whatever: int
 
+class FooBarModel(BaseModel):
+    banana: float
+    foo: datetime
+    bar: BarModel
 
-class SimpleJsonModel(BaseModel):
-    json_obj: Json
+m = FooBarModel(banana=3.14, foo=datetime(2032, 6, 1, 12, 13, 14), bar={'whatever': 123})
 
+print(m.json())
+# (returns a str)
+# > {"banana": 3.14, "foo": "2032-06-01T12:13:14", "bar": {"whatever": 123}}
 
-class ComplexJsonModel(BaseModel):
-    json_obj: Json[List[int]]
+class WithCustomEncoders(BaseModel):
+    dt: datetime
+    diff: timedelta
 
+    class Config:
+        json_encoders = {
+            datetime: lambda v: (v - datetime(1970, 1, 1)).total_seconds(),
+            timedelta: timedelta_isoformat,
+        }
 
-print(SimpleJsonModel(json_obj='{"b": 1}'))
-# > SimpleJsonModel json_obj={'b': 1}
-
-print(ComplexJsonModel(json_obj='[1, 2, 3]'))
-# > ComplexJsonModel json_obj=[1, 2, 3]
-
-
-try:
-    ComplexJsonModel(json_obj=12)
-except ValidationError as e:
-    print(e)
-"""
-1 validation error
-json_obj
-  JSON object must be str, bytes or bytearray (type=type_error.json)
-"""
-
-try:
-    ComplexJsonModel(json_obj='[a, b]')
-except ValidationError as e:
-    print(e)
-"""
-1 validation error
-json_obj
-  Invalid JSON (type=value_error.json)
-"""
-
-try:
-    ComplexJsonModel(json_obj='["a", "b"]')
-except ValidationError as e:
-    print(e)
-"""
-2 validation errors
-json_obj -> 0
-  value is not a valid integer (type=type_error.integer)
-json_obj -> 1
-  value is not a valid integer (type=type_error.integer)
-"""
+print(WithCustomEncoders(dt=datetime(2032, 6, 1, microsecond=500000), diff=timedelta(hours=100)).json())
+# > {"dt": 1969660800.5, "diff": "P4DT4H0M0.000000S"}

--- a/docs/examples/ex_json.py
+++ b/docs/examples/ex_json.py
@@ -6,15 +6,13 @@ class BarModel(BaseModel):
     whatever: int
 
 class FooBarModel(BaseModel):
-    banana: float
     foo: datetime
     bar: BarModel
 
-m = FooBarModel(banana=3.14, foo=datetime(2032, 6, 1, 12, 13, 14), bar={'whatever': 123})
-
+m = FooBarModel(foo=datetime(2032, 6, 1, 12, 13, 14), bar={'whatever': 123})
 print(m.json())
 # (returns a str)
-# > {"banana": 3.14, "foo": "2032-06-01T12:13:14", "bar": {"whatever": 123}}
+# > {"foo": "2032-06-01T12:13:14", "bar": {"whatever": 123}}
 
 class WithCustomEncoders(BaseModel):
     dt: datetime
@@ -26,5 +24,6 @@ class WithCustomEncoders(BaseModel):
             timedelta: timedelta_isoformat,
         }
 
-print(WithCustomEncoders(dt=datetime(2032, 6, 1, microsecond=500000), diff=timedelta(hours=100)).json())
-# > {"dt": 1969660800.5, "diff": "P4DT4H0M0.000000S"}
+m = WithCustomEncoders(dt=datetime(2032, 6, 1), diff=timedelta(hours=100))
+print(m.json())
+# > {"dt": 1969660800.0, "diff": "P4DT4H0M0.000000S"}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -488,18 +488,18 @@ to new values that will be applied as the model is duplicated.
 Serialisation
 .............
 
-*pydantic* has native support for serialisation to JSON and Pickle, you can of course serialise to any other format
-you like by processing the result of ``dict()``.
+*pydantic* has native support for serialisation to **JSON** and **Pickle**, you can of course serialise to any
+other format you like by processing the result of ``dict()``.
 
 .. _json_dump:
 
 JSON Serialisation
 ~~~~~~~~~~~~~~~~~~
 
-The ``json`` method will serialise a model to JSON. ``json`` in term calls ``dict`` and serialises it's result.
+The ``json()`` method will serialise a model to JSON, ``json()`` in turn calls ``dict()`` and serialises its result.
 
-Serialisation can be customised on a model config using the ``json_encoders`` property, the keys should be types and
-the values should be functions which serialise that type.
+Serialisation can be customised on a model using the ``json_encoders`` config property, the keys should be types and
+the values should be functions which serialise that type, see the example below.
 
 If this is not sufficient, ``json()`` takes an optional ``encoder`` argument which allows complete control
 over how non-standard types are encoded to JSON.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -246,9 +246,9 @@ contain information about all the errors and how they happened.
 
 You can access these errors in a several ways:
 
-:errors: method will return list of errors found in the input data.
-:json: method will return a JSON representation of ``errors``.
-:__str__: method will return a human readable representation of the errors.
+:e.errors(): method will return list of errors found in the input data.
+:e.json(): method will return a JSON representation of ``errors``.
+:str(e): method will return a human readable representation of the errors.
 
 Each error object contains:
 
@@ -357,6 +357,8 @@ Options:
     Pass in a dictionary with keys matching the error messages you want to override (default: ``{}``)
 :arbitrary_types_allowed: whether to allow arbitrary user types for fields (they are validated simply by checking if the
     value is instance of that type). If False - RuntimeError will be raised on model declaration (default: ``False``)
+:json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
+    details.
 
 .. warning::
 
@@ -469,27 +471,49 @@ a model.
 Trying to change ``a`` caused an error and it remains unchanged, however the dict ``b`` is mutable and the
 immutability of ``foobar`` doesn't stop being changed.
 
-Copying and Serialization
-.........................
+Copying
+.......
 
 The ``dict`` function returns a dictionary containing the attributes of a model. Sub-models are recursively
-converted to dicts. The ``json`` method will serialise a model to JSON using ``dict``.
-
-While ``copy`` allows models to be duplicated, this is particularly useful for immutable models.
+converted to dicts, ``copy`` allows models to be duplicated, this is particularly useful for immutable models.
 
 
-``dict``, ``json`` and ``copy`` all take the optional ``include`` and ``exclude`` keyword arguments to control
-which attributes are returned or copied, respectively. ``copy`` accepts an extra keyword argument, ``update``,
-which accepts a ``dict`` mapping attributes to new values that will be applied as the model is duplicated.
+``dict``, ``copy``, and ``json`` (described :ref:`below <json_dump>`) all take the optional
+``include`` and ``exclude`` keyword arguments to control which attributes are returned or copied,
+respectively. ``copy`` accepts an extra keyword argument, ``update``, which accepts a ``dict`` mapping attributes
+to new values that will be applied as the model is duplicated.
 
-.. literalinclude:: examples/copy_values.py
+.. literalinclude:: examples/copy_dict.py
 
-Pickle
-......
+Serialisation
+.............
 
-Using the same plumbing as ``copy()`` pydantic models support efficient pickling and unpicking.
+*pydantic* has native support for serialisation to JSON and Pickle, you can of course serialise to any other format
+you like by processing the result of ``dict()``.
+
+.. _json_dump:
+
+JSON Serialisation
+~~~~~~~~~~~~~~~~~~
+
+The ``json`` method will serialise a model to JSON. ``json`` in term calls ``dict`` and serialises it's result.
+
+Serialisation can be customised on a model config using the ``json_encoders`` property. If this is not sufficient,
+``json()`` takes an optional ``encoder`` argument which allows complete control over how non-standard types are encoded
+to JSON.
+
+.. literalinclude:: examples/ex_json.py
+
+(This script is complete, it should run "as is")
+
+Pickle Serialisation
+~~~~~~~~~~~~~~~~~~~~
+
+Using the same plumbing as ``copy()`` *pydantic* models support efficient pickling and unpicking.
 
 .. literalinclude:: examples/ex_pickle.py
+
+(This script is complete, it should run "as is")
 
 Abstract Base Classes
 .....................
@@ -498,6 +522,8 @@ Pydantic models can be used alongside Python's
 `Abstract Base Classes <https://docs.python.org/3/library/abc.html>`_ (ABCs).
 
 .. literalinclude:: examples/ex_abc.py
+
+(This script is complete, it should run "as is")
 
 .. _benchmarks_tag:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -498,9 +498,11 @@ JSON Serialisation
 
 The ``json`` method will serialise a model to JSON. ``json`` in term calls ``dict`` and serialises it's result.
 
-Serialisation can be customised on a model config using the ``json_encoders`` property. If this is not sufficient,
-``json()`` takes an optional ``encoder`` argument which allows complete control over how non-standard types are encoded
-to JSON.
+Serialisation can be customised on a model config using the ``json_encoders`` property, the keys should be types and
+the values should be functions which serialise that type.
+
+If this is not sufficient, ``json()`` takes an optional ``encoder`` argument which allows complete control
+over how non-standard types are encoded to JSON.
 
 .. literalinclude:: examples/ex_json.py
 

--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -183,6 +183,9 @@ def parse_duration(value: StrIntFloat) -> timedelta:
 
     Also supports ISO 8601 representation.
     """
+    if isinstance(value, timedelta):
+        return value
+
     if isinstance(value, (int, float)):
         # bellow code requires a string
         value = str(value)

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -4,9 +4,7 @@ from enum import Enum
 from types import GeneratorType
 from uuid import UUID
 
-from .main import BaseModel
-
-__all__ = ['pydantic_encoder']
+__all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
 
 
 def isoformat(o):
@@ -18,6 +16,7 @@ ENCODERS_BY_TYPE = {
     datetime.datetime: isoformat,
     datetime.date: isoformat,
     datetime.time: isoformat,
+    datetime.timedelta: lambda td: td.total_seconds(),
     set: list,
     frozenset: list,
     GeneratorType: list,
@@ -27,6 +26,7 @@ ENCODERS_BY_TYPE = {
 
 
 def pydantic_encoder(obj):
+    from .main import BaseModel
     if isinstance(obj, BaseModel):
         return obj.dict()
     elif isinstance(obj, Enum):
@@ -38,3 +38,20 @@ def pydantic_encoder(obj):
         raise TypeError(f"Object of type '{obj.__class__.__name__}' is not JSON serializable")
     else:
         return encoder(obj)
+
+
+def custom_pydantic_encoder(type_encoders, obj):
+    encoder = type_encoders.get(type(obj))
+    if encoder:
+        return encoder(obj)
+    else:
+        return pydantic_encoder(obj)
+
+
+def timedelta_isoformat(td: datetime.timedelta):
+    """
+    ISO 8601 encoding for timedeltas.
+    """
+    minutes, seconds = divmod(td.seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    return f'P{td.days}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -48,7 +48,7 @@ def custom_pydantic_encoder(type_encoders, obj):
         return pydantic_encoder(obj)
 
 
-def timedelta_isoformat(td: datetime.timedelta):
+def timedelta_isoformat(td: datetime.timedelta) -> str:
     """
     ISO 8601 encoding for timedeltas.
     """

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.12.1')
+VERSION = StrictVersion('0.13a1')

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -101,11 +101,13 @@ def test_datetime_parsing(value, result):
     timedelta(seconds=30),  # seconds
 ])
 def test_parse_python_format(delta):
-    assert parse_duration(format(delta)) == delta
+    assert parse_duration(delta) == delta
+    assert parse_duration(str(delta)) == delta
 
 
 @pytest.mark.parametrize('value,result', [
     # seconds
+    (timedelta(seconds=30), timedelta(seconds=30)),
     ('30', timedelta(seconds=30)),
     (30, timedelta(seconds=30)),
     (30.1, timedelta(seconds=30, milliseconds=100)),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -80,7 +80,7 @@ def test_custom_encoder():
     assert m.json() == '{"x": "datetime.timedelta(0, 123)", "y": "a decimal", "z": "2032-06-01"}'
 
 
-def test_iso_timedelt():
+def test_custom_iso_timedelta():
     class Model(BaseModel):
         x: datetime.timedelta
 
@@ -89,3 +89,12 @@ def test_iso_timedelt():
 
     m = Model(x=123)
     assert m.json() == '{"x": "P0DT0H2M3.000000S"}'
+
+
+def test_custom_encoder_arg():
+    class Model(BaseModel):
+        x: datetime.timedelta
+
+    m = Model(x=123)
+    assert m.json() == '{"x": 123.0}'
+    assert m.json(encoder=lambda v: '__default__') == '{"x": "__default__"}'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -74,10 +74,9 @@ def test_custom_encoder():
         z: datetime.date
 
         class Config:
-            json_encoders = {datetime.timedelta: repr, Decimal: lambda v: 'a decimal'}
+            json_encoders = {datetime.timedelta: lambda v: f'{v.total_seconds():0.3f}s', Decimal: lambda v: 'a decimal'}
 
-    m = Model(x=123, y=5, z='2032-06-01')
-    assert m.json() == '{"x": "datetime.timedelta(0, 123)", "y": "a decimal", "z": "2032-06-01"}'
+    assert Model(x=123, y=5, z='2032-06-01').json() == '{"x": "123.000s", "y": "a decimal", "z": "2032-06-01"}'
 
 
 def test_custom_iso_timedelta():


### PR DESCRIPTION
an alternative to #220. Needs a few more tests and docs but otherwise complete.

basically, I've added a `json_encoders` Config settings, allowing custom typing encoding defined on a model:

```py
class Model(BaseModel):
    x: datetime.timedelta

    class Config:
        json_encoders = {datetime.timedelta: timedelta_isoformat}

m = Model(x=123)
assert m.json() == '{"x": "P0DT0H2M3.000000S"}'
```

@Gr1N and @cfkanesan I'd appreciate your feedback on this.