### PR TITLE
Remove extra 0 from v0.13.0 date in HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-v0.13.0 (20180-08-25)
+v0.13.0 (2018-08-25)
 .....................
 * raise an exception if a field's name shadows an existing ``BaseModel`` attribute #242
 * add ``UrlStr`` and ``urlstr`` types #236


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Removed a stray 0 from the changelog

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
None

## Performance Changes

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:

Not applicable

## Checklist

* [ ] Unit tests for the changes exist [not applicable]
* [X] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes [not applicable]
* [ ] No performance deterioration (if applicable) [not applicable]
* [X] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
    * @aahancoc
