### PR TITLE
Add support for deep copy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.XX.X (XXXX-XX-XX)
+.....................
+* add deep copy support for ``BaseModel.copy()`` #249, @gangefors
+
 v0.13.0 (2018-08-25)
 .....................
 * raise an exception if a field's name shadows an existing ``BaseModel`` attribute #242

--- a/docs/examples/copy_dict.py
+++ b/docs/examples/copy_dict.py
@@ -31,3 +31,11 @@ print(m.copy(exclude={'foo', 'bar'}))
 
 print(m.copy(update={'banana': 0}))
 # > FooBarModel banana=0 foo='hello' bar=<BarModel whatever=123>
+
+print(id(m.bar), id(m.copy().bar))
+# normal copy gives the same object reference for `bar`
+# > 140494497582280 140494497582280
+
+print(id(m.bar), id(m.copy(deep=True).bar))
+# deep copy gives a new object reference for `bar`
+# > 140494497582280 140494497582856

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -480,8 +480,8 @@ converted to dicts, ``copy`` allows models to be duplicated, this is particularl
 
 ``dict``, ``copy``, and ``json`` (described :ref:`below <json_dump>`) all take the optional
 ``include`` and ``exclude`` keyword arguments to control which attributes are returned or copied,
-respectively. ``copy`` accepts an extra keyword argument, ``update``, which accepts a ``dict`` mapping attributes
-to new values that will be applied as the model is duplicated.
+respectively. ``copy`` accepts extra keyword arguments, ``update``, which accepts a ``dict`` mapping attributes
+to new values that will be applied as the model is duplicated and ``deep`` to make a deep copy of the model.
 
 .. literalinclude:: examples/copy_dict.py
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -261,7 +261,7 @@ class BaseModel(metaclass=MetaModel):
         m.__setstate__(values)
         return m
 
-    def copy(self, *, include: Set[str]=None, exclude: Set[str]=None, update: Dict[str, Any]=None):
+    def copy(self, *, include: Set[str]=None, exclude: Set[str]=None, update: Dict[str, Any]=None, deep: bool=False):
         """
         Duplicate a model, optionally choose which fields to include, exclude and change.
 
@@ -269,6 +269,7 @@ class BaseModel(metaclass=MetaModel):
         :param exclude: fields to exclude from new model, as with values this takes precedence over include
         :param update: values to change/add in the new model. Note: the data is not validated before creating
             the new model: you should trust this data
+        :param deep: set to `True` to make a deep copy of the model
         :return: new model instance
         """
         if include is None and exclude is None and update is None:
@@ -280,6 +281,8 @@ class BaseModel(metaclass=MetaModel):
                 **{k: v for k, v in self.__values__.items() if k not in exclude and (not include or k in include)},
                 **(update or {})
             }
+        if deep:
+            v = deepcopy(v)
         return self.__class__.construct(**v)
 
     @property

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -42,6 +42,18 @@ class ModelTwo(BaseModel):
     d: Model
 
 
+def test_deep_copy():
+    m = ModelTwo(a=24, d=Model(a='12'))
+    m2 = m.copy(deep=True)
+
+    assert m.a == m2.a == 24
+    assert m.b == m2.b == 10
+    assert m.c == m2.c == 'foobar'
+    assert m.d is not m2.d
+    assert m == m2
+    assert m.__fields__ == m2.__fields__
+
+
 def test_copy_exclude():
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy(exclude={'b'})


### PR DESCRIPTION
## Change Summary

Using `model.copy(deep=True)` will deep copy a module instance.

Making a deep copy is useful for models that have lists of dicts or
any other non-simple data structure to not accidentally modify data
between instances.

`model.copy()` behaviour is unchanged and will do a shallow copy of
the model instance.

## Related issue number

Solves #249 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Performance Changes

* before: pydantic best=39.896μs/iter avg=41.037μs/iter stdev=0.729μs/iter
* after: pydantic best=40.237μs/iter avg=41.397μs/iter stdev=0.841μs/iter

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
