### PR TITLE
use type() in int validator 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 v0.XX.X (XXXX-XX-XX)
 .....................
-* fix issue where int_validator doesn't cast a ``bool`` to an ``int``
+* fix issue where int_validator doesn't cast a ``bool`` to an ``int`` #264 by @nphyatt
 * add deep copy support for ``BaseModel.copy()`` #249, @gangefors
 
 v0.13.0 (2018-08-25)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 v0.XX.X (XXXX-XX-XX)
 .....................
+* fix issue where int_validator doesn't cast a ``bool`` to an ``int``
 * add deep copy support for ``BaseModel.copy()`` #249, @gangefors
 
 v0.13.0 (2018-08-25)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -63,7 +63,7 @@ def bool_validator(v) -> bool:
 
 
 def int_validator(v) -> int:
-    if type(v) is int:
+    if not isinstance(v, bool) and isinstance(v, int):
         return v
 
     with change_exception(errors.IntegerError, TypeError, ValueError):

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -63,7 +63,7 @@ def bool_validator(v) -> bool:
 
 
 def int_validator(v) -> int:
-    if isinstance(v, int):
+    if type(v) is int:
         return v
 
     with change_exception(errors.IntegerError, TypeError, ValueError):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -28,6 +28,25 @@ def test_simple():
     ]
 
 
+def test_int_validation():
+    class Model(BaseModel):
+        a: int
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='snap')
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('a',),
+            'msg': 'value is not a valid integer',
+            'type': 'type_error.integer',
+        },
+    ]
+    assert Model(a=3).a is 3
+    assert Model(a=True).a is 1
+    assert Model(a=False).a is 0
+    assert Model(a=4.5).a is 4
+
+
 def test_validate_whole():
     class Model(BaseModel):
         a: List[int]


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

This fixes an issue I would not expect where if you pass `True | False` to and field typed with `int` you'll get the `bool` value inside your object. I would expect to get `int` values `1 | 0` This is because in python a `bool` is actually a subclass of `int` so `isinstance(True, int)` returns `True`. Using `type(True) is int` returns `False` and will therefore cause `True` to be cast to an `int` which I think falls in line with how the other validators work.

## Related issue number

I didn't see any.

## Performance Changes

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:
* before: 
```
pydantic time=0.962s, success=48.10%
pydantic time=0.987s, success=48.10%
pydantic time=0.988s, success=48.10%
pydantic time=0.932s, success=48.10%
pydantic time=1.003s, success=48.10%
pydantic best=0.932s, avg=0.975s, stdev=0.028s

pydantic best=31.082μs/iter avg=32.493μs/iter stdev=0.930μs/iter
```

* after: 
```
pydantic time=0.951s, success=48.10%
pydantic time=0.970s, success=48.10%
pydantic time=0.963s, success=48.10%
pydantic time=0.930s, success=48.10%
pydantic time=0.971s, success=48.10%
pydantic best=0.930s, avg=0.957s, stdev=0.017s

pydantic best=31.000μs/iter avg=31.900μs/iter stdev=0.566μs/iter
```
## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
