### PR TITLE
Add additional parameters to Schema for validation and annotation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 v0.16.0 (2018-XX-XX)
 ....................
 
-* add additional fields to ``Schema`` class to declare validation for ``str`` and numeric values, #309 by @tiangolo
+* add additional fields to ``Schema`` class to declare validation for ``str`` and numeric values, #311 by @tiangolo
 * refactor schema generation to be compatible with JSON Schema and OpenAPI specs, #308 by @tiangolo
 * add ``schema`` to ``schema`` module to generate top-level schemas from base models, #308 by @tiangolo
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.16.0 (2018-XX-XX)
 ....................
 
+* add additional fields to ``Schema`` class to declare validation for ``str`` and numeric values, #309 by @tiangolo
 * refactor schema generation to be compatible with JSON Schema and OpenAPI specs, #308 by @tiangolo
 * add ``schema`` to ``schema`` module to generate top-level schemas from base models, #308 by @tiangolo
 

--- a/docs/examples/schema1.json
+++ b/docs/examples/schema1.json
@@ -18,8 +18,10 @@
     },
     "snap": {
       "title": "The Snap",
-      "default": 42,
       "description": "this is the value of snap",
+      "default": 42,
+      "exclusiveMinimum": 30,
+      "exclusiveMaximum": 50,
       "type": "integer"
     }
   },

--- a/docs/examples/schema1.py
+++ b/docs/examples/schema1.py
@@ -24,6 +24,8 @@ class MainModel(BaseModel):
         42,
         title='The Snap',
         description='this is the value of snap',
+        gt=30,
+        lt=50,
     )
 
     class Config:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -245,15 +245,31 @@ and reference.
 "sub-models" with modifications (via the ``Schema`` class) like a custom title, description or default value,
 are recursively included instead of referenced.
 
-The ``description`` for models is taken from the docstring of the class.
+The ``description`` for models is taken from the docstring of the class or the argument ``description`` to the ``Schema``
+class.
 
-Optionally the ``Schema`` class can be used to provide extra information about the field, arguments:
+Optionally the ``Schema`` class can be used to provide extra information about the field and validations, arguments:
 
 * ``default`` (positional argument), since the ``Schema`` is replacing the field's default, its first
   argument is used to set the default, use ellipsis (``...``) to indicate the field is required
+* ``alias`` - the public name of the field
 * ``title`` if omitted ``field_name.title()`` is used
-* ``alias`` - the public name of the field.
-* ``**`` any other keyword arguments (eg. ``description``) will be added verbatim to the field's schema
+* ``description`` if omitted and the annotation is a sub-model, the docstring of the sub-model will be used
+* ``gt`` for numeric values (``int``, ``float``, ``Decimal``), adds a validation of "greater than" and an annotation
+  of ``exclusiveMinimum`` to the JSON Schema
+* ``ge`` for numeric values, adds a validation of "greater than or equal" and an annotation of ``maximum`` to the
+  JSON Schema
+* ``lt`` for numeric values, adds a validation of "less than" and an annotation of ``exclusiveMaximum`` to the
+  JSON Schema
+* ``le`` for numeric values, adds a validation of "less than or equal" and an annotation of ``maximum`` to the
+  JSON Schema
+* ``min_length`` for string values, adds a corresponding validation and an annotation of ``minLength`` to the
+  JSON Schema
+* ``max_length`` for string values, adds a corresponding validation and an annotation of ``maxLength`` to the
+  JSON Schema
+* ``regex`` for string values, adds a Regular Expression validation generated from the passed string and an 
+  annotation of ``pattern`` to the JSON Schema
+* ``**`` any other keyword arguments (eg. ``examples``) will be added verbatim to the field's schema
 
 Instead of using ``Schema``, the ``fields`` property of :ref:`the Config class <config>` can be used
 to set all the arguments above except ``default``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -257,7 +257,7 @@ Optionally the ``Schema`` class can be used to provide extra information about t
 * ``description`` if omitted and the annotation is a sub-model, the docstring of the sub-model will be used
 * ``gt`` for numeric values (``int``, ``float``, ``Decimal``), adds a validation of "greater than" and an annotation
   of ``exclusiveMinimum`` to the JSON Schema
-* ``ge`` for numeric values, adds a validation of "greater than or equal" and an annotation of ``maximum`` to the
+* ``ge`` for numeric values, adds a validation of "greater than or equal" and an annotation of ``minimum`` to the
   JSON Schema
 * ``lt`` for numeric values, adds a validation of "less than" and an annotation of ``exclusiveMaximum`` to the
   JSON Schema

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -2,9 +2,10 @@
 from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
-from .fields import Required, Schema
+from .fields import Required
 from .main import BaseConfig, BaseModel, create_model, validate_model, validator
 from .parse import Protocol
 from .types import *
 from .version import VERSION
 from . import dataclasses
+from .schema import Schema

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -52,6 +52,29 @@ class Validator(NamedTuple):
 class Schema:
     """
     Used to provide extra information about a field in a model schema. The parameters will be
+    converted to validations and will add annotations to the generated JSON Schema. Some arguments
+    apply only to number fields (``int``, ``float``, ``Decimal``) and some apply only to ``str``
+
+    :param default: since the Schema is replacing the field’s default, its first argument is used
+      to set the default, use ellipsis (``...``) to indicate the field is required
+    :param alias: the public name of the field
+    :param title: can be any string, used in the schema
+    :param description: can be any string, used in the schema
+    :param gt: only applies to numbers, requires the field to be "greater than". The schema
+      will have an ``exclusiveMinimum`` validation keyword
+    :param ge: only applies to numbers, requires the field to be "greater than or equal to". The
+    schema will have a ``minimum`` validation keyword
+    :param lt: only applies to numbers, requires the field to be "less than". The schema
+    will have an ``exclusiveMaximum`` validation keyword
+    :param le: only applies to numbers, requires the field to be "less than or equal to". The
+    schema will have a ``maximum`` validation keyword
+    :param min_length: only applies to strings, requires the field to have a minimum length. The
+    schema will have a ``maximum`` validation keyword
+    :param max_length: only applies to strings, requires the field to have a maximum length. The
+    schema will have a ``maxLength`` validation keyword
+    :param regex: only applies to strings, requires the field match agains a regular expression
+    pattern string. The schema will have a ``pattern`` validation keyword
+    :param **extra: any additional keyword arguments will be added as is to the schema
     """
 
     __slots__ = (

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -99,7 +99,6 @@ class Schema:
         self.regex = regex
 
 
-# base classes, classes blacklist, args to check and assign
 _numeric_types = (int, float, Decimal)
 _blacklist = (EmailStr, DSN, UrlStr, ConstrainedStr, ConstrainedInt, ConstrainedFloat, ConstrainedDecimal)
 _str_attrs = ('max_length', 'min_length', 'regex')
@@ -127,7 +126,8 @@ def get_annotation_from_schema(annotation, schema):
             attrs = _str_attrs
             kwargs = {'min_length': None, 'max_length': None, 'regex': None}
             con = _map_types_const[str]
-        elif issubclass(annotation, _numeric_types):
+        else:
+            # Is numeric type
             attrs = _numeric_attrs
             kwargs = {'gt': None, 'lt': None, 'ge': None, 'le': None}
             for t in _numeric_types:
@@ -135,9 +135,7 @@ def get_annotation_from_schema(annotation, schema):
                     con = _map_types_const[t]
                     break
         for attr in attrs:
-            if hasattr(annotation, attr) and getattr(annotation, attr) is not None:
-                kwargs[attr] = getattr(annotation, attr)
-            elif hasattr(schema, attr) and getattr(schema, attr) is not None:
+            if hasattr(schema, attr) and getattr(schema, attr) is not None:
                 params_to_set = True
                 kwargs[attr] = getattr(schema, attr)
         if params_to_set:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,11 +1,11 @@
 import inspect
-from dataclasses import dataclass
 from decimal import Decimal
 from enum import IntEnum
 from typing import Any, Callable, List, Mapping, NamedTuple, Pattern, Set, Tuple, Type, Union
 
 from . import errors as errors_
 from .error_wrappers import ErrorWrapper
+from .schema_class import Schema
 from .types import (
     DSN,
     ConstrainedDecimal,
@@ -48,80 +48,6 @@ class Validator(NamedTuple):
     whole: bool
     always: bool
     check_fields: bool
-
-
-@dataclass
-class Schema:
-    """
-    Used to provide extra information about a field in a model schema. The parameters will be
-    converted to validations and will add annotations to the generated JSON Schema. Some arguments
-    apply only to number fields (``int``, ``float``, ``Decimal``) and some apply only to ``str``
-
-    :param default: since the Schema is replacing the field’s default, its first argument is used
-      to set the default, use ellipsis (``...``) to indicate the field is required
-    :param alias: the public name of the field
-    :param title: can be any string, used in the schema
-    :param description: can be any string, used in the schema
-    :param gt: only applies to numbers, requires the field to be "greater than". The schema
-      will have an ``exclusiveMinimum`` validation keyword
-    :param ge: only applies to numbers, requires the field to be "greater than or equal to". The
-      schema will have a ``minimum`` validation keyword
-    :param lt: only applies to numbers, requires the field to be "less than". The schema
-      will have an ``exclusiveMaximum`` validation keyword
-    :param le: only applies to numbers, requires the field to be "less than or equal to". The
-      schema will have a ``maximum`` validation keyword
-    :param min_length: only applies to strings, requires the field to have a minimum length. The
-      schema will have a ``maximum`` validation keyword
-    :param max_length: only applies to strings, requires the field to have a maximum length. The
-      schema will have a ``maxLength`` validation keyword
-    :param regex: only applies to strings, requires the field match agains a regular expression
-      pattern string. The schema will have a ``pattern`` validation keyword
-    :param **extra: any additional keyword arguments will be added as is to the schema
-    """
-
-    __slots__ = (
-        'default',
-        'alias',
-        'title',
-        'description',
-        'gt',
-        'ge',
-        'lt',
-        'le',
-        'min_length',
-        'max_length',
-        'regex',
-        'extra',
-    )
-
-    def __init__(
-        self,
-        default,
-        *,
-        alias: str = None,
-        title: str = None,
-        description: str = None,
-        gt: float = None,
-        ge: float = None,
-        lt: float = None,
-        le: float = None,
-        min_length: int = None,
-        max_length: int = None,
-        regex: str = None,
-        **extra,
-    ):
-        self.default = default
-        self.alias = alias
-        self.title = title
-        self.description = description
-        self.extra = extra
-        self.gt = gt
-        self.ge = ge
-        self.lt = lt
-        self.le = le
-        self.min_length = min_length
-        self.max_length = max_length
-        self.regex = regex
 
 
 _numeric_types = (int, float, Decimal)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -76,7 +76,7 @@ def get_annotation_from_schema(annotation, schema):
             # Is numeric type
             attrs = _numeric_attrs
             kwargs = {'gt': None, 'lt': None, 'ge': None, 'le': None}
-            numeric_type = next(t for t in _numeric_types if issubclass(annotation, t))
+            numeric_type = next(t for t in _numeric_types if issubclass(annotation, t))  # pragma: no branch
             constraint_func = _map_types_const[numeric_type]
         for attr_name in attrs:
             attr = getattr(schema, attr_name, None)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -130,10 +130,8 @@ def get_annotation_from_schema(annotation, schema):
             # Is numeric type
             attrs = _numeric_attrs
             kwargs = {'gt': None, 'lt': None, 'ge': None, 'le': None}
-            for t in _numeric_types:
-                if issubclass(annotation, t):
-                    con = _map_types_const[t]
-                    break
+            n_types = [t for t in _numeric_types if issubclass(annotation, t)]
+            con = _map_types_const[n_types[0]]
         for attr in attrs:
             if hasattr(schema, attr) and getattr(schema, attr) is not None:
                 params_to_set = True

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -8,10 +8,12 @@ from uuid import UUID
 from . import main
 from .fields import Field, Shape
 from .json import pydantic_encoder
+from .schema_class import Schema
 from .types import DSN, UUID1, UUID3, UUID4, UUID5, DirectoryPath, EmailStr, FilePath, Json, NameEmail, UrlStr
 from .utils import clean_docstring, lenient_issubclass
 
 __all__ = [
+    'Schema',
     'schema',
     'model_schema',
     'field_schema',

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -9,7 +9,7 @@ from . import main
 from .fields import Field, Shape
 from .json import pydantic_encoder
 from .types import DSN, UUID1, UUID3, UUID4, UUID5, DirectoryPath, EmailStr, FilePath, Json, NameEmail, UrlStr
-from .utils import clean_docstring
+from .utils import clean_docstring, lenient_issubclass
 
 __all__ = [
     'schema',
@@ -147,32 +147,36 @@ def field_schema(
 
 
 numeric_types = (int, float, Decimal)
-_str_types_attrs = {
-    'max_length': (numeric_types, 'maxLength'),
-    'min_length': (numeric_types, 'minLength'),
-    'regex': (str, 'pattern'),
-}
-_numeric_types_attrs = {
-    'gt': (numeric_types, 'exclusiveMinimum'),
-    'lt': (numeric_types, 'exclusiveMaximum'),
-    'ge': (numeric_types, 'minimum'),
-    'le': (numeric_types, 'maximum'),
-}
+_str_types_attrs = (
+    ('max_length', numeric_types, 'maxLength'),
+    ('min_length', numeric_types, 'minLength'),
+    ('regex', str, 'pattern'),
+)
+
+_numeric_types_attrs = (
+    ('gt', numeric_types, 'exclusiveMinimum'),
+    ('lt', numeric_types, 'exclusiveMaximum'),
+    ('ge', numeric_types, 'minimum'),
+    ('le', numeric_types, 'maximum'),
+)
 
 
 def get_field_schema_validations(field):
-    """Get the JSON Schema validation keywords for a ``field`` with an annotation of
+    """
+    Get the JSON Schema validation keywords for a ``field`` with an annotation of
       a Pydantic ``Schema`` with validation arguments.
     """
     f_schema = {}
-    if isinstance(field.type_, type) and issubclass(field.type_, (str, bytes)):
-        for attr, (t, keyword) in _str_types_attrs.items():
-            if getattr(field._schema, attr) and isinstance(getattr(field._schema, attr), t):
-                f_schema[keyword] = getattr(field._schema, attr)
-    if isinstance(field.type_, type) and issubclass(field.type_, numeric_types) and not issubclass(field.type_, bool):
-        for attr, (t, keyword) in _numeric_types_attrs.items():
-            if getattr(field._schema, attr) and isinstance(getattr(field._schema, attr), t):
-                f_schema[keyword] = getattr(field._schema, attr)
+    if lenient_issubclass(field.type_, (str, bytes)):
+        for attr_name, t, keyword in _str_types_attrs:
+            attr = getattr(field._schema, attr_name, None)
+            if isinstance(attr, t):
+                f_schema[keyword] = attr
+    if lenient_issubclass(field.type_, numeric_types) and not issubclass(field.type_, bool):
+        for attr_name, t, keyword in _numeric_types_attrs:
+            attr = getattr(field._schema, attr_name, None)
+            if isinstance(attr, t):
+                f_schema[keyword] = attr
     if field._schema.extra:
         f_schema.update(field._schema.extra)
     return f_schema
@@ -235,7 +239,7 @@ def get_flat_models_from_field(field: Field) -> Set[Type['main.BaseModel']]:
     flat_models = set()
     if field.sub_fields:
         flat_models |= get_flat_models_from_fields(field.sub_fields)
-    elif isinstance(field.type_, type) and issubclass(field.type_, main.BaseModel):
+    elif lenient_issubclass(field.type_, main.BaseModel):
         flat_models |= get_flat_models_from_model(field.type_)
     return flat_models
 

--- a/pydantic/schema_class.py
+++ b/pydantic/schema_class.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Schema:
+    """
+    Used to provide extra information about a field in a model schema. The parameters will be
+    converted to validations and will add annotations to the generated JSON Schema. Some arguments
+    apply only to number fields (``int``, ``float``, ``Decimal``) and some apply only to ``str``
+
+    :param default: since the Schema is replacing the field’s default, its first argument is used
+      to set the default, use ellipsis (``...``) to indicate the field is required
+    :param alias: the public name of the field
+    :param title: can be any string, used in the schema
+    :param description: can be any string, used in the schema
+    :param gt: only applies to numbers, requires the field to be "greater than". The schema
+      will have an ``exclusiveMinimum`` validation keyword
+    :param ge: only applies to numbers, requires the field to be "greater than or equal to". The
+      schema will have a ``minimum`` validation keyword
+    :param lt: only applies to numbers, requires the field to be "less than". The schema
+      will have an ``exclusiveMaximum`` validation keyword
+    :param le: only applies to numbers, requires the field to be "less than or equal to". The
+      schema will have a ``maximum`` validation keyword
+    :param min_length: only applies to strings, requires the field to have a minimum length. The
+      schema will have a ``maximum`` validation keyword
+    :param max_length: only applies to strings, requires the field to have a maximum length. The
+      schema will have a ``maxLength`` validation keyword
+    :param regex: only applies to strings, requires the field match agains a regular expression
+      pattern string. The schema will have a ``pattern`` validation keyword
+    :param **extra: any additional keyword arguments will be added as is to the schema
+    """
+
+    __slots__ = (
+        'default',
+        'alias',
+        'title',
+        'description',
+        'gt',
+        'ge',
+        'lt',
+        'le',
+        'min_length',
+        'max_length',
+        'regex',
+        'extra',
+    )
+
+    def __init__(
+        self,
+        default,
+        *,
+        alias: str = None,
+        title: str = None,
+        description: str = None,
+        gt: float = None,
+        ge: float = None,
+        lt: float = None,
+        le: float = None,
+        min_length: int = None,
+        max_length: int = None,
+        regex: str = None,
+        **extra,
+    ):
+        self.default = default
+        self.alias = alias
+        self.title = title
+        self.description = description
+        self.extra = extra
+        self.gt = gt
+        self.ge = ge
+        self.lt = lt
+        self.le = le
+        self.min_length = min_length
+        self.max_length = max_length
+        self.regex = regex

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -129,7 +129,7 @@ def display_as_type(v):
     if not isinstance(v, typing_base) and not isinstance(v, type):
         v = type(v)
 
-    if isinstance(v, type) and issubclass(v, Enum):
+    if lenient_issubclass(v, Enum):
         if issubclass(v, int):
             return 'int'
         elif issubclass(v, str):
@@ -201,3 +201,7 @@ def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern:
         ),
         re.IGNORECASE,
     )
+
+
+def lenient_issubclass(cls, class_or_tuple):
+    return isinstance(cls, type) and issubclass(cls, class_or_tuple)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -991,10 +991,10 @@ def test_constraints_schema_validation_raises(kwargs, type_, value):
 
 def test_schema_kwargs():
     class Foo(BaseModel):
-        a: str = Schema('foo', example='bar')
+        a: str = Schema('foo', examples=['bar'])
 
     assert Foo.schema() == {
         'title': 'Foo',
         'type': 'object',
-        'properties': {'a': {'type': 'string', 'title': 'A', 'default': 'foo', 'example': 'bar'}},
+        'properties': {'a': {'type': 'string', 'title': 'A', 'default': 'foo', 'examples': ['bar']}},
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -861,6 +861,7 @@ def test_dict_default():
     'kwargs,type_,expected',
     [
         ({'max_length': 5}, str, {'type': 'string', 'maxLength': 5}),
+        ({'max_length': 5}, constr(max_length=6), {'type': 'string', 'maxLength': 6, 'minLength': 0}),
         ({'min_length': 2}, str, {'type': 'string', 'minLength': 2}),
         ({'max_length': 5}, bytes, {'type': 'string', 'maxLength': 5, 'format': 'binary'}),
         ({'regex': '^foo$'}, str, {'type': 'string', 'pattern': '^foo$'}),
@@ -923,9 +924,11 @@ def test_not_constraints_schema(kwargs, type_, expected):
     'kwargs,type_,value',
     [
         ({'max_length': 5}, str, 'foo'),
+        ({'max_length': 5}, constr(max_length=6), 'foo'),
         ({'min_length': 2}, str, 'foo'),
         ({'max_length': 5}, bytes, b'foo'),
         ({'regex': '^foo$'}, str, 'foo'),
+        ({'max_length': 5}, bool, True),
         ({'gt': 2}, int, 3),
         ({'lt': 5}, int, 3),
         ({'ge': 2}, int, 3),
@@ -984,3 +987,14 @@ def test_constraints_schema_validation_raises(kwargs, type_, value):
 
     with pytest.raises(ValidationError):
         Foo(a=value)
+
+
+def test_schema_kwargs():
+    class Foo(BaseModel):
+        a: str = Schema('foo', example='bar')
+
+    assert Foo.schema() == {
+        'title': 'Foo',
+        'type': 'object',
+        'properties': {'a': {'type': 'string', 'title': 'A', 'default': 'foo', 'example': 'bar'}},
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import pytest
 
-from pydantic.utils import display_as_type, import_string, make_dsn, validate_email
+from pydantic.utils import display_as_type, import_string, lenient_issubclass, make_dsn, validate_email
 
 try:
     import email_validator
@@ -135,3 +135,14 @@ def test_display_as_type_enum_str():
 
     displayed = display_as_type(SubField)
     assert displayed == 'str'
+
+
+def test_lenient_issubclass():
+    class A(str):
+        pass
+
+    assert lenient_issubclass(A, str) is True
+
+
+def test_lenient_issubclass_is_lenient():
+    assert lenient_issubclass('a', 'a') is False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Add additional parameters to Schema for validation and annotation, in a single declaration.

Integrates and uses `constr`, `conint`, `confloat` and `condecimal`. Doesn't change any of the current functionality.

As a result, a current model created as:

```Python
from pydantic import BaseModel, constr, Schema

class Foo(BaseModel):
    a: constr(min_length=2, max_length=10) = Schema('bar')
```

can also be created as:

```Python
from pydantic import BaseModel, Schema

class Foo(BaseModel):
    a: str = Schema('bar', min_length=2, max_length=10)
```

by being able to declare `a` as a pure `str` makes it simpler for some editors to get the hint that the property `a` is a `str` and provide support for it (autocomplete, type error checking, etc).

### Note

The generated JSON Schema will output validation keywords of `minLength` and `maxLength` in this case. 

For numbers validations like `gt` it outputs `exclusiveMinimum`. 

Other option for the parameters would be to use the literal name used in JSON Schema, as `exclusiveMinimum`, but it wouldn't be very "Pythonic". 

And other option would be using JSON Schema names and change them to snake-case, as `exclusive_minimum`.

But I imagine the preferred option is to keep the same parameter names used in the rest of the code, as in `conint`, etc. Otherwise, let me know and I'll change it.

### Specific parameters added to `Schema`

* `description`
* `gt`
* `ge`
* `lt`
* `le`
* `min_length`
* `max_length`
* `regex`

<!-- Please give a short summary of the changes. -->

## Related issue number

I didn't create a specific issue for this. But the changes where discussed here: https://github.com/samuelcolvin/pydantic/issues/291#issuecomment-439056451

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Performance Changes

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:
* before:

```
                                pydantic time=0.775s, success=49.95%
                                pydantic time=0.794s, success=49.95%
                                pydantic time=0.792s, success=49.95%
                                pydantic time=0.773s, success=49.95%
                                pydantic time=0.790s, success=49.95%
                                pydantic best=0.773s, avg=0.785s, stdev=0.010s

                                pydantic best=25.770μs/iter avg=26.155μs/iter stdev=0.332μs/iter
```

* after:

```
                                pydantic time=0.794s, success=49.95%
                                pydantic time=0.801s, success=49.95%
                                pydantic time=0.809s, success=49.95%
                                pydantic time=0.765s, success=49.95%
                                pydantic time=0.797s, success=49.95%
                                pydantic best=0.765s, avg=0.793s, stdev=0.017s

                                pydantic best=25.507μs/iter avg=26.441μs/iter stdev=0.554μs/iter
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
