### PR TITLE
feat: add support for case insensitive env names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.16.0 (2018-XX-XX)
 
 * refactor schema generation to be compatible with JSON Schema and OpenAPI specs, #308 by @tiangolo
 * add ``schema`` to ``schema`` module to generate top-level schemas from base models, #308 by @tiangolo
+* add ``case_insensitive`` option to ``BaseSettings`` ``Config``, #277 by @jasonkuhrt
 
 v0.15.0 (2018-11-18)
 ....................

--- a/docs/examples/settings_case_insensitive.py
+++ b/docs/examples/settings_case_insensitive.py
@@ -5,4 +5,4 @@ class Settings(BaseSettings):
     redis_host = 'localhost'
 
     class Config:
-        case_insensitive = False
+        case_insensitive = True

--- a/docs/examples/settings_case_insensitive.py
+++ b/docs/examples/settings_case_insensitive.py
@@ -1,0 +1,8 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    redis_host = 'localhost'
+
+    class Config:
+        case_insensitive = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -231,7 +231,7 @@ Outputs:
 
 The generated schemas are compliant with the specifications:
 `JSON Schema Core <https://json-schema.org/latest/json-schema-core.html>`__,
-`JSON Schema Validation <https://json-schema.org/latest/json-schema-validation.html>`__ and 
+`JSON Schema Validation <https://json-schema.org/latest/json-schema-validation.html>`__ and
 `OpenAPI <https://github.com/OAI/OpenAPI-Specification>`__.
 
 ``BaseModel.schema`` will return a dict of the schema, while ``BaseModel.schema_json`` will return a JSON string
@@ -458,6 +458,12 @@ Here ``redis_port`` could be modified via ``export MY_PREFIX_REDIS_PORT=6380`` o
 ``export my_api_key=6380``.
 
 Complex types like ``list``, ``set``, ``dict`` and submodels can be set by using JSON environment variables.
+
+Environment variables can be read in a case insensitive manner:
+
+.. literalinclude:: examples/settings_case_insensitive.py
+
+Here ``redis_port`` could be modified via ``export APP_REDIS_HOST``, ``export app_redis_host``, ``export app_REDIS_host``, etc.
 
 Dynamic model creation
 ......................

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -39,17 +39,20 @@ class BaseSettings(BaseModel):
         """
         d = {}
 
-        env_vars = {k.lower(): v for (k, v) in os.environ.items()} if self.__config__.case_insensitive else os.environ
+        if self.__config__.case_insensitive:
+            env_vars = {k.lower(): v for (k, v) in os.environ.items()}
+        else:
+            env_vars = os.environ
 
         for field in self.__fields__.values():
 
-            env_name = field.alias if field.has_alias else self.__config__.env_prefix + field.name.upper()
+            if field.has_alias:
+                env_name = field.alias
+            else:
+                env_name = self.__config__.env_prefix + field.name.upper()
 
-            env_val = (
-                env_vars.get(env_name.lower(), None)
-                if self.__config__.case_insensitive
-                else env_vars.get(env_name, None)
-            )
+            env_name_ = env_name.lower() if self.__config__.case_insensitive else env_name
+            env_val = env_vars.get(env_name_, None)
 
             if env_val:
                 if _complex_field(field):

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -39,19 +39,11 @@ class BaseSettings(BaseModel):
         """
         d = {}
 
-        env_vars = (
-            {k.lower(): v for (k, v) in os.environ.items()}
-            if self.__config__.case_insensitive
-            else os.environ
-        )
+        env_vars = {k.lower(): v for (k, v) in os.environ.items()} if self.__config__.case_insensitive else os.environ
 
         for field in self.__fields__.values():
 
-            env_name = (
-                field.alias
-                if field.has_alias
-                else self.__config__.env_prefix + field.name.upper()
-            )
+            env_name = field.alias if field.has_alias else self.__config__.env_prefix + field.name.upper()
 
             env_val = (
                 env_vars.get(env_name.lower(), None)
@@ -69,7 +61,7 @@ class BaseSettings(BaseModel):
         return d
 
     class Config:
-        env_prefix = 'APP_'
+        env_prefix = "APP_"
         validate_all = True
         ignore_extra = False
         arbitrary_types_allowed = True

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -42,7 +42,7 @@ class BaseSettings(BaseModel):
         if self.__config__.case_insensitive:
             env_vars = {k.lower(): v for (k, v) in os.environ.items()}
         else:
-            env_vars = dict(os.environ)
+            env_vars = os.environ
 
         for field in self.__fields__.values():
             if field.has_alias:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+skip-string-normalization = true
+line-length = 120
+py36 = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,0 @@
-[tool.black]
-skip-string-normalization = true
-line-length = 120
-py36 = true

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -110,3 +110,18 @@ def test_alias_matches_name(env):
     env.set('foobar', 'xxx')
     s = Settings()
     assert s.foobar == 'xxx'
+
+
+def test_case_insensitive(env):
+    class Settings(BaseSettings):
+        foo: str
+        bAR: str
+
+        class Config:
+            case_insensitive = True
+
+    env.set('apP_foO', 'foo')
+    env.set('app_bar', 'bar')
+    s = Settings()
+    assert s.foo == 'foo'
+    assert s.bAR == 'bar'


### PR DESCRIPTION
feat: add support for case insensitive env names


 ## Change Summary

 <!-- Please give a short summary of the changes. -->

 `BaseSettings` can now be configured to read from os.environ in a
 case-insensitive way.

 ## Related issue number

 <!-- Are there any issues opened that will be resolved by merging this change? -->
Arguably will close #277. Doesn't quite meet the exact idea as proposed there, however it achieves the end goal that motivated #277, I think.

 ## Performance Changes

 pydantic cares about performance, if there's any risk performance changed on this PR,
 please run `make benchmark-pydantic` before and after the change:
 * before: **pydantic best=32.086μs/iter avg=33.792μs/iter stdev=1.696μs/iter**
 * after: **pydantic best=31.856μs/iter avg=32.579μs/iter stdev=0.731μs/iter**

 ## Checklist
 
* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
