### PR TITLE
Implement dict_jsonable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.16.0 (2018-XX-XX)
 ....................
 
+* add ``dict_jsonable`` and ``jsonable_encoder``, #317 by @tiangolo
 * refactor schema generation to be compatible with JSON Schema and OpenAPI specs, #308 by @tiangolo
 * add ``schema`` to ``schema`` module to generate top-level schemas from base models, #308 by @tiangolo
 * add ``case_insensitive`` option to ``BaseSettings`` ``Config``, #277 by @jasonkuhrt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -583,6 +583,20 @@ over how non-standard types are encoded to JSON.
 By default timedelta's are encoded as a simple float of total seconds. The ``timedelta_isoformat`` is provided
 as an optional alternative which implements ISO 8601 time diff encoding.
 
+The method ``dict()`` returns a ``dict`` with the value types unchanged. For example, a ``datetime`` will still be
+a ``datetime``, a ``set`` will still be a ``set``, etc.
+
+The method ``json()`` will return the serialised model: it will convert all the value types to JSON compatible and
+then will serialise everything, the return value will be a `str`.
+
+There is an intermediate method ``dict_jsonable()`` for situations where you need something between ``dict()`` and
+``json()``. It will return a ``dict`` (not a ``str``) that you can pass directly to ``json.dumps()`` or any equivalent
+function. All the value types will be converted to JSON compatible values. For example, a ``datetime`` will be converted
+to a ISO date-time string, a ``set`` will be converted to a ``list``, etc.
+
+This is useful for example if you need to pass a ``dict`` to something that will then serialise it to JSON
+or other format before sending it to a NoSQL database or that will be serialized by a web framework afterwards.
+
 Pickle Serialisation
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -9,8 +9,8 @@ __all__ = (
     'pydantic_encoder',
     'custom_pydantic_encoder',
     'timedelta_isoformat',
-    'serializable_encoder',
-    'model_serializable_dict',
+    'jsonable_encoder',
+    'model_dict_jsonable',
 )
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Set, Type, Union
 from .error_wrappers import ErrorWrapper, ValidationError
 from .errors import ConfigError, ExtraError, MissingError
 from .fields import Field, Validator
-from .json import custom_pydantic_encoder, pydantic_encoder
+from .json import custom_pydantic_encoder, model_dict_jsonable, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
 from .types import StrBytes
@@ -212,6 +212,11 @@ class BaseModel(metaclass=MetaModel):
             for k, v in self._iter(by_alias=by_alias)
             if k not in exclude and (not include or k in include)
         }
+
+    def dict_jsonable(
+        self, *, include: Set[str] = None, exclude: Set[str] = set(), by_alias: bool = False
+    ) -> Dict[str, Any]:
+        return model_dict_jsonable(self, include=include, exclude=exclude, by_alias=by_alias)
 
     def _get_key_factory(self, by_alias: bool) -> Callable:
         if by_alias:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -144,3 +144,20 @@ def test_invalid_model_jsonable():
 
     with pytest.raises(TypeError):
         jsonable_encoder(Foo)
+
+
+def test_model_jsonable():
+    class ModelA(BaseModel):
+        x: int
+        y: str
+
+    class Model(BaseModel):
+        a: float
+        b: bytes
+        c: Decimal
+        d: ModelA
+        e: MyEnum
+
+    m = Model(a=10.2, b='foobar', c=10.2, d={'x': 123, 'y': '123'}, e=MyEnum.foo)
+    assert m.dict_jsonable() == {'a': 10.2, 'b': 'foobar', 'c': 10.2, 'd': {'x': 123, 'y': '123'}, 'e': 'bar'}
+    assert m.dict_jsonable(exclude={'b'}) == {'a': 10.2, 'c': 10.2, 'd': {'x': 123, 'y': '123'}, 'e': 'bar'}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import pytest
 
 from pydantic import BaseModel, create_model
-from pydantic.json import jsonable_encoder, model_dict_jsonable, pydantic_encoder, timedelta_isoformat
+from pydantic.json import jsonable_encoder, pydantic_encoder, timedelta_isoformat
 
 
 class MyEnum(Enum):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

This PR implements a `dict_jsonable()` method that returns a `dict` (equivalent to the one returned by `dict()` ) but with all the values converted to JSON serialisable values (like it is done to generate the `str` returned by `json()` ).

The return of `dict_jsonable()` is a `dict` that can be passed to other functions that need something that can be serialised to JSON, like with `json.dumps()`.

For example, NoSQL DB connections or web frameworks.

<!-- Please give a short summary of the changes. -->

## Related issue number

I didn't create an issue with the feature request before the PR, should I?

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Performance Changes

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:

**No performance loss:**

* before:

```
                                pydantic time=1.047s, success=49.95%
                                pydantic time=0.945s, success=49.95%
                                pydantic time=0.943s, success=49.95%
                                pydantic time=0.874s, success=49.95%
                                pydantic time=0.920s, success=49.95%
                                pydantic best=0.874s, avg=0.946s, stdev=0.063s

                                pydantic best=29.143μs/iter avg=31.531μs/iter stdev=2.113μs/iter
```

* after:

```
                                pydantic time=0.871s, success=49.95%
                                pydantic time=0.928s, success=49.95%
                                pydantic time=0.909s, success=49.95%
                                pydantic time=0.941s, success=49.95%
                                pydantic time=0.906s, success=49.95%
                                pydantic best=0.871s, avg=0.911s, stdev=0.026s

                                pydantic best=29.047μs/iter avg=30.370μs/iter stdev=0.881μs/iter
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
