### PR TITLE
Properly set Config in create_model

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -100,17 +100,25 @@ def _extract_validators(namespace):
     return validators
 
 
+def inherit_validators(base_validators, validators):
+    for field, field_validators in base_validators.items():
+        validators.setdefault(field, []).extend(field_validators)
+
+
 class MetaModel(ABCMeta):
     def __new__(mcs, name, bases, namespace):
         fields: Dict[name, Field] = {}
         config = BaseConfig
+        validators = {}
         for base in reversed(bases):
             if issubclass(base, BaseModel) and base != BaseModel:
                 fields.update(base.__fields__)
                 config = inherit_config(base.__config__, config)
+                inherit_validators(base.__validators__, validators)
 
         config = inherit_config(namespace.get('Config'), config)
-        vg = ValidatorGroup(_extract_validators(namespace))
+        inherit_validators(_extract_validators(namespace), validators)
+        vg = ValidatorGroup(validators)
 
         for f in fields.values():
             f.set_config(config)
@@ -402,19 +410,20 @@ def create_model(
         `<name>=(<type>, <default default>)` or `<name>=<default value> eg. `foobar=(str, ...)` or `foobar=123`
     """
     if __base__:
-        fields = deepcopy(__base__.__fields__)
         validators = __base__.__validators__
         if __config__ is not None:
             raise ConfigError('to avoid confusion __config__ and __base__ cannot be used together')
     else:
         __base__ = BaseModel
-        fields = {}
         validators = {}
 
-    config = __config__ or BaseConfig
     vg = ValidatorGroup(validators)
+    fields = {}
+    annotations = {}
 
     for f_name, f_def in field_definitions.items():
+        if f_name.startswith('_'):
+            warnings.warn(f'fields may not start with an underscore, ignoring "{f_name}"', RuntimeWarning)
         if isinstance(f_def, tuple):
             try:
                 f_annotation, f_value = f_def
@@ -426,18 +435,22 @@ def create_model(
                 ) from e
         else:
             f_annotation, f_value = None, f_def
-        if f_name.startswith('_'):
-            warnings.warn(f'fields may not start with an underscore, ignoring "{f_name}"', RuntimeWarning)
-        else:
-            fields[f_name] = Field.infer(
-                name=f_name,
-                value=f_value,
-                annotation=f_annotation,
-                class_validators=vg.get_validators(f_name),
-                config=config,
-            )
 
-    namespace = {'config': config, '__fields__': fields}
+        # f_validators = vg.get_validators(f_name)
+        # if f_validators:
+        #     setattr(f_value, "__validator_config", f_validators)
+        if f_annotation:
+            annotations[f_name] = f_annotation
+        fields[f_name] = f_value
+
+    namespace = {
+        "__annotations__": annotations,
+        "__validators__": vg.validators,
+    }
+    namespace.update(fields)
+    if __config__:
+        namespace["Config"] = __config__
+
     return type(model_name, (__base__,), namespace)
 
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -61,6 +61,17 @@ def test_custom_config():
         model(foo=654)
 
 
+def test_custom_config_extras():
+    class Config(BaseModel.Config):
+        ignore_extra = False
+        allow_extra = False
+
+    model = create_model("FooModel", foo=(int, ...), __config__=Config)
+    assert model(foo=654)
+    with pytest.raises(ValidationError):
+        model(bar=654)
+
+
 def test_inheritance_validators():
     class BarModel(BaseModel):
         @validator('a', check_fields=False)


### PR DESCRIPTION
## Change Summary

Set the Config attribute in create_model, so it is found by the
MetaModel.  Pushes the field and validator configuration into the
metaclass.

## Related issue number

None

## Performance Changes

Not run.

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes
* [ ] No performance deterioration (if applicable)
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`