### PR TITLE
Add section "Based on Pydantic" with FastAPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.16.x (xxxx-xx-xx)
+....................
+* Add "Based on Pydantic" to docs, #323 by @tiangolo
+
 v0.16.1 (2018-12-10)
 ....................
 * fix ``create_model`` to correctly use the passed ``__config__``, #320 by @hugoduncan

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,6 @@
 History
 -------
 
-v0.16.x (xxxx-xx-xx)
-....................
-* Add "Based on Pydantic" to docs, #323 by @tiangolo
-
 v0.16.1 (2018-12-10)
 ....................
 * fix ``create_model`` to correctly use the passed ``__config__``, #320 by @hugoduncan

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -633,34 +633,11 @@ Below are the results of crude benchmarks comparing *pydantic* to other validati
 (See `the benchmarks code <https://github.com/samuelcolvin/pydantic/tree/master/benchmarks>`_
 for more details on the test case. Feel free to submit more benchmarks or improve an existing one.)
 
-Based on Pydantic
------------------
+Third-Party libraries
+---------------------
 
-FastAPI
-.......
+* `FastAPI <https://github.com/tiangolo/fastapi>`_ is a high performance API framework, easy to learn, fast to code and ready for production, based on Pydantic and Starlette.
 
-Source code: `https://github.com/tiangolo/fastapi <https://github.com/tiangolo/fastapi>`_
-
-Documentation: `https://fastapi.tiangolo.com <https://fastapi.tiangolo.com/>`_
-
-**FastAPI** framework: high performance, easy to learn, fast to code, ready for production, based on Pydantic and Starlette.
-
-* **Fast**: Very high performance, on par with **NodeJS** and **Go** (thanks to Starlette and Pydantic).
-* **Intuitive**: Great editor support. **Completion everywhere**. Less time debugging.
-* **Easy**: Designed to be **easy to use** and learn. Less time reading docs.
-* **Short**: Minimize code duplication. Multiple features from each parameter declaration. **Less bugs**.
-* **Robust**: Get production-ready code. With **automatic interactive documentation**.
-* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: **OpenAPI** and **JSON Schema**.
-
-Use the same **Python 3.6+** types (and Pydantic models) to declare parameters, request bodies, etc.
-
-From these standard Python type declarations get:
-
-* Editor support.
-* Data conversion.
-* Data validation.
-* Documentation (as OpenAPI and JSON Schema annotations).
-* Automatic interactive documentation user interfaces included (based on **Swagger UI** and **ReDoc**).
 
 .. include:: .TMP_HISTORY.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -633,6 +633,35 @@ Below are the results of crude benchmarks comparing *pydantic* to other validati
 (See `the benchmarks code <https://github.com/samuelcolvin/pydantic/tree/master/benchmarks>`_
 for more details on the test case. Feel free to submit more benchmarks or improve an existing one.)
 
+Based on Pydantic
+-----------------
+
+FastAPI
+.......
+
+Source code: `https://github.com/tiangolo/fastapi <https://github.com/tiangolo/fastapi>`_
+
+Documentation: `https://fastapi.tiangolo.com <https://fastapi.tiangolo.com/>`_
+
+**FastAPI** framework: high performance, easy to learn, fast to code, ready for production, based on Pydantic and Starlette.
+
+* **Fast**: Very high performance, on par with **NodeJS** and **Go** (thanks to Starlette and Pydantic).
+* **Intuitive**: Great editor support. **Completion everywhere**. Less time debugging.
+* **Easy**: Designed to be **easy to use** and learn. Less time reading docs.
+* **Short**: Minimize code duplication. Multiple features from each parameter declaration. **Less bugs**.
+* **Robust**: Get production-ready code. With **automatic interactive documentation**.
+* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: **OpenAPI** and **JSON Schema**.
+
+Use the same **Python 3.6+** types (and Pydantic models) to declare parameters, request bodies, etc.
+
+From these standard Python type declarations get:
+
+* Editor support.
+* Data conversion.
+* Data validation.
+* Documentation (as OpenAPI and JSON Schema annotations).
+* Automatic interactive documentation user interfaces included (based on **Swagger UI** and **ReDoc**).
+
 .. include:: .TMP_HISTORY.rst
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Add section "Based on Pydantic" to docs. Including [FastAPI](https://github.com/tiangolo/fastapi), an API web framework based on Pydantic.

---

Let me know if it doesn't seem sensible to have a section "Based on Pydantic".

Also, let me know if I'm being too verbose and you would prefer just a list of links with each third party (just FastAPI for now).

<!-- Please give a short summary of the changes. -->

## Related issue number

No relevant issue.

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Performance Changes

Just docs.

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:
* before: **?**
* after: **?**

## Checklist

* [n/a] Unit tests for the changes exist
* [n/a] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [n/a] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
