### PR TITLE
Fix schema for timedelta as number, instead of str

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.x.x (xxx-xx-xx)
+..................
+* fix schema for ``timedelta`` as number, by @tiangolo
+
 v0.16.1 (2018-12-10)
 ....................
 * fix ``create_model`` to correctly use the passed ``__config__``, #320 by @hugoduncan

--- a/docs/schema_mapping.py
+++ b/docs/schema_mapping.py
@@ -228,9 +228,9 @@ table = [
     ],
     [
         'timedelta',
-        'string',
+        'number',
         '{"format": "time-delta"}',
-        'Pydantic standard "format" extension',
+        'Difference in seconds (a ``float``), with Pydantic standard "format" extension',
         'Suggested in JSON Schema repository\'s issues by maintainer.'
     ],
     [

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -569,7 +569,7 @@ field_class_to_schema_enum_disabled = (
     (datetime, {'type': 'string', 'format': 'date-time'}),
     (date, {'type': 'string', 'format': 'date'}),
     (time, {'type': 'string', 'format': 'time'}),
-    (timedelta, {'type': 'string', 'format': 'time-delta'}),
+    (timedelta, {'type': 'number', 'format': 'time-delta'}),
     (Json, {'type': 'string', 'format': 'json-string'}),
 )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -371,19 +371,22 @@ def test_list_union_dict(field_type, expected_schema):
 
 
 @pytest.mark.parametrize(
-    'field_type,expected_schema', [(datetime, 'date-time'), (date, 'date'), (time, 'time'), (timedelta, 'time-delta')]
+    'field_type,expected_schema',
+    [
+        (datetime, {'type': 'string', 'format': 'date-time'}),
+        (date, {'type': 'string', 'format': 'date'}),
+        (time, {'type': 'string', 'format': 'time'}),
+        (timedelta, {'type': 'number', 'format': 'time-delta'}),
+    ],
 )
 def test_date_types(field_type, expected_schema):
     class Model(BaseModel):
         a: field_type
 
-    base_schema = {
-        'title': 'Model',
-        'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'string', 'format': ''}},
-        'required': ['a'],
-    }
-    base_schema['properties']['a']['format'] = expected_schema
+    attribute_schema = {'title': 'A'}
+    attribute_schema.update(expected_schema)
+
+    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': attribute_schema}, 'required': ['a']}
 
     assert Model.schema() == base_schema
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Currently, the generated schema for `datetime.timedelta` is as `string`.

But by default, Pydantic will convert it to a `float` with the difference in seconds.

(Bug created by me in the JSON Schema compatibility PR).

This PR fixes that and makes the schema for `timedelta` be a `number` by default, which corresponds to the actual behavior.

<!-- Please give a short summary of the changes. -->

## Related issue number

I didn't create one.

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Performance Changes

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:
* before: **?**
* after: **?**

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
