### PR TITLE
Fix schema generation for fields annotated as `: dict`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ v0.17.0 (unreleased)
 * prevent validators being called repeatedly after inheritance, #327 by @samuelcolvin
 * prevent duplicate validator check in ipython, fix #312 by @samuelcolvin
 * add "Using Pydantic" section to docs, #323 by @tiangolo & #326 by @samuelcolvin
+* fix schema generation for fields annotated as ``: dict``, #330 by @nkonin
 
 v0.16.1 (2018-12-10)
 ....................

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -558,7 +558,7 @@ field_class_to_schema_enum_enabled = (
     (UUID5, {'type': 'string', 'format': 'uuid5'}),
     (UUID, {'type': 'string', 'format': 'uuid'}),
     (NameEmail, {'type': 'string', 'format': 'name-email'}),
-    (dict, {'type': 'object'})
+    (dict, {'type': 'object'}),
 )
 
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -558,6 +558,7 @@ field_class_to_schema_enum_enabled = (
     (UUID5, {'type': 'string', 'format': 'uuid5'}),
     (UUID, {'type': 'string', 'format': 'uuid'}),
     (NameEmail, {'type': 'string', 'format': 'name-email'}),
+    (dict, {'type': 'object'})
 )
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -308,6 +308,18 @@ def test_bool():
     }
 
 
+def test_dict():
+    class Model(BaseModel):
+        a: dict
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'object'}},
+        'required': ['a'],
+    }
+
+
 class Foo(BaseModel):
     a: float
 


### PR DESCRIPTION

## Change Summary

Fix schema generation for fields annotated as `: dict`

## Related issue number

#330 

## Performance Changes

Not run

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes (it's already in docs)
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated