### PR TITLE
Restore environment variable override behaviour

### DIFF
--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -30,7 +30,7 @@ class BaseSettings(BaseModel):
     """
 
     def __init__(self, **values):
-        values = {**self._substitute_environ(), **values}
+        values = {**values, **self._substitute_environ()}
         super().__init__(**values)
 
     def _substitute_environ(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,7 +19,7 @@ def test_sub_env(env):
 def test_sub_env_override(env):
     env.set('APP_APPLE', 'hello')
     s = SimpleSettings(apple='goodbye')
-    assert s.apple == 'goodbye'
+    assert s.apple == 'hello'
 
 
 def test_sub_env_missing():


### PR DESCRIPTION
## Change Summary

Sometime after v0.14 a syntatic change was made to how env vars
and passed config settings were merged which inverted the precedence
behaviour and prevented env vars from overriding config settings.
This commit restores the original precedence order. Without this change,
the value of an env var is only used for a setting which is not
specified as a parameter to the `BaseSettings` constructor.

This commit also changes the relevant test behaviour, to make it expect
the env var rather than the passed parameter.

## Related issue number

#340

## Performance Changes

N/A

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
