### PR TITLE
don't call validators on keys of dictionaries

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.18.0 (unreleased)
+....................
+* **breaking change**: don't call validators on keys of dictionaries, #254 by @samuelcolvin
+
 v0.17.0 (2018-12-27)
 ....................
 * fix schema for ``timedelta`` as number, #325 by @tiangolo

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,6 +170,13 @@ A few things to note on validators:
   - If validation fails on another field (or that field is missing) it will not be included in ``values``, hence
     ``if 'password1' in values and ...`` in this example.
 
+
+.. note::
+
+   From ``v0.18`` onwards validators are not called on keys of dictionaries. If you wish to validate keys,
+   User ``whole`` (see below).
+
+
 Pre and Whole Validators
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,9 +1,10 @@
 # flake8: noqa
+from .class_validators import validator
 from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
 from .fields import Required
-from .main import BaseConfig, BaseModel, create_model, validate_model, validator
+from .main import BaseConfig, BaseModel, create_model, validate_model
 from .parse import Protocol
 from .types import *
 from .version import VERSION

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -1,0 +1,141 @@
+import inspect
+from dataclasses import dataclass
+from enum import IntEnum
+from itertools import chain
+from types import FunctionType
+from typing import Callable, Dict
+
+from .errors import ConfigError
+from .utils import in_ipython
+
+
+class ValidatorSignature(IntEnum):
+    JUST_VALUE = 1
+    VALUE_KWARGS = 2
+    CLS_JUST_VALUE = 3
+    CLS_VALUE_KWARGS = 4
+
+
+@dataclass
+class Validator:
+    func: Callable
+    pre: bool
+    whole: bool
+    always: bool
+    check_fields: bool
+
+
+_FUNCS = set()
+
+
+def validator(*fields, pre: bool = False, whole: bool = False, always: bool = False, check_fields: bool = True):
+    """
+    Decorate methods on the class indicating that they should be used to validate fields
+    :param fields: which field(s) the method should be called on
+    :param pre: whether or not this validator should be called before the standard validators (else after)
+    :param whole: for complex objects (sets, lists etc.) whether to validate individual elements or the whole object
+    :param always: whether this method and other validators should be called even if the value is missing
+    :param check_fields: whether to check that the fields actually exist on the model
+    """
+    if not fields:
+        raise ConfigError('validator with no fields specified')
+    elif isinstance(fields[0], FunctionType):
+        raise ConfigError(
+            "validators should be used with fields and keyword arguments, not bare. "
+            "E.g. usage should be `@validator('<field_name>', ...)`"
+        )
+
+    def dec(f):
+        # avoid validators with duplicated names since without this validators can be overwritten silently
+        # which generally isn't the intended behaviour, don't run in ipython - see #312
+        if not in_ipython():  # pragma: no branch
+            ref = f.__module__ + '.' + f.__qualname__
+            if ref in _FUNCS:
+                raise ConfigError(f'duplicate validator function "{ref}"')
+            _FUNCS.add(ref)
+        f_cls = classmethod(f)
+        f_cls.__validator_config = fields, Validator(f, pre, whole, always, check_fields)
+        return f_cls
+
+    return dec
+
+
+class ValidatorGroup:
+    def __init__(self, validators):
+        self.validators: Dict[str, Validator] = validators
+        self.used_validators = {'*'}
+
+    def get_validators(self, name):
+        self.used_validators.add(name)
+        specific_validators = self.validators.get(name)
+        wildcard_validators = self.validators.get('*')
+        if specific_validators or wildcard_validators:
+            validators = (specific_validators or []) + (wildcard_validators or [])
+            return {v.func.__name__: v for v in validators}
+
+    def check_for_unused(self):
+        unused_validators = set(
+            chain(
+                *[
+                    (v.func.__name__ for v in self.validators[f] if v.check_fields)
+                    for f in (self.validators.keys() - self.used_validators)
+                ]
+            )
+        )
+        if unused_validators:
+            fn = ', '.join(unused_validators)
+            raise ConfigError(
+                f"Validators defined with incorrect fields: {fn} "
+                f"(use check_fields=False if you're inheriting from the model and intended this)"
+            )
+
+
+def extract_validators(namespace):
+    validators = {}
+    for var_name, value in namespace.items():
+        validator_config = getattr(value, '__validator_config', None)
+        if validator_config:
+            fields, v = validator_config
+            for field in fields:
+                if field in validators:
+                    validators[field].append(v)
+                else:
+                    validators[field] = [v]
+    return validators
+
+
+def inherit_validators(base_validators, validators):
+    for field, field_validators in base_validators.items():
+        if field not in validators:
+            validators[field] = []
+        validators[field] += field_validators
+    return validators
+
+
+def get_validator_signature(validator):
+    signature = inspect.signature(validator)
+
+    # bind here will raise a TypeError so:
+    # 1. we can deal with it before validation begins
+    # 2. (more importantly) it doesn't get confused with a TypeError when executing the validator
+    try:
+        if 'cls' in signature._parameters:
+            if len(signature.parameters) == 2:
+                signature.bind(object(), 1)
+                return ValidatorSignature.CLS_JUST_VALUE
+            else:
+                signature.bind(object(), 1, values=2, config=3, field=4)
+                return ValidatorSignature.CLS_VALUE_KWARGS
+        else:
+            if len(signature.parameters) == 1:
+                signature.bind(1)
+                return ValidatorSignature.JUST_VALUE
+            else:
+                signature.bind(1, values=2, config=3, field=4)
+                return ValidatorSignature.VALUE_KWARGS
+    except TypeError as e:
+        raise ConfigError(
+            f'Invalid signature for validator {validator}: {signature}, should be: '
+            f'(value) or (value, *, values, config, field) or for class validators '
+            f'(cls, value) or (cls, value, *, values, config, field)'
+        ) from e

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -3,19 +3,19 @@ import warnings
 from abc import ABCMeta
 from copy import deepcopy
 from functools import partial
-from itertools import chain
 from pathlib import Path
 from types import FunctionType
 from typing import Any, Callable, ClassVar, Dict, Set, Type, Union
 
+from .class_validators import ValidatorGroup, extract_validators, inherit_validators
 from .error_wrappers import ErrorWrapper, ValidationError
 from .errors import ConfigError, ExtraError, MissingError
-from .fields import Field, Validator
+from .fields import Field
 from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
 from .types import StrBytes
-from .utils import in_ipython, truncate, validate_field_name
+from .utils import truncate, validate_field_name
 from .validators import dict_validator
 
 
@@ -57,58 +57,6 @@ def inherit_config(self_config: Type, parent_config: Type[BaseConfig]) -> Type[B
 TYPE_BLACKLIST = FunctionType, property, type, classmethod, staticmethod
 
 
-class ValidatorGroup:
-    def __init__(self, validators):
-        self.validators: Dict[str, Validator] = validators
-        self.used_validators = {'*'}
-
-    def get_validators(self, name):
-        self.used_validators.add(name)
-        specific_validators = self.validators.get(name)
-        wildcard_validators = self.validators.get('*')
-        if specific_validators or wildcard_validators:
-            validators = (specific_validators or []) + (wildcard_validators or [])
-            return {v.func.__name__: v for v in validators}
-
-    def check_for_unused(self):
-        unused_validators = set(
-            chain(
-                *[
-                    (v.func.__name__ for v in self.validators[f] if v.check_fields)
-                    for f in (self.validators.keys() - self.used_validators)
-                ]
-            )
-        )
-        if unused_validators:
-            fn = ', '.join(unused_validators)
-            raise ConfigError(
-                f"Validators defined with incorrect fields: {fn} "
-                f"(use check_fields=False if you're inheriting from the model and intended this)"
-            )
-
-
-def _extract_validators(namespace):
-    validators = {}
-    for var_name, value in namespace.items():
-        validator_config = getattr(value, '__validator_config', None)
-        if validator_config:
-            fields, v = validator_config
-            for field in fields:
-                if field in validators:
-                    validators[field].append(v)
-                else:
-                    validators[field] = [v]
-    return validators
-
-
-def inherit_validators(base_validators, validators):
-    for field, field_validators in base_validators.items():
-        if field not in validators:
-            validators[field] = []
-        validators[field] += field_validators
-    return validators
-
-
 class MetaModel(ABCMeta):
     def __new__(mcs, name, bases, namespace):
         fields: Dict[name, Field] = {}
@@ -121,7 +69,7 @@ class MetaModel(ABCMeta):
                 validators = inherit_validators(base.__validators__, validators)
 
         config = inherit_config(namespace.get('Config'), config)
-        validators = inherit_validators(_extract_validators(namespace), validators)
+        validators = inherit_validators(extract_validators(namespace), validators)
         vg = ValidatorGroup(validators)
 
         for f in fields.values():
@@ -448,41 +396,6 @@ def create_model(model_name: str, *, __config__: Type = None, __base__: Type[Bas
         namespace['Config'] = inherit_config(__config__, BaseConfig)
 
     return type(model_name, (__base__,), namespace)
-
-
-_FUNCS = set()
-
-
-def validator(*fields, pre: bool = False, whole: bool = False, always: bool = False, check_fields: bool = True):
-    """
-    Decorate methods on the class indicating that they should be used to validate fields
-    :param fields: which field(s) the method should be called on
-    :param pre: whether or not this validator should be called before the standard validators (else after)
-    :param whole: for complex objects (sets, lists etc.) whether to validate individual elements or the whole object
-    :param always: whether this method and other validators should be called even if the value is missing
-    :param check_fields: whether to check that the fields actually exist on the model
-    """
-    if not fields:
-        raise ConfigError('validator with no fields specified')
-    elif isinstance(fields[0], FunctionType):
-        raise ConfigError(
-            "validators should be used with fields and keyword arguments, not bare. "
-            "E.g. usage should be `@validator('<field_name>', ...)`"
-        )
-
-    def dec(f):
-        # avoid validators with duplicated names since without this validators can be overwritten silently
-        # which generally isn't the intended behaviour, don't run in ipython - see #312
-        if not in_ipython():  # pragma: no branch
-            ref = f.__module__ + '.' + f.__qualname__
-            if ref in _FUNCS:
-                raise ConfigError(f'duplicate validator function "{ref}"')
-            _FUNCS.add(ref)
-        f_cls = classmethod(f)
-        f_cls.__validator_config = fields, Validator(f, pre, whole, always, check_fields)
-        return f_cls
-
-    return dec
 
 
 def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (ignore complexity)

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.17.1a1')
+VERSION = StrictVersion('0.18a1')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 
 import pytest
 
@@ -456,3 +456,25 @@ def test_inheritance_new():
             return v + 5
 
     assert Child(a=0).a == 6
+
+
+def test_no_key_validation():
+    class Model(BaseModel):
+        foobar: Dict[int, int]
+
+        @validator('foobar')
+        def check_foobar(cls, v):
+            return v + 1
+
+    assert Model(foobar={1: 1}).foobar == {1: 2}
+
+
+def test_key_validation_whole():
+    class Model(BaseModel):
+        foobar: Dict[int, int]
+
+        @validator('foobar', whole=True)
+        def check_foobar(cls, value):
+            return {k + 1: v + 1 for k, v in value.items()}
+
+    assert Model(foobar={1: 1}).foobar == {2: 2}


### PR DESCRIPTION
## Change Summary

don't call validators on keys of dictionaries.

## Related issue number

fix #254


## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [ ] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
