### PR TITLE
allow validate_always with default=None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 v0.18.0 (unreleased)
 ....................
 * **breaking change**: don't call validators on keys of dictionaries, #254 by @samuelcolvin
+* Fix validators with ``always=True`` when the default is ``None`` or the type is optional, also prevent
+  ``whole`` validators being called for sub-fields, fix #132 by @samuelcolvin
 
 v0.17.0 (2018-12-27)
 ....................

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -42,6 +42,11 @@ class NoneIsNotAllowedError(PydanticTypeError):
     msg_template = 'none is not an allow value'
 
 
+class NoneIsAllowedError(PydanticTypeError):
+    code = 'none.allowed'
+    msg_template = 'value is not none'
+
+
 class BytesError(PydanticTypeError):
     msg_template = 'byte type expected'
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -512,6 +512,7 @@ def field_singleton_sub_fields_schema(
     """
     ref_prefix = ref_prefix or default_prefix
     definitions = {}
+    sub_fields = [sf for sf in sub_fields if sf.include_in_schema()]
     if len(sub_fields) == 1:
         return field_type_schema(
             sub_fields[0],

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -20,6 +20,11 @@ def not_none_validator(v):
     return v
 
 
+def is_none_validator(v):
+    if v is not None:
+        raise errors.NoneIsAllowedError()
+
+
 def str_validator(v) -> str:
     if isinstance(v, (str, NoneType)):
         return v
@@ -232,6 +237,7 @@ _VALIDATORS = [
     (bool, [bool_validator]),
     (int, [int_validator]),
     (float, [float_validator]),
+    (NoneType, [is_none_validator]),
     (Path, [path_validator]),
     (datetime, [parse_datetime]),
     (date, [parse_date]),

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -590,3 +590,20 @@ def test_get_validator():
             x: CustomClass
 
     assert Model(x=42).x == 84
+
+
+def test_multiple_errors():
+    class Model(BaseModel):
+        a: Union[None, int, float, Decimal]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='foobar')
+
+    assert exc_info.value.errors() == [
+        {'loc': ('a',), 'msg': 'value is not none', 'type': 'type_error.none.allowed'},
+        {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('a',), 'msg': 'value is not a valid float', 'type': 'type_error.float'},
+        {'loc': ('a',), 'msg': 'value is not a valid decimal', 'type': 'type_error.decimal'},
+    ]
+    assert Model().a is None
+    assert Model(a=None).a is None

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -40,7 +40,6 @@ def test_str_bytes_none():
 
     m = Model(v=None)
     assert m.v is None
-    assert 'not_none_validator' not in [v[1].__qualname__ for v in m.fields['v'].sub_fields[0].validators]
 
 
 def test_union_int_str():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict, List, Optional
 
 import pytest
 
@@ -478,3 +479,60 @@ def test_key_validation_whole():
             return {k + 1: v + 1 for k, v in value.items()}
 
     assert Model(foobar={1: 1}).foobar == {2: 2}
+
+
+def test_validator_always_optional():
+    check_calls = 0
+
+    class Model(BaseModel):
+        a: Optional[str] = None
+
+        @validator('a', pre=True, always=True)
+        def check_a(cls, v):
+            nonlocal check_calls
+            check_calls += 1
+            return v or 'default value'
+
+    assert Model(a='y').a == 'y'
+    assert check_calls == 1
+    assert Model().a == 'default value'
+    assert check_calls == 2
+
+
+def test_validator_always_post():
+    check_calls = 0
+
+    class Model(BaseModel):
+        a: str = None
+
+        @validator('a', always=True)
+        def check_a(cls, v):
+            nonlocal check_calls
+            check_calls += 1
+            return v
+
+    assert Model(a='y').a == 'y'
+    assert check_calls == 1
+    with pytest.raises(ValidationError):
+        Model()
+    # assert check_calls == 1  # check_a comes after allow_none so check_a is never called
+
+
+def test_datetime_validator():
+    check_calls = 0
+
+    class Model(BaseModel):
+        d: datetime = None
+
+        @validator('d', pre=True, always=True)
+        def check_d(cls, v):
+            nonlocal check_calls
+            check_calls += 1
+            return v or datetime(2032, 1, 1)
+
+    assert Model(d='2023-01-01T00:00:00').d == datetime(2023, 1, 1)
+    assert check_calls == 1
+    assert Model().d == datetime(2032, 1, 1)
+    assert check_calls == 2
+    assert Model(d=datetime(2023, 1, 1)).d == datetime(2023, 1, 1)
+    assert check_calls == 3

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -521,7 +521,7 @@ def test_validator_always_post_optional():
             return v or 'default value'
 
     assert Model(a='y').a == 'y'
-    assert Model().a is None
+    assert Model().a == 'default value'
 
 
 def test_datetime_validator():


### PR DESCRIPTION
## Change Summary

This should allow `always=True` to work with `None` as a default.

## Related issue number

fix #132, replace #118

## Performance Changes

pydantic cares about performance, if there's any risk performance changed on this PR, 
please run `make benchmark-pydantic` before and after the change:
* before: **29.506μs/iter**
* after: **29.831μs/iter**

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes
* [x] No performance deterioration (if applicable)
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * if you're not a regular contributer please include your github username `@whatever`
