### PR TITLE
support postponed annotations and ForwardRef in python 3.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ v0.18.0 (unreleased)
 * fix ``ignore_extra=False`` and ``allow_population_by_alias=True``, fix #257 by @samuelcolvin
 * **breaking change**: Set ``BaseConfig`` attributes ``min_anystr_length`` and ``max_anystr_length`` to
     ``None`` by default, fix #349 in #350, by @tiangolo
+* add support for postponed annotations, #348 by @samuelcolvin
 
 v0.17.0 (2018-12-27)
 ....................

--- a/docs/examples/forward_ref.py
+++ b/docs/examples/forward_ref.py
@@ -1,0 +1,15 @@
+from typing import ForwardRef
+from pydantic import BaseModel
+
+Foo = ForwardRef('Foo')
+
+class Foo(BaseModel):
+    a: int = 123
+    b: Foo = None
+
+Foo.update_forward_refs()
+
+print(Foo())
+#> Foo a=123 b=None
+print(Foo(b={'a': '321'}))
+#> Foo a=123 b=<Foo a=321 b=None>

--- a/docs/examples/postponed_annotations.py
+++ b/docs/examples/postponed_annotations.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+from typing import List
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    a: List[int]
+
+print(Model(a=('1', 2, 3)))
+#> Model a=[1, 2, 3]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,9 +54,9 @@ So *pydantic* uses some cool new language feature, but why should I actually go 
     :ref:`mypy <usage_mypy>` and your intuition should all work properly with your validated data.
 
 **dual use**
-    *pydantic's* :ref:`BaseSettings <settings>` class allows it to be used in both a "validate this request data" context
-    and "load my system settings" context. The main difference being that system settings can have defaults changed
-    by environment variables and more complex objects like DSNs and python objects are often required.
+    *pydantic's* :ref:`BaseSettings <settings>` class allows it to be used in both a "validate this request data"
+    context and "load my system settings" context. The main difference being that system settings can have defaults
+    changed by environment variables and more complex objects like DSNs and python objects are often required.
 
 **fast**
     In :ref:`benchmarks <benchmarks_tag>` *pydantic* is faster than all other tested libraries.
@@ -261,8 +261,8 @@ and reference.
 "sub-models" with modifications (via the ``Schema`` class) like a custom title, description or default value,
 are recursively included instead of referenced.
 
-The ``description`` for models is taken from the docstring of the class or the argument ``description`` to the ``Schema``
-class.
+The ``description`` for models is taken from the docstring of the class or the argument ``description`` to
+the ``Schema`` class.
 
 Optionally the ``Schema`` class can be used to provide extra information about the field and validations, arguments:
 
@@ -316,7 +316,8 @@ Outputs:
 
 .. literalinclude:: examples/schema2.json
 
-You can customize the generated ``$ref`` JSON location, the definitions will still be in the key ``definitions`` and you can still get them from there, but the references will point to your defined prefix instead of the default.
+You can customize the generated ``$ref`` JSON location, the definitions will still be in the key ``definitions`` and
+you can still get them from there, but the references will point to your defined prefix instead of the default.
 
 This is useful if you need to extend or modify JSON Schema default definitions location, e.g. with OpenAPI:
 
@@ -651,6 +652,30 @@ Pydantic models can be used alongside Python's
 `Abstract Base Classes <https://docs.python.org/3/library/abc.html>`_ (ABCs).
 
 .. literalinclude:: examples/ex_abc.py
+
+(This script is complete, it should run "as is")
+
+Postponed Annotations
+.....................
+
+.. note::
+
+   Both postponed annotations via the future import and ``ForwardRef`` require python 3.7+.
+
+With globally postponed annotations *pydantic* should "just work".
+
+.. literalinclude:: examples/postponed_annotations.py
+
+(This script is complete, it should run "as is")
+
+Internally *pydantic*  will call a method similar to ``typing.get_type_hints`` to resolve annotations.
+
+To make use of ``ForwardRef`` you may need to call ``Model.update_forward_refs()`` after creating the model,
+this is because in the example below ``Foo`` doesn't exist before it has been created (obviously) so ``ForwardRef``
+can't initially be resolved. You have to wait until after ``Foo`` is created, then call ``update_forward_refs``
+to properly set types before the model can be used.
+
+.. literalinclude:: examples/forward_ref.py
 
 (This script is complete, it should run "as is")
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -6,7 +6,7 @@ from . import errors as errors_
 from .class_validators import Validator, ValidatorSignature, get_validator_signature
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
-from .utils import display_as_type, lenient_issubclass, list_like
+from .utils import ForwardRef, display_as_type, lenient_issubclass, list_like
 from .validators import NoneType, dict_validator, find_validators, is_none_validator
 
 Required: Any = Ellipsis
@@ -117,6 +117,10 @@ class Field:
 
         if self.type_ is None:
             raise errors_.ConfigError(f'unable to infer type for attribute "{self.name}"')
+
+        if type(self.type_) == ForwardRef:
+            # self.type_ is currently a ForwardRef and there's nothing we can do now, user will need to call
+            return
 
         self.validate_always: bool = (
             getattr(self.type_, 'validate_always', False) or any(v.always for v in self.class_validators.values())

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -119,7 +119,8 @@ class Field:
             raise errors_.ConfigError(f'unable to infer type for attribute "{self.name}"')
 
         if type(self.type_) == ForwardRef:
-            # self.type_ is currently a ForwardRef and there's nothing we can do now, user will need to call
+            # self.type_ is currently a ForwardRef and there's nothing we can do now,
+            # user will need to call model.update_forward_refs()
             return
 
         self.validate_always: bool = (

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -329,7 +329,7 @@ class BaseModel(metaclass=MetaModel):
     @classmethod
     def update_forward_refs(cls, **localns):
         """
-        Try to update ForwardRefs on fields based on this Model and globalns.
+        Try to update ForwardRefs on fields based on this Model, globalns and localns.
         """
         globalns = sys.modules[cls.__module__].__dict__
         globalns.setdefault(cls.__name__, cls)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -424,10 +424,11 @@ def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (igno
     check_extra = (not model.__config__.ignore_extra) or model.__config__.allow_extra
 
     for name, field in model.__fields__.items():
-        debug(type(field.type_))
         if type(field.type_) == ForwardRef:
-            raise ConfigError(f"field {field.name} not yet prepared and type is still a ForwardRef, "
-                              f"you'll need to call update_forward_refs")
+            raise ConfigError(
+                f"field {field.name} not yet prepared and type is still a ForwardRef, "
+                f"you'll need to call update_forward_refs"
+            )
 
         value = input_data.get(field.alias, _missing)
         using_name = False

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,11 +1,12 @@
 import json
+import sys
 import warnings
 from abc import ABCMeta
 from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from types import FunctionType
-from typing import Any, Callable, ClassVar, Dict, Set, Type, Union
+from typing import Any, Callable, ClassVar, Dict, Set, Type, Union, get_type_hints
 
 from .class_validators import ValidatorGroup, extract_validators, inherit_validators
 from .error_wrappers import ErrorWrapper, ValidationError
@@ -81,6 +82,12 @@ class MetaModel(ABCMeta):
                 f.prepare()
 
         annotations = namespace.get('__annotations__', {})
+        if sys.version_info >= (3, 7):
+            annotations_eval = get_type_hints(super().__new__(mcs, name, bases, namespace))
+            # use this rather than just annotations_eval so annotations of parent classes are not included
+            # in annotations here.
+            annotations = {k: annotations_eval[k] for k in annotations.keys()}
+
         class_vars = set()
         # annotation only fields need to come first in fields
         for ann_name, ann_type in annotations.items():

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -414,7 +414,7 @@ def create_model(model_name: str, *, __config__: Type = None, __base__: Type[Bas
     return type(model_name, (__base__,), namespace)
 
 
-def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (ignore complexity)
+def validate_model(model: BaseModel, input_data: dict, raise_exc=True):  # noqa: C901 (ignore complexity)
     """
     validate data against a model.
     """
@@ -427,7 +427,7 @@ def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (igno
         if type(field.type_) == ForwardRef:
             raise ConfigError(
                 f"field {field.name} not yet prepared and type is still a ForwardRef, "
-                f"you'll need to call update_forward_refs"
+                f"you'll need to call {model.__class__.__name__}.update_forward_refs()"
             )
 
         value = input_data.get(field.alias, _missing)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -338,11 +338,7 @@ class BaseModel(metaclass=MetaModel):
         for f in cls.__fields__.values():
             if type(f.type_) == ForwardRef:
                 f.type_ = f.type_._evaluate(None, context)
-
-            if type(f.type_) != ForwardRef:
                 f.prepare()
-            else:
-                raise NameError(f'unable to evaluate ForwardRef for field {f.name}, type: {f.type_.__name__}')
 
     def __iter__(self):
         """

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     from typing import _Final as typing_base
 
+try:
+    from typing import ForwardRef
+except ImportError:
+    # python 3.6
+    ForwardRef = None
 
 PRETTY_REGEX = re.compile(r'([\w ]*?) *<(.*)> *')
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -235,7 +235,7 @@ def resolve_annotations(raw_annotations, module):
         base_globals = sys.modules[module].__dict__
     else:
         base_globals = None
-    hints = {}
+    annotations = {}
     for name, value in raw_annotations.items():
         if isinstance(value, str):
             value = ForwardRef(value, is_argument=False)
@@ -244,5 +244,5 @@ def resolve_annotations(raw_annotations, module):
         except NameError:
             # this is ok, it can be fixed with update_forward_refs
             pass
-        hints[name] = value
-    return hints
+        annotations[name] = value
+    return annotations

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -237,8 +237,6 @@ def resolve_annotations(raw_annotations, module):
         base_globals = None
     hints = {}
     for name, value in raw_annotations.items():
-        if value is None:
-            value = type(None)
         if isinstance(value, str):
             value = ForwardRef(value, is_argument=False)
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from importlib.machinery import SourceFileLoader
 
 import pytest
 
@@ -23,3 +24,13 @@ def env():
     yield setenv
 
     setenv.clear()
+
+
+@pytest.fixture
+def create_module(tmp_path):
+    def run(code):
+        path = tmp_path / 'test_code.py'
+        path.write_text(code)
+        return SourceFileLoader('test_code', str(path)).load_module()
+
+    return run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 from importlib.machinery import SourceFileLoader
 
 import pytest
@@ -29,8 +30,9 @@ def env():
 @pytest.fixture
 def create_module(tmp_path):
     def run(code):
-        path = tmp_path / 'test_code.py'
+        name = f'test_code_{secrets.token_hex(5)}'
+        path = tmp_path / f'{name}.py'
         path.write_text(code)
-        return SourceFileLoader('test_code', str(path)).load_module()
+        return SourceFileLoader(name, str(path)).load_module()
 
     return run

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -1,0 +1,39 @@
+"""
+Tests for python 3.7 behaviour, eg postponed annotations and (in future maybe) ForwardRef.
+"""
+import sys
+
+import pytest
+
+skip_not_37 = pytest.mark.skipif(sys.version_info < (3, 7), reason='testing >= 3.7 behaviour only')
+
+
+@skip_not_37
+def test_postponed_annotations(create_module):
+    module = create_module(
+        """
+from __future__ import annotations
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    a: int
+"""
+    )
+    m = module.Model(a='123')
+    assert m.dict() == {'a': 123}
+
+
+@skip_not_37
+def test_postponed_annotations_optional(create_module):
+    module = create_module(
+        """
+from __future__ import annotations
+from typing import Optional
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    a: Optional[int]
+"""
+    )
+    assert module.Model(a='123').dict() == {'a': 123}
+    assert module.Model().dict() == {'a': None}

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -72,11 +72,10 @@ Foo = ForwardRef('Foo')
 class Foo(BaseModel):
     a: int = 123
     b: Foo = None
-    
+
 Foo.update_forward_refs()
     """
     )
 
     assert module.Foo().dict() == {'a': 123, 'b': None}
-    debug(module.Foo(b={'a': '321'}).dict())
     assert module.Foo(b={'a': '321'}).dict() == {'a': 123, 'b': {'a': 321, 'b': None}}

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -1,5 +1,5 @@
 """
-Tests for python 3.7 behaviour, eg postponed annotations and (in future maybe) ForwardRef.
+Tests for python 3.7 behaviour, eg postponed annotations and ForwardRef.
 """
 import sys
 

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -37,3 +37,46 @@ class Model(BaseModel):
     )
     assert module.Model(a='123').dict() == {'a': 123}
     assert module.Model().dict() == {'a': None}
+
+
+@skip_not_37
+def test_basic_forward_ref(create_module):
+    module = create_module(
+        """
+from typing import ForwardRef, Optional
+from pydantic import BaseModel
+
+class Foo(BaseModel):
+    a: int
+
+FooRef = ForwardRef('Foo')
+
+class Bar(BaseModel):
+    b: Optional[FooRef]
+"""
+    )
+
+    assert module.Bar().dict() == {'b': None}
+    assert module.Bar(b={'a': '123'}).dict() == {'b': {'a': 123}}
+
+
+@skip_not_37
+def test_self_forward_ref(create_module):
+    module = create_module(
+        """
+from typing import ForwardRef
+from pydantic import BaseModel
+
+Foo = ForwardRef('Foo')
+
+class Foo(BaseModel):
+    a: int = 123
+    b: Foo = None
+    
+Foo.update_forward_refs()
+    """
+    )
+
+    assert module.Foo().dict() == {'a': 123, 'b': None}
+    debug(module.Foo(b={'a': '321'}).dict())
+    assert module.Foo(b={'a': '321'}).dict() == {'a': 123, 'b': {'a': 321, 'b': None}}


### PR DESCRIPTION
## Change Summary

support postponed annotations in python 3.7

## Related issue number

fix #234 ~~partial solution use of `ForwardRef` for the model itself isn't yet supported. Since almost all of the field setup logic assumes the model already exists this will be much more complicated~~

`ForwardRef` should now be fully supported. If the `ForwardRef` can't evaluate when creating the Model you'll need to call `Model.update_forward_refs()` after it's been created.

Also note that the Model will need to be defined in the root of the module so it's included in globals, this is a limitation of `get_type_hints` it could be fixed in future by implementing our own version of `get_type_hints` but that's beyond the scope of this PR I think.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
