### PR TITLE
Fix BaseConfig max_anystr_length default to fixed number to None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ v0.18.0 (unreleased)
   ``whole`` validators being called for sub-fields, fix #132 by @samuelcolvin
 * improve documentation for settings priority and allow it to be easily changed, #343 by @samuelcolvin
 * fix ``ignore_extra=False`` and ``allow_population_by_alias=True``, fix #257 by @samuelcolvin
+* **breaking change**: Set ``BaseConfig`` attributes ``min_anystr_length`` and ``max_anystr_length`` to
+    ``None`` by default, fix #349 in #350, by @tiangolo
 
 v0.17.0 (2018-12-27)
 ....................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -22,8 +22,8 @@ from .validators import dict_validator
 class BaseConfig:
     title = None
     anystr_strip_whitespace = False
-    min_anystr_length = 0
-    max_anystr_length = 2 ** 16
+    min_anystr_length = None
+    max_anystr_length = None
     validate_all = False
     ignore_extra = True
     allow_extra = False

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -25,6 +25,18 @@ def test_construct_missing():
     assert "'Model' object has no attribute 'b'" in str(exc_info)
 
 
+def test_large_any_str():
+    class Model(BaseModel):
+        a: bytes
+        b: str
+
+    content_bytes = b"x" * (2 ** 16 + 1)
+    content_str = "x" * (2 ** 16 + 1)
+    m = Model(a=content_bytes, b=content_str)
+    assert m.a == content_bytes
+    assert m.b == content_str
+
+
 def test_simple_copy():
     m = Model(a=24)
     m2 = m.copy()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Make `BaseConfig` by default have `min_anystr_length` and `max_anystr_length` set to `None`.

All the discussion/motivation is in issue #349 .

<!-- Please give a short summary of the changes. -->

## Related issue number

#349 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
