### PR TITLE
Refactored extra types to use a single enum

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ v0.18.0 (unreleased)
   ``whole`` validators being called for sub-fields, fix #132 by @samuelcolvin
 * improve documentation for settings priority and allow it to be easily changed, #343 by @samuelcolvin
 * fix ``ignore_extra=False`` and ``allow_population_by_alias=True``, fix #257 by @samuelcolvin
+* Deprecated ``ignore_extra`` and ``allow_extra`` Config fields in favor of ``extra``, #352 by @liiight
 
 v0.17.0 (2018-12-27)
 ....................

--- a/benchmarks/test_pydantic.py
+++ b/benchmarks/test_pydantic.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List
 
-from pydantic import BaseModel, constr, EmailStr, PositiveInt, ValidationError
+from pydantic import BaseModel, Extra, PositiveInt, ValidationError, constr
 
 
 class TestPydantic:
@@ -36,7 +36,7 @@ class TestPydantic:
             skills: List[Skill] = []
 
             class Config:
-                ignore_extra = allow_extra
+                extra = Extra.allowed if allow_extra else Extra.forbidden
 
         self.model = Model
 

--- a/benchmarks/test_pydantic.py
+++ b/benchmarks/test_pydantic.py
@@ -36,7 +36,7 @@ class TestPydantic:
             skills: List[Skill] = []
 
             class Config:
-                extra = Extra.allowed if allow_extra else Extra.forbidden
+                extra = Extra.allow if allow_extra else Extra.forbid
 
         self.model = Model
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -446,7 +446,7 @@ Options:
 :max_anystr_length: max length for str & byte types (default: ``2 ** 16``)
 :validate_all: whether or not to validate field defaults (default: ``False``)
 :extra: whether to ignore, allow or forbid extra attributes in model. Can use either string values of ``ignore``,
-  ``allow`` or ``forbidden``, or use ``Extra`` enum. Default is ``Extra.ignore``
+  ``allow`` or ``forbidden``, or use ``Extra`` enum (default is ``Extra.ignore``)
 :allow_mutation: whether or not models are faux-immutable, e.g. __setattr__ fails (default: ``True``)
 :use_enum_values: whether to populate models with the ``value`` property of enums,
     rather than the raw enum - useful if you want to serialise ``model.dict()`` later (default: ``False``)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -445,10 +445,8 @@ Options:
 :min_anystr_length: min length for str & byte types (default: ``0``)
 :max_anystr_length: max length for str & byte types (default: ``2 ** 16``)
 :validate_all: whether or not to validate field defaults (default: ``False``)
-:ignore_extra: whether to ignore any extra values in input data; if this option is set to be ``True``,
-  any extra attributes will be dropped without raising a ``ValidationError`` (default: ``True``)
-:allow_extra: whether or not to allow (and include on the model) any extra values from input data;
-  when ``allow_extra`` option is set to ``True`` it overrides ``ignore_extra`` (default: ``False``)
+:extra: whether to ignore, allow or forbid extra attributes in model. Can use either string values of ``ignore``,
+  ``allow`` or ``forbidden``, or use ``Extra`` enum. Default is ``Extra.ignore``
 :allow_mutation: whether or not models are faux-immutable, e.g. __setattr__ fails (default: ``True``)
 :use_enum_values: whether to populate models with the ``value`` property of enums,
     rather than the raw enum - useful if you want to serialise ``model.dict()`` later (default: ``False``)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -446,7 +446,7 @@ Options:
 :max_anystr_length: max length for str & byte types (default: ``2 ** 16``)
 :validate_all: whether or not to validate field defaults (default: ``False``)
 :extra: whether to ignore, allow or forbid extra attributes in model. Can use either string values of ``ignore``,
-  ``allow`` or ``forbidden``, or use ``Extra`` enum (default is ``Extra.ignore``)
+  ``allow`` or ``forbid``, or use ``Extra`` enum (default is ``Extra.ignore``)
 :allow_mutation: whether or not models are faux-immutable, e.g. __setattr__ fails (default: ``True``)
 :use_enum_values: whether to populate models with the ``value`` property of enums,
     rather than the raw enum - useful if you want to serialise ``model.dict()`` later (default: ``False``)

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -4,7 +4,7 @@ from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
 from .fields import Required
-from .main import BaseConfig, BaseModel, create_model, validate_model
+from .main import BaseConfig, BaseModel, create_model, validate_model, ExtraAttributes
 from .parse import Protocol
 from .types import *
 from .version import VERSION

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -4,7 +4,7 @@ from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
 from .fields import Required
-from .main import BaseConfig, BaseModel, create_model, validate_model, ExtraAttributes
+from .main import BaseConfig, BaseModel, Extra, create_model, validate_model
 from .parse import Protocol
 from .types import *
 from .version import VERSION

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from .main import BaseModel
+from .main import BaseModel, Extra
 
 
 class SettingsError(ValueError):
@@ -57,6 +57,6 @@ class BaseSettings(BaseModel):
     class Config:
         env_prefix = 'APP_'
         validate_all = True
-        ignore_extra = False
+        extra = Extra.forbidden
         arbitrary_types_allowed = True
         case_insensitive = False

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -57,6 +57,6 @@ class BaseSettings(BaseModel):
     class Config:
         env_prefix = 'APP_'
         validate_all = True
-        extra = Extra.forbidden
+        extra = Extra.forbid
         arbitrary_types_allowed = True
         case_insensitive = False

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -67,9 +67,9 @@ def set_extra(config, cls_name):
     has_ignore_extra, has_allow_extra = hasattr(config, 'ignore_extra'), hasattr(config, 'allow_extra')
     if has_ignore_extra or has_allow_extra:
         if getattr(config, 'allow_extra', False):
-            config.extra = Extra.allowed
+            config.extra = Extra.allow
         elif getattr(config, 'ignore_extra', True):
-            config.extra = Extra.ignored
+            config.extra = Extra.ignore
         else:
             config.extra = Extra.forbid
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -96,7 +96,6 @@ def set_extra(config, cls_name):
             raise ValueError(f'"{cls_name}": {config.extra} is not a valid value for "extra"')
 
 
-
 TYPE_BLACKLIST = FunctionType, property, type, classmethod, staticmethod
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -21,9 +21,9 @@ from .validators import dict_validator
 
 
 class Extra(str, Enum):
-    allowed = 'allowed'
-    ignored = 'ignored'
-    forbidden = 'forbidden'
+    allow = 'allow'
+    ignore = 'ignore'
+    forbid = 'forbid'
 
 
 class BaseConfig:
@@ -32,7 +32,7 @@ class BaseConfig:
     min_anystr_length = None
     max_anystr_length = None
     validate_all = False
-    extra = Extra.ignored
+    extra = Extra.ignore
     allow_mutation = True
     allow_population_by_alias = False
     use_enum_values = False
@@ -71,7 +71,7 @@ def set_extra(config, cls_name):
         elif getattr(config, 'ignore_extra', True):
             config.extra = Extra.ignored
         else:
-            config.extra = Extra.forbidden
+            config.extra = Extra.forbid
 
         if has_ignore_extra and has_allow_extra:
             warnings.warn(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -84,12 +84,10 @@ def set_extra(config, cls_name):
                 f'{cls_name}: "ignore_extra" is deprecated and replaced by "extra", see {EXTRA_LINK}',
                 DeprecationWarning,
             )
-            del config.ignore_extra
-        elif has_allow_extra:
+        else:
             warnings.warn(
                 f'{cls_name}: "allow_extra" is deprecated and replaced by "extra", see {EXTRA_LINK}', DeprecationWarning
             )
-            del config.allow_extra
     else:
         config.extra = Extra(config.extra)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -61,7 +61,7 @@ def inherit_config(self_config: Type, parent_config: Type[BaseConfig]) -> Type[B
     return type('Config', base_classes, {})
 
 
-EXTRA_LINK = 'TODO/link/to/docs'
+EXTRA_LINK = 'https://pydantic-docs.helpmanual.io/#model-config'
 
 
 def set_extra(config, cls_name):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -415,13 +415,12 @@ def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (igno
     """
     validate data against a model.
     """
+    def _deprecated_values() -> bool:
+        return hasattr(model.__config__, 'ignore_extra') or hasattr(model.__config__, 'allow_extra')
 
-    def _get_extra():
-        ignore_extra = getattr(model.__config__, 'ignore_extra', None)
-        allow_extra = getattr(model.__config__, 'allow_extra', None)
-        if not any((ignore_extra, allow_extra)):
-            return
-
+    def _get_extra()-> Union[ExtraAttributes, None]:
+        ignore_extra = getattr(model.__config__, 'ignore_extra', True)
+        allow_extra = getattr(model.__config__, 'allow_extra', False)
         if ignore_extra is True:
             if allow_extra is False:
                 extra_att = ExtraAttributes.DISALLOW_MUTATION
@@ -438,7 +437,7 @@ def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (igno
     values = {}
     errors = []
     names_used = set()
-    extra_ = _get_extra() or model.__config__.extra
+    extra_ = _get_extra() if _deprecated_values() else model.__config__.extra
 
     for name, field in model.__fields__.items():
         value = input_data.get(field.alias, _missing)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -416,14 +416,11 @@ def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (igno
     validate data against a model.
     """
 
-    def _deprecated_values():
-        ignore_extra = getattr(model.__config__, 'ignore_extra', None)
-        allow_extra = getattr(model.__config__, 'allow_extra', None)
-        return ignore_extra is not None or allow_extra is not None
-
     def _get_extra():
         ignore_extra = getattr(model.__config__, 'ignore_extra', None)
         allow_extra = getattr(model.__config__, 'allow_extra', None)
+        if not any((ignore_extra, allow_extra)):
+            return
 
         if ignore_extra is True:
             if allow_extra is False:
@@ -441,7 +438,7 @@ def validate_model(model, input_data: dict, raise_exc=True):  # noqa: C901 (igno
     values = {}
     errors = []
     names_used = set()
-    extra_ = _get_extra() if _deprecated_values() else model.__config__.extra
+    extra_ = _get_extra() or model.__config__.extra
 
     for name, field in model.__fields__.items():
         value = input_data.get(field.alias, _missing)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -89,7 +89,11 @@ def set_extra(config, cls_name):
                 f'{cls_name}: "allow_extra" is deprecated and replaced by "extra", see {EXTRA_LINK}', DeprecationWarning
             )
     else:
-        config.extra = Extra(config.extra)
+        try:
+            config.extra = Extra(config.extra)
+        except ValueError:
+            raise ValueError(f'"{cls_name}": {config.extra} is not a valid value for "extra"')
+
 
 
 TYPE_BLACKLIST = FunctionType, property, type, classmethod, staticmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -191,7 +191,7 @@ class BaseModel(metaclass=MetaModel):
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     def __setattr__(self, name, value):
-        if self.__config__.extra is not Extra.allowed and name not in self.__fields__:
+        if self.__config__.extra is not Extra.allow and name not in self.__fields__:
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
         elif not self.__config__.allow_mutation:
             raise TypeError(f'"{self.__class__.__name__}" is immutable and does not support item assignment')
@@ -503,7 +503,7 @@ def validate_model(model: BaseModel, input_data: dict, raise_exc=True):  # noqa:
     if check_extra:
         extra = input_data.keys() - names_used
         if extra:
-            if config.extra is Extra.allowed:
+            if config.extra is Extra.allow:
                 for field in extra:
                     values[field] = input_data[field]
             else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -465,7 +465,7 @@ def validate_model(model: BaseModel, input_data: dict, raise_exc=True):  # noqa:
     errors = []
     names_used = set()
     config = model.__config__
-    check_extra = config.extra is not Extra.ignored
+    check_extra = config.extra is not Extra.ignore
 
     for name, field in model.__fields__.items():
         if type(field.type_) == ForwardRef:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -189,13 +189,13 @@ class BaseModel(metaclass=MetaModel):
         return lambda _, key: key
 
     def json(
-            self,
-            *,
-            include: Set[str] = None,
-            exclude: Set[str] = set(),
-            by_alias: bool = False,
-            encoder=None,
-            **dumps_kwargs,
+        self,
+        *,
+        include: Set[str] = None,
+        exclude: Set[str] = set(),
+        by_alias: bool = False,
+        encoder=None,
+        **dumps_kwargs,
     ) -> str:
         """
         Generate a JSON representation of the model, `include` and `exclude` arguments as per `dict()`.
@@ -217,13 +217,13 @@ class BaseModel(metaclass=MetaModel):
 
     @classmethod
     def parse_raw(
-            cls,
-            b: StrBytes,
-            *,
-            content_type: str = None,
-            encoding: str = 'utf8',
-            proto: Protocol = None,
-            allow_pickle: bool = False,
+        cls,
+        b: StrBytes,
+        *,
+        content_type: str = None,
+        encoding: str = 'utf8',
+        proto: Protocol = None,
+        allow_pickle: bool = False,
     ):
         try:
             obj = load_str_bytes(
@@ -235,13 +235,13 @@ class BaseModel(metaclass=MetaModel):
 
     @classmethod
     def parse_file(
-            cls,
-            path: Union[str, Path],
-            *,
-            content_type: str = None,
-            encoding: str = 'utf8',
-            proto: Protocol = None,
-            allow_pickle: bool = False,
+        cls,
+        path: Union[str, Path],
+        *,
+        content_type: str = None,
+        encoding: str = 'utf8',
+        proto: Protocol = None,
+        allow_pickle: bool = False,
     ):
         obj = load_file(path, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle)
         return cls.parse_obj(obj)
@@ -257,8 +257,7 @@ class BaseModel(metaclass=MetaModel):
         return m
 
     def copy(
-            self, *, include: Set[str] = None, exclude: Set[str] = None, update: Dict[str, Any] = None,
-            deep: bool = False
+        self, *, include: Set[str] = None, exclude: Set[str] = None, update: Dict[str, Any] = None, deep: bool = False
     ):
         """
         Duplicate a model, optionally choose which fields to include, exclude and change.

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic import BaseModel, ValidationError, create_model, errors, validator
+from pydantic import BaseModel, Extra, ValidationError, create_model, errors, validator
 
 
 def test_create_model():
@@ -75,8 +75,7 @@ def test_custom_config_inherits():
 
 def test_custom_config_extras():
     class Config(BaseModel.Config):
-        ignore_extra = False
-        allow_extra = False
+        extra = Extra.forbidden
 
     model = create_model('FooModel', foo=(int, ...), __config__=Config)
     assert model(foo=654)

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -75,7 +75,7 @@ def test_custom_config_inherits():
 
 def test_custom_config_extras():
     class Config(BaseModel.Config):
-        extra = Extra.forbidden
+        extra = Extra.forbid
 
     model = create_model('FooModel', foo=(int, ...), __config__=Config)
     assert model(foo=654)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -698,6 +698,7 @@ def test_force_extra():
 
 def test_illegal_extra_value():
     with pytest.raises(ValueError, match='is not a valid value for "extra"'):
+
         class Model(BaseModel):
             foo: int
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -5,7 +5,17 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import pytest
 
-from pydantic import BaseConfig, BaseModel, NoneStrBytes, StrBytes, ValidationError, constr, errors, validate_model
+from pydantic import (
+    BaseConfig,
+    BaseModel,
+    Extra,
+    NoneStrBytes,
+    StrBytes,
+    ValidationError,
+    constr,
+    errors,
+    validate_model,
+)
 
 
 def test_str_bytes():
@@ -463,7 +473,7 @@ def test_string_none():
         a: constr(min_length=20, max_length=1000) = ...
 
         class Config:
-            ignore_extra = True
+            extra = Extra.ignored
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=None)
@@ -614,7 +624,7 @@ def test_pop_by_alias():
         last_updated_by: Optional[str] = None
 
         class Config:
-            ignore_extra = False
+            extra = Extra.forbidden
             allow_population_by_alias = True
             fields = {'last_updated_by': 'lastUpdatedBy'}
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -393,7 +393,6 @@ def test_inheritance():
 
 def test_invalid_type():
     with pytest.raises(RuntimeError) as exc_info:
-
         class Model(BaseModel):
             x: 43 = 123
 
@@ -568,7 +567,6 @@ def test_invalid_validator():
             pass
 
     with pytest.raises(errors.ConfigError) as exc_info:
-
         class InvalidValidatorModel(BaseModel):
             x: InvalidValidator = ...
 
@@ -577,7 +575,6 @@ def test_invalid_validator():
 
 def test_unable_to_infer():
     with pytest.raises(errors.ConfigError) as exc_info:
-
         class InvalidDefinitionModel(BaseModel):
             x = None
 
@@ -595,7 +592,6 @@ def test_get_validator():
             return v * 2
 
     with pytest.warns(DeprecationWarning):
-
         class Model(BaseModel):
             x: CustomClass
 
@@ -639,7 +635,6 @@ def test_pop_by_alias():
 
 def test_ignore_extra_true():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
-
         class Model(BaseModel):
             foo: int
 
@@ -651,7 +646,6 @@ def test_ignore_extra_true():
 
 def test_ignore_extra_false():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
-
         class Model(BaseModel):
             foo: int
 
@@ -663,7 +657,6 @@ def test_ignore_extra_false():
 
 def test_allow_extra():
     with pytest.warns(DeprecationWarning, match='Model: "allow_extra" is deprecated and replaced by "extra"'):
-
         class Model(BaseModel):
             foo: int
 
@@ -675,7 +668,6 @@ def test_allow_extra():
 
 def test_ignore_extra_allow_extra():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" and "allow_extra" are deprecated and'):
-
         class Model(BaseModel):
             foo: int
 
@@ -694,3 +686,12 @@ def test_force_extra():
             extra = 'ignored'
 
     assert Model.__config__.extra is Extra.ignored
+
+
+def test_illegal_extra_value():
+    with pytest.raises(ValueError, match='is not a valid value for "extra"'):
+        class Model(BaseModel):
+            foo: int
+
+            class Config:
+                extra = 'foo'

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -697,7 +697,7 @@ def test_force_extra():
 
 
 def test_illegal_extra_value():
-    with pytest.raises(ValueError, match='is not a valid Extra'):
+    with pytest.raises(ValueError, match='is not a valid value for "extra"'):
 
         class Model(BaseModel):
             foo: int

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -393,6 +393,7 @@ def test_inheritance():
 
 def test_invalid_type():
     with pytest.raises(RuntimeError) as exc_info:
+
         class Model(BaseModel):
             x: 43 = 123
 
@@ -567,6 +568,7 @@ def test_invalid_validator():
             pass
 
     with pytest.raises(errors.ConfigError) as exc_info:
+
         class InvalidValidatorModel(BaseModel):
             x: InvalidValidator = ...
 
@@ -575,6 +577,7 @@ def test_invalid_validator():
 
 def test_unable_to_infer():
     with pytest.raises(errors.ConfigError) as exc_info:
+
         class InvalidDefinitionModel(BaseModel):
             x = None
 
@@ -592,6 +595,7 @@ def test_get_validator():
             return v * 2
 
     with pytest.warns(DeprecationWarning):
+
         class Model(BaseModel):
             x: CustomClass
 
@@ -635,6 +639,7 @@ def test_pop_by_alias():
 
 def test_ignore_extra_true():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
+
         class Model(BaseModel):
             foo: int
 
@@ -646,6 +651,7 @@ def test_ignore_extra_true():
 
 def test_ignore_extra_false():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
+
         class Model(BaseModel):
             foo: int
 
@@ -657,6 +663,7 @@ def test_ignore_extra_false():
 
 def test_allow_extra():
     with pytest.warns(DeprecationWarning, match='Model: "allow_extra" is deprecated and replaced by "extra"'):
+
         class Model(BaseModel):
             foo: int
 
@@ -668,6 +675,7 @@ def test_allow_extra():
 
 def test_ignore_extra_allow_extra():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" and "allow_extra" are deprecated and'):
+
         class Model(BaseModel):
             foo: int
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -639,6 +639,7 @@ def test_pop_by_alias():
 
 def test_ignore_extra_true():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
+
         class Model(BaseModel):
             foo: int
 
@@ -650,6 +651,7 @@ def test_ignore_extra_true():
 
 def test_ignore_extra_false():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
+
         class Model(BaseModel):
             foo: int
 
@@ -661,6 +663,7 @@ def test_ignore_extra_false():
 
 def test_allow_extra():
     with pytest.warns(DeprecationWarning, match='Model: "allow_extra" is deprecated and replaced by "extra"'):
+
         class Model(BaseModel):
             foo: int
 
@@ -672,6 +675,7 @@ def test_allow_extra():
 
 def test_ignore_extra_allow_extra():
     with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" and "allow_extra" are deprecated and'):
+
         class Model(BaseModel):
             foo: int
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -635,3 +635,58 @@ def test_pop_by_alias():
     assert exc_info.value.errors() == [
         {'loc': ('last_updated_by',), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'}
     ]
+
+
+def test_ignore_extra_true():
+    with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
+        class Model(BaseModel):
+            foo: int
+
+            class Config:
+                ignore_extra = True
+
+    assert Model.__config__.extra is Extra.ignored
+
+
+def test_ignore_extra_false():
+    with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
+        class Model(BaseModel):
+            foo: int
+
+            class Config:
+                ignore_extra = False
+
+    assert Model.__config__.extra is Extra.forbidden
+
+
+def test_allow_extra():
+    with pytest.warns(DeprecationWarning, match='Model: "allow_extra" is deprecated and replaced by "extra"'):
+        class Model(BaseModel):
+            foo: int
+
+            class Config:
+                allow_extra = True
+
+    assert Model.__config__.extra is Extra.allowed
+
+
+def test_ignore_extra_allow_extra():
+    with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" and "allow_extra" are deprecated and'):
+        class Model(BaseModel):
+            foo: int
+
+            class Config:
+                ignore_extra = False
+                allow_extra = False
+
+    assert Model.__config__.extra is Extra.forbidden
+
+
+def test_force_extra():
+    class Model(BaseModel):
+        foo: int
+
+        class Config:
+            extra = 'ignored'
+
+    assert Model.__config__.extra is Extra.ignored

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -610,7 +610,7 @@ def test_multiple_errors():
         Model(a='foobar')
 
     assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'value is not none', 'type': 'type_error.none.allow'},
+        {'loc': ('a',), 'msg': 'value is not none', 'type': 'type_error.none.allowed'},
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
         {'loc': ('a',), 'msg': 'value is not a valid float', 'type': 'type_error.float'},
         {'loc': ('a',), 'msg': 'value is not a valid decimal', 'type': 'type_error.decimal'},
@@ -691,13 +691,13 @@ def test_force_extra():
         foo: int
 
         class Config:
-            extra = 'ignored'
+            extra = 'ignore'
 
     assert Model.__config__.extra is Extra.ignore
 
 
 def test_illegal_extra_value():
-    with pytest.raises(ValueError, match='is not a valid value for "extra"'):
+    with pytest.raises(ValueError, match='is not a valid Extra'):
 
         class Model(BaseModel):
             foo: int

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -473,7 +473,7 @@ def test_string_none():
         a: constr(min_length=20, max_length=1000) = ...
 
         class Config:
-            extra = Extra.ignored
+            extra = Extra.ignore
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a=None)
@@ -610,7 +610,7 @@ def test_multiple_errors():
         Model(a='foobar')
 
     assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'value is not none', 'type': 'type_error.none.allowed'},
+        {'loc': ('a',), 'msg': 'value is not none', 'type': 'type_error.none.allow'},
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
         {'loc': ('a',), 'msg': 'value is not a valid float', 'type': 'type_error.float'},
         {'loc': ('a',), 'msg': 'value is not a valid decimal', 'type': 'type_error.decimal'},
@@ -624,7 +624,7 @@ def test_pop_by_alias():
         last_updated_by: Optional[str] = None
 
         class Config:
-            extra = Extra.forbidden
+            extra = Extra.forbid
             allow_population_by_alias = True
             fields = {'last_updated_by': 'lastUpdatedBy'}
 
@@ -646,7 +646,7 @@ def test_ignore_extra_true():
             class Config:
                 ignore_extra = True
 
-    assert Model.__config__.extra is Extra.ignored
+    assert Model.__config__.extra is Extra.ignore
 
 
 def test_ignore_extra_false():
@@ -658,7 +658,7 @@ def test_ignore_extra_false():
             class Config:
                 ignore_extra = False
 
-    assert Model.__config__.extra is Extra.forbidden
+    assert Model.__config__.extra is Extra.forbid
 
 
 def test_allow_extra():
@@ -670,7 +670,7 @@ def test_allow_extra():
             class Config:
                 allow_extra = True
 
-    assert Model.__config__.extra is Extra.allowed
+    assert Model.__config__.extra is Extra.allow
 
 
 def test_ignore_extra_allow_extra():
@@ -683,7 +683,7 @@ def test_ignore_extra_allow_extra():
                 ignore_extra = False
                 allow_extra = False
 
-    assert Model.__config__.extra is Extra.forbidden
+    assert Model.__config__.extra is Extra.forbid
 
 
 def test_force_extra():
@@ -693,7 +693,7 @@ def test_force_extra():
         class Config:
             extra = 'ignored'
 
-    assert Model.__config__.extra is Extra.ignored
+    assert Model.__config__.extra is Extra.ignore
 
 
 def test_illegal_extra_value():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -223,7 +223,7 @@ def test_mutation_only():
             extra = ExtraAttributes.MUTATION_ONLY
 
     model = Model(a=0.2, b=0.1)
-    assert not getattr(model, 'b', None)
+    assert not hasattr(model, 'b')
 
     model = Model(a=0.2)
     model.b = 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, List
 
 import pytest
 
-from pydantic import BaseModel, ExtraAttributes, NoneBytes, NoneStr, Required, ValidationError, constr
+from pydantic import BaseModel, Extra, NoneBytes, NoneStr, Required, ValidationError, constr
 
 
 def test_success():
@@ -135,30 +135,6 @@ def test_recursion_fails():
         RecursiveModel(grape=1, banana=123)
 
 
-class PreventExtraModel(BaseModel):
-    foo = 'whatever'
-
-    class Config:
-        ignore_extra = False
-
-
-def test_prevent_extra_success():
-    m = PreventExtraModel()
-    assert m.foo == 'whatever'
-
-    m = PreventExtraModel(foo=1)
-    assert m.foo == '1'
-
-
-def test_prevent_extra_fails():
-    with pytest.raises(ValidationError) as exc_info:
-        PreventExtraModel(foo='ok', bar='wrong', spam='xx')
-    assert exc_info.value.errors() == [
-        {'loc': ('bar',), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'},
-        {'loc': ('spam',), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'},
-    ]
-
-
 def test_not_required():
     class Model(BaseModel):
         a: float = None
@@ -184,58 +160,71 @@ def test_allow_extra():
         a: float = ...
 
         class Config:
-            allow_extra = True
+            extra = Extra.allowed
 
-    with pytest.warns(PendingDeprecationWarning):
-        assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
+    assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
+
+
+def test_forbidden_extra_success():
+    class ForbiddenExtra(BaseModel):
+        foo = 'whatever'
+
+        class Config:
+            extra = Extra.forbidden
+
+    m = ForbiddenExtra()
+    assert m.foo == 'whatever'
+
+    m = ForbiddenExtra(foo=1)
+    assert m.foo == '1'
+
+
+def test_forbidden_extra_fails():
+    class ForbiddenExtra(BaseModel):
+        foo = 'whatever'
+
+        class Config:
+            extra = Extra.forbidden
+
+    with pytest.raises(ValidationError) as exc_info:
+        ForbiddenExtra(foo='ok', bar='wrong', spam='xx')
+    assert exc_info.value.errors() == [
+        {'loc': ('bar',), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'},
+        {'loc': ('spam',), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'},
+    ]
 
 
 def test_disallow_mutation():
     class Model(BaseModel):
-        a: float = ...
+        a: float
 
     model = Model(a=0.2)
     with pytest.raises(ValueError, match='"Model" object has no field "b"'):
         model.b = 2
 
 
-def test_always_disallow():
+def test_extra_allowed():
     class Model(BaseModel):
-        a: float = ...
+        a: float
 
         class Config:
-            extra = ExtraAttributes.forbidden
-
-    with pytest.raises(ValidationError, match='extra fields not permitted'):
-        Model(a=0.2, b=0.1)
-
-    model = Model(a=0.2)
-    with pytest.raises(ValueError, match='"Model" object has no field "b"'):
-        model.b = 1
-
-
-def test_always_allow():
-    class Model(BaseModel):
-        a: float = ...
-
-        class Config:
-            extra = ExtraAttributes.allowed
+            extra = Extra.allowed
 
     model = Model(a=0.2, b=0.1)
-    assert getattr(model, 'b') == 0.1
+    assert model.b == 0.1
 
-    model = Model(a=0.2)
+    assert not hasattr(model, 'c')
     model.c = 1
+    assert hasattr(model, 'c')
+    assert model.c == 1
 
-    assert getattr(model, 'c') == 1
 
-
-def test_ignore_extra():
+def test_extra_ignored():
     class Model(BaseModel):
-        a: float = ...
+        a: float
 
         class Config:
-            extra = ExtraAttributes.ignored
+            extra = Extra.ignored
 
     model = Model(a=0.2, b=0.1)
     assert not hasattr(model, 'b')
@@ -343,7 +332,7 @@ def test_not_immutability():
 
         class Config:
             allow_mutation = True
-            allow_extra = False
+            extra = Extra.forbidden
 
     m = TestModel()
     assert m.a == 10
@@ -360,7 +349,7 @@ def test_immutability():
 
         class Config:
             allow_mutation = False
-            allow_extra = False
+            extra = Extra.forbidden
 
     m = TestModel()
     assert m.a == 10

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -180,15 +180,13 @@ def test_infer_type():
 
 
 def test_allow_extra():
-    """Will be removed in a future release"""
-
     class Model(BaseModel):
         a: float = ...
 
         class Config:
             allow_extra = True
-
-    assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
+    with pytest.warns(PendingDeprecationWarning):
+        assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
 
 
 def test_disallow_mutation():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -160,7 +160,7 @@ def test_allow_extra():
         a: float = ...
 
         class Config:
-            extra = Extra.allowed
+            extra = Extra.allow
 
     assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
 
@@ -170,7 +170,7 @@ def test_forbidden_extra_success():
         foo = 'whatever'
 
         class Config:
-            extra = Extra.forbidden
+            extra = Extra.forbid
 
     m = ForbiddenExtra()
     assert m.foo == 'whatever'
@@ -184,7 +184,7 @@ def test_forbidden_extra_fails():
         foo = 'whatever'
 
         class Config:
-            extra = Extra.forbidden
+            extra = Extra.forbid
 
     with pytest.raises(ValidationError) as exc_info:
         ForbiddenExtra(foo='ok', bar='wrong', spam='xx')
@@ -208,7 +208,7 @@ def test_extra_allowed():
         a: float
 
         class Config:
-            extra = Extra.allowed
+            extra = Extra.allow
 
     model = Model(a=0.2, b=0.1)
     assert model.b == 0.1
@@ -224,7 +224,7 @@ def test_extra_ignored():
         a: float
 
         class Config:
-            extra = Extra.ignored
+            extra = Extra.ignore
 
     model = Model(a=0.2, b=0.1)
     assert not hasattr(model, 'b')
@@ -332,7 +332,7 @@ def test_not_immutability():
 
         class Config:
             allow_mutation = True
-            extra = Extra.forbidden
+            extra = Extra.forbid
 
     m = TestModel()
     assert m.a == 10
@@ -349,7 +349,7 @@ def test_immutability():
 
         class Config:
             allow_mutation = False
-            extra = Extra.forbidden
+            extra = Extra.forbid
 
     m = TestModel()
     assert m.a == 10

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, List
 
 import pytest
 
-from pydantic import BaseModel, NoneBytes, NoneStr, Required, ValidationError, constr, ExtraAttributes
+from pydantic import BaseModel, ExtraAttributes, NoneBytes, NoneStr, Required, ValidationError, constr
 
 
 def test_success():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -185,6 +185,7 @@ def test_allow_extra():
 
         class Config:
             allow_extra = True
+
     with pytest.warns(PendingDeprecationWarning):
         assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
 
@@ -497,6 +498,7 @@ def test_arbitrary_type_allowed_validation_fails():
 
 def test_arbitrary_types_not_allowed():
     with pytest.raises(RuntimeError) as exc_info:
+
         class ArbitraryTypeNotAllowedModel(BaseModel):
             t: ArbitraryType
 
@@ -513,6 +515,7 @@ def test_annotation_field_name_shadows_attribute():
 def test_value_field_name_shadows_attribute():
     # When defining a model that has an attribute with the name of a built-in attribute, an exception is raised
     with pytest.raises(NameError):
+
         class BadModel(BaseModel):
             schema = 'abc'  # This conflicts with the BaseModel's schema() class method
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -179,7 +179,7 @@ def test_infer_type():
     assert Model().c == 0
 
 
-def test_allow_extra_deprecated():
+def test_allow_extra():
     """Will be removed in a future release"""
 
     class Model(BaseModel):
@@ -205,7 +205,7 @@ def test_always_disallow():
         a: float = ...
 
         class Config:
-            extra = ExtraAttributes.ALWAYS_DISALLOW
+            extra = ExtraAttributes.forbidden
 
     with pytest.raises(ValidationError, match='extra fields not permitted'):
         Model(a=0.2, b=0.1)
@@ -215,28 +215,12 @@ def test_always_disallow():
         model.b = 1
 
 
-def test_mutation_only():
-    class Model(BaseModel):
-        a: float = ...
-
-        class Config:
-            extra = ExtraAttributes.MUTATION_ONLY
-
-    model = Model(a=0.2, b=0.1)
-    assert not hasattr(model, 'b')
-
-    model = Model(a=0.2)
-    model.b = 1
-
-    assert getattr(model, 'b') == 1
-
-
 def test_always_allow():
     class Model(BaseModel):
         a: float = ...
 
         class Config:
-            extra = ExtraAttributes.ALWAYS_ALLOW
+            extra = ExtraAttributes.allowed
 
     model = Model(a=0.2, b=0.1)
     assert getattr(model, 'b') == 0.1
@@ -245,6 +229,20 @@ def test_always_allow():
     model.c = 1
 
     assert getattr(model, 'c') == 1
+
+
+def test_ignore_extra():
+    class Model(BaseModel):
+        a: float = ...
+
+        class Config:
+            extra = ExtraAttributes.ignored
+
+    model = Model(a=0.2, b=0.1)
+    assert not hasattr(model, 'b')
+
+    with pytest.raises(ValueError, match='"Model" object has no field "c"'):
+        model.c = 1
 
 
 def test_set_attr():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary
Use a single value to describe allowing extra attributes or ignoring them, by using an enum:
```python
class ExtraAttributes(Enum):
    DISALLOW_MUTATION = auto()
    ALWAYS_DISALLOW = auto()
    MUTATION_ONLY = auto()
    ALWAYS_ALLOW = auto()

    def allow_mutation(self):
        return self in (self.MUTATION_ONLY, self.ALWAYS_ALLOW)

    def should_ignore(self):
        return self in (self.DISALLOW_MUTATION, self.MUTATION_ONLY)
```
<!-- Please give a short summary of the changes. -->

## Related issue number
#351 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
