### PR TITLE
custom validators in schema

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.19.0 (unreleased)
 ....................
 * Support ``Callable`` type hint, fix #279 by @proofit404
+* Fix schema for fields with ``validator`` decorator, fix #375 by @tiangolo
 
 v0.18.2 (2019-01-22)
 ....................

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -7,7 +7,7 @@ from .class_validators import Validator, ValidatorSignature, get_validator_signa
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
 from .utils import Callable, ForwardRef, display_as_type, lenient_issubclass, list_like
-from .validators import NoneType, dict_validator, find_validators, is_none_validator
+from .validators import NoneType, dict_validator, find_validators
 
 Required: Any = Ellipsis
 
@@ -358,7 +358,7 @@ class Field:
         """
         False if this is a simple field just allowing None as used in Unions/Optional.
         """
-        return len(self.validators) != 1 or self.validators[0][1] != is_none_validator
+        return self.type_ != NoneType
 
     def is_complex(self):
         """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 import pytest
 
-from pydantic import BaseModel, Schema, ValidationError
+from pydantic import BaseModel, Schema, ValidationError, validator
 from pydantic.schema import get_flat_models_from_model, get_flat_models_from_models, get_model_name_map, schema
 from pydantic.types import (
     DSN,
@@ -1104,3 +1104,18 @@ def test_optional_dict():
 
     assert Model().dict() == {'something': None}
     assert Model(something={'foo': 'Bar'}).dict() == {'something': {'foo': 'Bar'}}
+
+
+def test_field_with_validator():
+    class Model(BaseModel):
+        something: Optional[int] = None
+
+        @validator('something')
+        def check_field(cls, v, *, values, config, field):
+            return v
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'something': {'type': 'integer', 'title': 'Something'}},
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Test NoneType directly in Field.include_in_schema and add test for validator decorator

<!-- Please give a short summary of the changes. -->

## Related issue number

Issue #363

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
