### PR TITLE
correct python_tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ max-line-length = 120
 max-complexity = 12
 
 [bdist_wheel]
-python-tag = py36+
+python-tag = py36.py37
 
 [coverage:run]
 source = pydantic


### PR DESCRIPTION
## Change Summary

Set `python_tag` in `setup.cfg` to be correct

## Related issue number

fix #376
