### PR TITLE
Fix typo in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ So *pydantic* uses some cool new language feature, but why should I actually go 
     use of recursive *pydantic* models, ``typing``'s ``List`` and ``Dict`` etc. and validators allow
     complex data schemas to be clearly and easily defined and then checked.
 
-**extendible**
+**extensible**
     *pydantic* allows custom data types to be defined or you can extend validation with methods on a model decorated
     with the ``validator`` decorator.
 


### PR DESCRIPTION
## Change Summary

Fixed documentation typo

extendible -> extensible

See [extensibility](https://en.wikipedia.org/wiki/Extensibility).

## Related issue number

None, would be happy to create one if desired.

## Checklist

N/A (probably)
