### PR TITLE
change ms/s watershed for datetime parsing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-v0.19.0 (unreleased)
+v0.19.0 (2019-02-04)
 ....................
 * Support ``Callable`` type hint, fix #279 by @proofit404
 * Fix schema for fields with ``validator`` decorator, fix #375 by @tiangolo

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ v0.19.0 (unreleased)
 * Deprecated ``ignore_extra`` and ``allow_extra`` Config fields in favor of ``extra``, #352 by @liiight
 * Add type annotations to all functions, test fully with mypy, #373 by @samuelcolvin
 * fix for 'missing' error with ``validate_all`` or ``validate_always``, #381 by @samuelcolvin
+* Change the second/millisecond watershed for date/datetime parsing to ``2e10``, #385 by @samuelcolvin
 
 v0.18.2 (2019-01-22)
 ....................

--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -58,7 +58,9 @@ iso8601_duration_re = re.compile(
 )
 
 EPOCH = datetime(1970, 1, 1)
-MS_WATERSHED = int(1e11)  # if greater than this, the number is in ms (in seconds this is 3rd March 5138)
+# if greater than this, the number is in ms, if less than or equal it's in seconds
+# (in seconds this is 11th October 2603, in ms it's 20th August 1970)
+MS_WATERSHED = int(2e10)
 StrIntFloat = Union[str, int, float]
 
 

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.18.2')
+VERSION = StrictVersion('0.19.0')

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -36,10 +36,10 @@ def create_tz(minutes):
         ('2012-04-56', errors.DateError),
         (19_999_999_999, date(2603, 10, 11)),  # just before watershed
         (20_000_000_001, date(1970, 8, 20)),  # just after watershed
-        (1549316052, date(2019, 2, 4)),  # nowish in s
-        (1549316052104, date(2019, 2, 4)),  # nowish in ms
-        (1549316052104324, date(2019, 2, 4)),  # nowish in μs
-        (1549316052104324096, date(2019, 2, 4)),  # nowish in ns
+        (1_549_316_052, date(2019, 2, 4)),  # nowish in s
+        (1_549_316_052_104, date(2019, 2, 4)),  # nowish in ms
+        (1_549_316_052_104_324, date(2019, 2, 4)),  # nowish in μs
+        (1_549_316_052_104_324_096, date(2019, 2, 4)),  # nowish in ns
     ],
 )
 def test_date_parsing(value, result):
@@ -98,10 +98,10 @@ def test_time_parsing(value, result):
         ('2012-04-56T09:15:90', errors.DateTimeError),
         (19_999_999_999, datetime(2603, 10, 11, 11, 33, 19, tzinfo=timezone.utc)),  # just before watershed
         (20_000_000_001, datetime(1970, 8, 20, 11, 33, 20, 1000, tzinfo=timezone.utc)),  # just after watershed
-        (1549316052, datetime(2019, 2, 4, 21, 34, 12, 0, tzinfo=timezone.utc)),  # nowish in s
-        (1549316052104, datetime(2019, 2, 4, 21, 34, 12, 104000, tzinfo=timezone.utc)),  # nowish in ms
-        (1549316052104324, datetime(2019, 2, 4, 21, 34, 12, 104324, tzinfo=timezone.utc)),  # nowish in μs
-        (1549316052104324096, datetime(2019, 2, 4, 21, 34, 12, 104324, tzinfo=timezone.utc)),  # nowish in ns
+        (1_549_316_052, datetime(2019, 2, 4, 21, 34, 12, 0, tzinfo=timezone.utc)),  # nowish in s
+        (1_549_316_052_104, datetime(2019, 2, 4, 21, 34, 12, 104_000, tzinfo=timezone.utc)),  # nowish in ms
+        (1_549_316_052_104_324, datetime(2019, 2, 4, 21, 34, 12, 104_324, tzinfo=timezone.utc)),  # nowish in μs
+        (1_549_316_052_104_324_096, datetime(2019, 2, 4, 21, 34, 12, 104_324, tzinfo=timezone.utc)),  # nowish in ns
     ],
 )
 def test_datetime_parsing(value, result):

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -36,6 +36,10 @@ def create_tz(minutes):
         ('2012-04-56', errors.DateError),
         (19_999_999_999, date(2603, 10, 11)),  # just before watershed
         (20_000_000_001, date(1970, 8, 20)),  # just after watershed
+        (1549316052, date(2019, 2, 4)),  # nowish in s
+        (1549316052104, date(2019, 2, 4)),  # nowish in ms
+        (1549316052104324, date(2019, 2, 4)),  # nowish in μs
+        (1549316052104324096, date(2019, 2, 4)),  # nowish in ns
     ],
 )
 def test_date_parsing(value, result):
@@ -94,7 +98,10 @@ def test_time_parsing(value, result):
         ('2012-04-56T09:15:90', errors.DateTimeError),
         (19_999_999_999, datetime(2603, 10, 11, 11, 33, 19, tzinfo=timezone.utc)),  # just before watershed
         (20_000_000_001, datetime(1970, 8, 20, 11, 33, 20, 1000, tzinfo=timezone.utc)),  # just after watershed
-        (int(4e22) + 1, datetime(1971, 4, 8, 23, 6, 40, tzinfo=timezone.utc)),  # divide twice
+        (1549316052, datetime(2019, 2, 4, 21, 34, 12, 0, tzinfo=timezone.utc)),  # nowish in s
+        (1549316052104, datetime(2019, 2, 4, 21, 34, 12, 104000, tzinfo=timezone.utc)),  # nowish in ms
+        (1549316052104324, datetime(2019, 2, 4, 21, 34, 12, 104324, tzinfo=timezone.utc)),  # nowish in μs
+        (1549316052104324096, datetime(2019, 2, 4, 21, 34, 12, 104324, tzinfo=timezone.utc)),  # nowish in ns
     ],
 )
 def test_datetime_parsing(value, result):

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -34,6 +34,8 @@ def create_tz(minutes):
         # Invalid inputs
         ('x20120423', errors.DateError),
         ('2012-04-56', errors.DateError),
+        (19_999_999_999, date(2603, 10, 11)),  # just before watershed
+        (20_000_000_001, date(1970, 8, 20)),  # just after watershed
     ],
 )
 def test_date_parsing(value, result):
@@ -90,6 +92,9 @@ def test_time_parsing(value, result):
         # Invalid inputs
         ('x20120423091500', errors.DateTimeError),
         ('2012-04-56T09:15:90', errors.DateTimeError),
+        (19_999_999_999, datetime(2603, 10, 11, 11, 33, 19, tzinfo=timezone.utc)),  # just before watershed
+        (20_000_000_001, datetime(1970, 8, 20, 11, 33, 20, 1000, tzinfo=timezone.utc)),  # just after watershed
+        (int(4e22) + 1, datetime(1971, 4, 8, 23, 6, 40, tzinfo=timezone.utc)),  # divide twice
     ],
 )
 def test_datetime_parsing(value, result):


### PR DESCRIPTION
## Change Summary

Change the second/millisecond watershed for date/datetime parsing to ``2e10``

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
