### PR TITLE
rebuild validator arguments

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+v0.20.0 (unreleased)
+....................
+* **breaking change** (maybe): more sophisticated argument parsing for validators, unused arguments
+  will now be omitted meaning no need for ``**kwargs``, but key word arguments **must** now be called
+  ``kwargs``, #388 by @samuelcolvin
+
 v0.19.0 (2019-02-04)
 ....................
 * Support ``Callable`` type hint, fix #279 by @proofit404

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,9 @@ History
 
 v0.20.0 (unreleased)
 ....................
-* **breaking change** (maybe): more sophisticated argument parsing for validators, unused arguments
-  will now be omitted meaning no need for ``**kwargs``, but key word arguments **must** now be called
-  ``kwargs``, #388 by @samuelcolvin
+* **breaking change** (maybe): more sophisticated argument parsing for validators, any subset of
+  ``values``, ``config`` and ``field`` is now permitted, eg. ``(cls, value, field)``,
+  however the variadic key word argument ("``**kwargs``") **must** be called ``kwargs``, #388 by @samuelcolvin
 
 v0.19.0 (2019-02-04)
 ....................

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -171,7 +171,9 @@ A few things to note on validators:
 
 * validators are "class methods", the first value they receive here will be the ``UserModel`` not an instance
   of ``UserModel``
-* their signature can be ``(cls, value)`` or ``(cls, value, *, values, config, field)``
+* their signature can be ``(cls, value)`` or ``(cls, value, values, config, field)``. As of **v0.20**, any subset of
+  ``values``, ``config`` and ``field`` is also permitted, eg. ``(cls, value, field)``, however due to the way
+  validators are inspected, the variadic key word argument ("``**kwargs``") **must** be called ``kwargs``.
 * validator should either return the new value or raise a ``ValueError`` or ``TypeError``
 * where validators rely on other values, you should be aware that:
 

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -1,19 +1,18 @@
 import inspect
 from dataclasses import dataclass
-from enum import IntEnum
+from functools import wraps
 from itertools import chain
 from types import FunctionType
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type
 
 from .errors import ConfigError
 from .utils import AnyCallable, in_ipython
 
+if TYPE_CHECKING:
+    from .main import BaseConfig, BaseModel
+    from .fields import Field
 
-class ValidatorSignature(IntEnum):
-    JUST_VALUE = 1
-    VALUE_KWARGS = 2
-    CLS_JUST_VALUE = 3
-    CLS_VALUE_KWARGS = 4
+    ValidatorCallable = Callable[[Optional[Type[BaseModel]], Any, Dict[str, Any], Field, Type[BaseConfig]], Any]
 
 
 @dataclass
@@ -118,30 +117,99 @@ def inherit_validators(base_validators: ValidatorListDict, validators: Validator
     return validators
 
 
-def get_validator_signature(validator: Any) -> ValidatorSignature:
+all_kwargs = {'values', 'field', 'config'}
+
+
+def _make_generic_validator(validator: AnyCallable) -> 'ValidatorCallable':  # noqa: C901 (ignore complexity)
+    """
+    Logic for building validators with a generic signature.
+
+    Unfortunately other approaches eg. return a partial of a function that builds the arguments is slow than this,
+    hence this laborious way of doing things.
+
+    It's done like this so validators don't all need **kwargs in their signature, eg. any combination of
+    the arguments "values", "fields" and/or "config" are permitted.
+    """
     signature = inspect.signature(validator)
+    args = list(signature.parameters.keys())
+    # debug(validator, args)
 
     # bind here will raise a TypeError so:
     # 1. we can deal with it before validation begins
     # 2. (more importantly) it doesn't get confused with a TypeError when executing the validator
-    try:
-        if 'cls' in signature._parameters:  # type: ignore
-            if len(signature.parameters) == 2:
-                signature.bind(object(), 1)
-                return ValidatorSignature.CLS_JUST_VALUE
-            else:
-                signature.bind(object(), 1, values=2, config=3, field=4)
-                return ValidatorSignature.CLS_VALUE_KWARGS
+    if args[0] == 'cls':
+        other_args = set(args[2:])
+        has_kwargs = False
+        if 'kwargs' in other_args:
+            has_kwargs = True
+            other_args -= {'kwargs'}
+        if not other_args.issubset(all_kwargs):
+            raise ConfigError(
+                f'Invalid signature for validator {validator}: {signature}, should be: '
+                f'(cls, value, *, values, config, field), "values", "config" and "field" are all optional.'
+            )
+        if has_kwargs:
+            return lambda cls, v, values, field, config: validator(cls, v, values=values, field=field, config=config)
+        elif other_args == set():
+            return lambda cls, v, values, field, config: validator(cls, v)
+        elif other_args == {'values'}:
+            return lambda cls, v, values, field, config: validator(cls, v, values=values)
+        elif other_args == {'field'}:
+            return lambda cls, v, values, field, config: validator(cls, v, field=field)
+        elif other_args == {'config'}:
+            return lambda cls, v, values, field, config: validator(cls, v, config=config)
+        elif other_args == {'values', 'field'}:
+            return lambda cls, v, values, field, config: validator(cls, v, values=values, field=field)
+        elif other_args == {'values', 'config'}:
+            return lambda cls, v, values, field, config: validator(cls, v, values=values, config=config)
+        elif other_args == {'field', 'config'}:
+            return lambda cls, v, values, field, config: validator(cls, v, field=field, config=config)
         else:
-            if len(signature.parameters) == 1:
-                signature.bind(1)
-                return ValidatorSignature.JUST_VALUE
-            else:
-                signature.bind(1, values=2, config=3, field=4)
-                return ValidatorSignature.VALUE_KWARGS
-    except TypeError as e:
+            # other_args == {'values', 'field', 'config'}
+            return lambda cls, v, values, field, config: validator(cls, v, values=values, field=field, config=config)
+    elif args[0] == 'self':
         raise ConfigError(
             f'Invalid signature for validator {validator}: {signature}, should be: '
-            f'(value) or (value, *, values, config, field) or for class validators '
-            f'(cls, value) or (cls, value, *, values, config, field)'
-        ) from e
+            f'(cls, value, *, values, config, field), "values", "config" and "field" are all optional.'
+        )
+    else:
+        # assume the first argument is value
+        other_args = set(args[1:])
+        has_kwargs = False
+        if 'kwargs' in other_args:
+            has_kwargs = True
+            other_args -= {'kwargs'}
+        if not other_args.issubset(all_kwargs):
+            raise ConfigError(
+                f'Invalid signature for validator {validator}: {signature}, should be: '
+                f'(value, *, values, config, field), "values", "config" and "field" are all optional.'
+            )
+        if has_kwargs:
+            return lambda cls, v, values, field, config: validator(v, values=values, field=field, config=config)
+        elif other_args == set():
+            return lambda cls, v, values, field, config: validator(v)
+        elif other_args == {'values'}:
+            return lambda cls, v, values, field, config: validator(v, values=values)
+        elif other_args == {'field'}:
+            return lambda cls, v, values, field, config: validator(v, field=field)
+        elif other_args == {'config'}:
+            return lambda cls, v, values, field, config: validator(v, config=config)
+        elif other_args == {'values', 'field'}:
+            return lambda cls, v, values, field, config: validator(v, values=values, field=field)
+        elif other_args == {'values', 'config'}:
+            return lambda cls, v, values, field, config: validator(v, values=values, config=config)
+        elif other_args == {'field', 'config'}:
+            return lambda cls, v, values, field, config: validator(v, field=field, config=config)
+        else:
+            # other_args == {'values', 'field', 'config'}
+            return lambda cls, v, values, field, config: validator(v, values=values, field=field, config=config)
+
+
+def make_generic_validator(validator: AnyCallable) -> 'ValidatorCallable':
+    """
+    Make a generic function which calls a validator with the right arguments.
+
+    make_generic_validator vs. _make_generic_validator is a bodge to avoid "E731 do not assign a lambda expression"
+    errors.
+    """
+    return wraps(validator)(_make_generic_validator(validator))

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Pattern, Set, Tuple, Type, Union, cast
 
 from . import errors as errors_
-from .class_validators import Validator, ValidatorSignature, get_validator_signature
+from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
 from .utils import AnyCallable, AnyType, Callable, ForwardRef, display_as_type, lenient_issubclass, list_like
@@ -12,11 +12,12 @@ from .validators import NoneType, dict_validator, find_validators
 Required: Any = Ellipsis
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .schema import Schema  # noqa: F401
-    from .main import BaseConfig, BaseModel  # noqa: F401
+    from .class_validators import ValidatorCallable  # noqa: F401
     from .error_wrappers import ErrorList
+    from .main import BaseConfig, BaseModel  # noqa: F401
+    from .schema import Schema  # noqa: F401
 
-    ValidatorTuple = Tuple[Tuple[ValidatorSignature, AnyCallable], ...]
+    ValidatorsTuple = Tuple[ValidatorCallable, ...]
     ValidateReturn = Tuple[Optional[Any], Optional[ErrorList]]
     LocType = Union[Tuple[str, ...], str]
 
@@ -78,9 +79,9 @@ class Field:
         self.validate_always: bool = False
         self.sub_fields: Optional[List[Field]] = None
         self.key_field: Optional[Field] = None
-        self.validators: 'ValidatorTuple' = ()
-        self.whole_pre_validators: Optional['ValidatorTuple'] = None
-        self.whole_post_validators: Optional['ValidatorTuple'] = None
+        self.validators: 'ValidatorsTuple' = ()
+        self.whole_pre_validators: Optional['ValidatorsTuple'] = None
+        self.whole_post_validators: Optional['ValidatorsTuple'] = None
         self.parse_json: bool = False
         self.shape: Shape = Shape.SINGLETON
         self.prepare()
@@ -235,8 +236,8 @@ class Field:
             self.whole_post_validators = self._prep_vals(v.func for v in class_validators_ if v.whole and not v.pre)
 
     @staticmethod
-    def _prep_vals(v_funcs: Iterable[AnyCallable]) -> 'ValidatorTuple':
-        return tuple((get_validator_signature(f), f) for f in v_funcs if f)
+    def _prep_vals(v_funcs: Iterable[AnyCallable]) -> 'ValidatorsTuple':
+        return tuple(make_generic_validator(f) for f in v_funcs if f)
 
     def validate(
         self, v: Any, values: Dict[str, Any], *, loc: 'LocType', cls: Optional[Type['BaseModel']] = None
@@ -379,19 +380,11 @@ class Field:
         values: Dict[str, Any],
         loc: 'LocType',
         cls: Optional[Type['BaseModel']],
-        validators: 'ValidatorTuple',
+        validators: 'ValidatorsTuple',
     ) -> 'ValidateReturn':
-        for signature, validator in validators:
+        for validator in validators:
             try:
-                if signature is ValidatorSignature.JUST_VALUE:
-                    v = validator(v)
-                elif signature is ValidatorSignature.VALUE_KWARGS:
-                    v = validator(v, values=values, config=self.model_config, field=self)
-                elif signature is ValidatorSignature.CLS_JUST_VALUE:
-                    v = validator(cls, v)
-                else:
-                    # ValidatorSignature.CLS_VALUE_KWARGS
-                    v = validator(cls, v, values=values, config=self.model_config, field=self)
+                v = validator(cls, v, values, self, self.model_config)
             except (ValueError, TypeError) as exc:
                 return v, ErrorWrapper(exc, loc=loc, config=self.model_config)
         return v, None

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -276,7 +276,7 @@ class DSN(str):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value: str, values: Dict[str, Any], **kwarg: Any) -> str:
+    def validate(cls, value: str, values: Dict[str, Any]) -> str:
         if value:
             return value
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -89,7 +89,7 @@ def float_validator(v: Any) -> float:
         return float(v)
 
 
-def number_multiple_validator(v: 'Number', field: 'Field', config: 'BaseConfig', **kwargs: Any) -> 'Number':
+def number_multiple_validator(v: 'Number', field: 'Field') -> 'Number':
     field_type = cast('ConstrainedNumber', field.type_)
     if field_type.multiple_of is not None and v % field_type.multiple_of != 0:  # type: ignore
         raise errors.NumberNotMultipleError(multiple_of=field_type.multiple_of)
@@ -97,7 +97,7 @@ def number_multiple_validator(v: 'Number', field: 'Field', config: 'BaseConfig',
     return v
 
 
-def number_size_validator(v: 'Number', field: 'Field', config: 'BaseConfig', **kwargs: Any) -> 'Number':
+def number_size_validator(v: 'Number', field: 'Field') -> 'Number':
     field_type = cast('ConstrainedNumber', field.type_)
     if field_type.gt is not None and not v > field_type.gt:
         raise errors.NumberNotGtError(limit_value=field_type.gt)
@@ -112,7 +112,7 @@ def number_size_validator(v: 'Number', field: 'Field', config: 'BaseConfig', **k
     return v
 
 
-def anystr_length_validator(v: 'StrBytes', field: 'Field', config: 'BaseConfig', **kwargs: Any) -> 'StrBytes':
+def anystr_length_validator(v: 'StrBytes', field: 'Field', config: 'BaseConfig') -> 'StrBytes':
     v_len = len(v)
 
     min_length = getattr(field.type_, 'min_length', config.min_anystr_length)
@@ -126,7 +126,7 @@ def anystr_length_validator(v: 'StrBytes', field: 'Field', config: 'BaseConfig',
     return v
 
 
-def anystr_strip_whitespace(v: 'StrBytes', field: 'Field', config: 'BaseConfig', **kwargs: Any) -> 'StrBytes':
+def anystr_strip_whitespace(v: 'StrBytes', field: 'Field', config: 'BaseConfig') -> 'StrBytes':
     strip_whitespace = getattr(field.type_, 'strip_whitespace', config.anystr_strip_whitespace)
     if strip_whitespace:
         v = v.strip()
@@ -177,14 +177,14 @@ def set_validator(v: Any) -> Set[Any]:
         raise errors.SetError()
 
 
-def enum_validator(v: Any, field: 'Field', config: 'BaseConfig', **kwargs: Any) -> Enum:
+def enum_validator(v: Any, field: 'Field', config: 'BaseConfig') -> Enum:
     with change_exception(errors.EnumError, ValueError):
         enum_v = field.type_(v)
 
     return enum_v.value if config.use_enum_values else enum_v
 
 
-def uuid_validator(v: Any, field: 'Field', config: 'BaseConfig', **kwargs: Any) -> UUID:
+def uuid_validator(v: Any, field: 'Field') -> UUID:
     with change_exception(errors.UUIDError, ValueError):
         if isinstance(v, str):
             v = UUID(v)

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.19.0')
+VERSION = StrictVersion('0.20.0a1')

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -25,7 +25,7 @@ def test_str_bytes():
     m = Model(v='s')
     assert m.v == 's'
     assert '<Field(v type=typing.Union[str, bytes] required)>' == repr(m.fields['v'])
-    assert 'not_none_validator' in [v[1].__qualname__ for v in m.fields['v'].sub_fields[0].validators]
+    assert 'not_none_validator' in [v.__qualname__ for v in m.fields['v'].sub_fields[0].validators]
 
     m = Model(v=b'b')
     assert m.v == 'b'

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,8 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from pydantic import BaseModel, ValidationError, errors, validator
+from pydantic import BaseModel, ConfigError, ValidationError, errors, validator
+from pydantic.class_validators import make_generic_validator
 
 
 def test_simple():
@@ -558,3 +559,82 @@ def test_whole_called_once():
 
     assert Model(a=['1', '2', '3']).a == (1, 2, 3)
     assert check_calls == 1
+
+
+@pytest.mark.parametrize(
+    'fields,result',
+    [
+        (['val'], '_v_'),
+        (['foobar'], '_v_'),
+        (['val', 'field'], '_v_,_field_'),
+        (['val', 'config'], '_v_,_config_'),
+        (['val', 'values'], '_v_,_values_'),
+        (['val', 'field', 'config'], '_v_,_field_,_config_'),
+        (['val', 'field', 'values'], '_v_,_field_,_values_'),
+        (['val', 'config', 'values'], '_v_,_config_,_values_'),
+        (['val', 'field', 'values', 'config'], '_v_,_field_,_values_,_config_'),
+        (['cls', 'val'], '_cls_,_v_'),
+        (['cls', 'foobar'], '_cls_,_v_'),
+        (['cls', 'val', 'field'], '_cls_,_v_,_field_'),
+        (['cls', 'val', 'config'], '_cls_,_v_,_config_'),
+        (['cls', 'val', 'values'], '_cls_,_v_,_values_'),
+        (['cls', 'val', 'field', 'config'], '_cls_,_v_,_field_,_config_'),
+        (['cls', 'val', 'field', 'values'], '_cls_,_v_,_field_,_values_'),
+        (['cls', 'val', 'config', 'values'], '_cls_,_v_,_config_,_values_'),
+        (['cls', 'val', 'field', 'values', 'config'], '_cls_,_v_,_field_,_values_,_config_'),
+    ],
+)
+def test_make_generic_validator(fields, result):
+    exec(f"""def testing_function({', '.join(fields)}): return {' + "," + '.join(fields)}""")
+    func = locals()['testing_function']
+    validator = make_generic_validator(func)
+    assert validator.__qualname__ == 'testing_function'
+    assert validator.__name__ == 'testing_function'
+    # args: cls, v, values, field, config
+    assert validator('_cls_', '_v_', '_values_', '_field_', '_config_') == result
+
+
+def test_make_generic_validator_kwargs():
+    def test_validator(v, **kwargs):
+        return ', '.join(f'{k}: {v}' for k, v in kwargs.items())
+
+    validator = make_generic_validator(test_validator)
+    assert validator.__name__ == 'test_validator'
+    assert validator('_cls_', '_v_', '_vs_', '_f_', '_c_') == 'values: _vs_, field: _f_, config: _c_'
+
+
+def test_make_generic_validator_invalid():
+    def test_validator(v, foobar):
+        return foobar
+
+    with pytest.raises(ConfigError) as exc_info:
+        make_generic_validator(test_validator)
+    assert ': (v, foobar), should be: (value, values, config, field)' in str(exc_info.value)
+
+
+def test_make_generic_validator_cls_kwargs():
+    def test_validator(cls, v, **kwargs):
+        return ', '.join(f'{k}: {v}' for k, v in kwargs.items())
+
+    validator = make_generic_validator(test_validator)
+    assert validator.__name__ == 'test_validator'
+    assert validator('_cls_', '_v_', '_vs_', '_f_', '_c_') == 'values: _vs_, field: _f_, config: _c_'
+
+
+def test_make_generic_validator_cls_invalid():
+    def test_validator(cls, v, foobar):
+        return foobar
+
+    with pytest.raises(ConfigError) as exc_info:
+        make_generic_validator(test_validator)
+    assert ': (cls, v, foobar), should be: (cls, value, values, config, field)' in str(exc_info.value)
+
+
+def test_make_generic_validator_self():
+    def test_validator(self, v):
+        return v
+
+    with pytest.raises(ConfigError) as exc_info:
+        make_generic_validator(test_validator)
+    debug(str(exc_info.value))
+    assert ': (self, v), "self" not permitted as first argument, should be: (cls, value' in str(exc_info.value)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -636,5 +636,4 @@ def test_make_generic_validator_self():
 
     with pytest.raises(ConfigError) as exc_info:
         make_generic_validator(test_validator)
-    debug(str(exc_info.value))
     assert ': (self, v), "self" not permitted as first argument, should be: (cls, value' in str(exc_info.value)


### PR DESCRIPTION
## Change Summary

Before now, you either had to use all or none of `values`, `field` and `config` extra arguments on validators. This fixes that by allowing any combination of the arguments to be used.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
