### PR TITLE
Tracking for setting attributes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@
 History
 -------
 
+* Adds ``skip_defaults`` argument to ``BaseModel.dict()`` to allow skipping of fields that were not
+  explicitly set, #389 by @dgasmith
+
 v0.19.0 (2019-02-04)
 ....................
 * Support ``Callable`` type hint, fix #279 by @proofit404

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@
 History
 -------
 
+v0.20.0 (unreleased)
+....................
 * Adds ``skip_defaults`` argument to ``BaseModel.dict()`` to allow skipping of fields that were not
   explicitly set, #389 by @dgasmith
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -632,6 +632,10 @@ converted to dicts, ``copy`` allows models to be duplicated, this is particularl
 respectively. ``copy`` accepts extra keyword arguments, ``update``, which accepts a ``dict`` mapping attributes
 to new values that will be applied as the model is duplicated and ``deep`` to make a deep copy of the model.
 
+``dict`` and ``json`` take the optional ``skip_defaults`` keyword argument which will skip attributes that were
+not explicitly set. This is useful to reduce the serialized size of models thats have many default fields that
+are not often changed.
+
 .. literalinclude:: examples/copy_dict.py
 
 Serialisation

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -332,21 +332,14 @@ class BaseModel(metaclass=MetaModel):
         return cls.parse_obj(obj)
 
     @classmethod
-    def construct(cls, **values: Any) -> 'BaseModel':
+    def construct(cls, fields_set: Optional[Set[str]] = None, **values: Any) -> 'BaseModel':
         """
         Creates a new model and set __values__ without any validation, thus values should already be trusted.
         Chances are you don't want to use this method directly.
         """
         m = cls.__new__(cls)
-        m.__setstate__(values)
-        return m
-
-    @classmethod
-    def construct_with_state(cls, values: Any, fields_set: Optional[Set[str]]) -> 'BaseModel':
-        m = cls.__new__(cls)
         m.__setstate__(values, fields_set=fields_set)
         return m
-
 
     def copy(
         self, *, include: Set[str] = None, exclude: Set[str] = None, update: 'DictStrAny' = None, deep: bool = False
@@ -369,7 +362,7 @@ class BaseModel(metaclass=MetaModel):
             v = {**{k: v for k, v in self.__values__.items() if k in return_keys}, **(update or {})}
         if deep:
             v = deepcopy(v)
-        m = self.__class__.construct_with_state(v, self.__fields_set__)
+        m = self.__class__.construct(fields_set=self.__fields_set__, **v)
         return m
 
     @property

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -212,7 +212,7 @@ class BaseModel(metaclass=MetaModel):
         if TYPE_CHECKING:  # pragma: no cover
             self.__values__: Dict[str, Any] = {}
             self.__fields_set__: Set[str] = set()
-        self.__setstate__(self._process_values(data), fields_set=data.pop("__fields_set__", None))
+        self.__setstate__(self._process_values(data), fields_set=set(data.keys()))
 
     @no_type_check
     def __getattr__(self, name):
@@ -349,7 +349,7 @@ class BaseModel(metaclass=MetaModel):
         """
         if include is None and exclude is None and update is None:
             # skip constructing values if no arguments are passed
-            v = self.__values__
+            v = self.__values__.copy()
         else:
             return_keys = self._calculate_keys(include=include, exclude=exclude, skip_defaults=False)
             v = {

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -269,7 +269,9 @@ class BaseModel(metaclass=MetaModel):
         if return_keys is None:
             return {get_key(k): v for k, v in self._iter(by_alias=by_alias, skip_defaults=skip_defaults)}
         else:
-            return {get_key(k): v for k, v in self._iter(by_alias=by_alias, skip_defaults=skip_defaults) if k in return_keys}
+            return {
+                get_key(k): v for k, v in self._iter(by_alias=by_alias, skip_defaults=skip_defaults) if k in return_keys
+            }
 
     def _get_key_factory(self, by_alias: bool) -> Callable[..., str]:
         if by_alias:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -438,7 +438,7 @@ class BaseModel(metaclass=MetaModel):
             yield k, self._get_value(v, by_alias=by_alias, skip_defaults=skip_defaults)
 
     def _calculate_keys(
-        self, include: Set[str] = None, exclude: Set[str] = set(), skip_defaults: bool = False
+        self, include: Set[str] = None, exclude: Optional[Set[str]] = set(), skip_defaults: bool = False
     ) -> Set[str]:
         if skip_defaults:
             keys = self.__fields_set__.copy()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -237,7 +237,7 @@ class BaseModel(metaclass=MetaModel):
                 self.__fields_set__.add(name)
         else:
             self.__values__[name] = value
-            self.__fields_set__.update({name})
+            self.__fields_set__.add(name)
 
     def __getstate__(self) -> Dict[Any, Any]:
         return self.__values__

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -234,7 +234,7 @@ class BaseModel(metaclass=MetaModel):
                 raise ValidationError([error_])
             else:
                 self.__values__[name] = value_
-                self.__fields_set__.update({name})
+                self.__fields_set__.add(name)
         else:
             self.__values__[name] = value
             self.__fields_set__.update({name})

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -221,7 +221,11 @@ class BaseModel(metaclass=MetaModel):
             self.__values__: Dict[str, Any] = {}
             self.__fields_set__: Set[str] = set()
         object.__setattr__(self, '__values__', self._process_values(data))
-        object.__setattr__(self, '__fields_set__', set(data.keys()))
+        if self.__config__.extra is Extra.allow:
+            fields_set = set(data.keys())
+        else:
+            fields_set = data.keys() & self.__values__.keys()  # type: ignore
+        object.__setattr__(self, '__fields_set__', fields_set)
 
     @no_type_check
     def __getattr__(self, name):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -112,6 +112,14 @@ def test_copy_update():
     assert m != m2
 
 
+def test_copy_set_fields():
+    m = ModelTwo(a=24, d=Model(a='12'))
+    m2 = m.copy()
+
+    assert m.dict(skip_defaults=True) == {"a": 24.0, "d": {"a": 12}}
+    assert m.dict(skip_defaults=True) == m2.dict(skip_defaults=True)
+
+
 def test_simple_pickle():
     m = Model(a='24')
     b = pickle.dumps(m)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 
 class Model(BaseModel):
-    a: float = ...
+    a: float
     b: int = 10
 
 
@@ -116,7 +116,8 @@ def test_copy_set_fields():
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy()
 
-    assert m.dict(skip_defaults=True) == m2.dict(skip_defaults=True) == {'a': 24.0, 'd': {'a': 12}}
+    assert m.dict(skip_defaults=True) == {'a': 24.0, 'd': {'a': 12}}
+    assert m.dict(skip_defaults=True) == m2.dict(skip_defaults=True)
 
 
 def test_simple_pickle():
@@ -157,3 +158,10 @@ def test_immutable_copy():
     assert str(m2) == 'Model a=40 b=12'
     with pytest.raises(TypeError):
         m2.b = 13
+
+
+def test_pickle_fields_set():
+    m = Model(a=24)
+    assert m.dict(skip_defaults=True) == {'a': 24}
+    m2 = pickle.loads(pickle.dumps(m))
+    assert m2.dict(skip_defaults=True) == {'a': 24}

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -11,13 +11,13 @@ class Model(BaseModel):
 
 
 def test_simple_construct():
-    m = Model.construct(a=40, b=10)
+    m = Model.construct(dict(a=40, b=10), {'a', 'b'})
     assert m.a == 40
     assert m.b == 10
 
 
 def test_construct_missing():
-    m = Model.construct(a='not a float')
+    m = Model.construct(dict(a='not a float'), {'a'})
     assert m.a == 'not a float'
     with pytest.raises(AttributeError) as exc_info:
         print(m.b)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -116,8 +116,7 @@ def test_copy_set_fields():
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy()
 
-    assert m.dict(skip_defaults=True) == {"a": 24.0, "d": {"a": 12}}
-    assert m.dict(skip_defaults=True) == m2.dict(skip_defaults=True)
+    assert m.dict(skip_defaults=True) == m2.dict(skip_defaults=True) == {'a': 24.0, 'd': {'a': 12}}
 
 
 def test_simple_pickle():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -370,6 +370,27 @@ def test_success_values_include():
     assert m.dict(include={'a', 'b'}, exclude={'a'}) == {'b': 2}
 
 
+def test_include_exclude_default():
+    class Model(BaseModel):
+        a: int
+        b: int
+        c: int = 3
+        d: int = 4
+
+    m = Model(a=1, b=2)
+    assert m.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+    assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+
+    assert m.dict(include={'a'}, skip_defaults=True) == {'a': 1}
+    assert m.dict(include={'c'}, skip_defaults=True) == {}
+
+    assert m.dict(exclude={'a'}, skip_defaults=True) == {'b': 2}
+    assert m.dict(exclude={'c'}, skip_defaults=True) == {'a': 1, 'b': 2}
+
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, skip_defaults=True) == {'a': 1}
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, skip_defaults=True) == {'b': 2}
+
+
 def test_values_order():
     class Model(BaseModel):
         a: int = 1

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -379,6 +379,7 @@ def test_include_exclude_default():
 
     m = Model(a=1, b=2)
     assert m.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+    assert m.__fields_set__ == {'a', 'b'}
     assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
 
     assert m.dict(include={'a'}, skip_defaults=True) == {'a': 1}
@@ -391,7 +392,48 @@ def test_include_exclude_default():
     assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, skip_defaults=True) == {'b': 2}
 
 
-def test_field_set():
+def test_field_set_ignore_extra():
+    class Model(BaseModel):
+        a: int
+        b: int
+        c: int = 3
+
+        class Config:
+            extra = Extra.ignore
+
+    m = Model(a=1, b=2)
+    assert m.dict() == {'a': 1, 'b': 2, 'c': 3}
+    assert m.__fields_set__ == {'a', 'b'}
+    assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+
+    m2 = Model(a=1, b=2, d=4)
+    assert m2.dict() == {'a': 1, 'b': 2, 'c': 3}
+    assert m2.__fields_set__ == {'a', 'b'}
+    assert m2.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+
+
+def test_field_set_allow_extra():
+    class Model(BaseModel):
+        a: int
+        b: int
+        c: int = 3
+
+        class Config:
+            extra = Extra.allow
+
+    m = Model(a=1, b=2)
+    assert m.dict() == {'a': 1, 'b': 2, 'c': 3}
+    assert m.__fields_set__ == {'a', 'b'}
+    assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+
+    m2 = Model(a=1, b=2, d=4)
+    assert m2.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+    assert m2.__fields_set__ == {'a', 'b', 'd'}
+    assert m2.dict(skip_defaults=True) == {'a': 1, 'b': 2, 'd': 4}
+
+
+
+def test_field_set_field_name():
     class Model(BaseModel):
         a: int
         field_set: int

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -399,7 +399,7 @@ def test_field_set():
 
     assert Model(a=1, field_set=2).dict() == {'a': 1, 'field_set': 2, 'b': 3}
     assert Model(a=1, field_set=2).dict(skip_defaults=True) == {'a': 1, 'field_set': 2}
-    assert Model.construct(a=1, fields_set=3).dict() == {'a': 1, 'field_set': 2, 'b': 3}
+    assert Model.construct(dict(a=1, field_set=3), {'a', 'field_set'}).dict() == {'a': 1, 'field_set': 3}
 
 
 def test_values_order():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -432,7 +432,6 @@ def test_field_set_allow_extra():
     assert m2.dict(skip_defaults=True) == {'a': 1, 'b': 2, 'd': 4}
 
 
-
 def test_field_set_field_name():
     class Model(BaseModel):
         a: int

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -391,6 +391,17 @@ def test_include_exclude_default():
     assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, skip_defaults=True) == {'b': 2}
 
 
+def test_field_set():
+    class Model(BaseModel):
+        a: int
+        field_set: int
+        b: int = 3
+
+    assert Model(a=1, field_set=2).dict() == {'a': 1, 'field_set': 2, 'b': 3}
+    assert Model(a=1, field_set=2).dict(skip_defaults=True) == {'a': 1, 'field_set': 2}
+    assert Model.construct(a=1, fields_set=3).dict() == {'a': 1, 'field_set': 2, 'b': 3}
+
+
 def test_values_order():
     class Model(BaseModel):
         a: int = 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -541,5 +541,21 @@ def test_skip_defaults_dict():
     m = MyModel(a=5)
     assert m.dict(skip_defaults=True) == {'a': 5}
 
-    m = MyModel(a=5, b=2)
-    assert m.dict(skip_defaults=True) == {'a': 5, 'b': 2}
+    m = MyModel(a=5, b=3)
+    assert m.dict(skip_defaults=True) == {'a': 5, 'b': 3}
+
+
+def test_skip_defaults_recursive():
+    class ModelA(BaseModel):
+        a: int
+        b: int = 1
+
+    class ModelB(BaseModel):
+        c: int
+        d: int = 2
+        e: ModelA
+
+    m = ModelB(c=5, e={'a': 0})
+    assert m.dict() == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
+    assert m.dict(skip_defaults=True) == {'c': 5, 'e': {'a': 0}}
+    assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -539,7 +539,7 @@ def test_skip_defaults_dict():
         b: int = 2
 
     m = MyModel(a=5)
-    assert m.dict(skip_defaults=True) == {"a": 5}
+    assert m.dict(skip_defaults=True) == {'a': 5}
 
     m = MyModel(a=5, b=2)
-    assert m.dict(skip_defaults=True) == {"a": 5, "b": 2}
+    assert m.dict(skip_defaults=True) == {'a': 5, 'b': 2}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -516,3 +516,30 @@ def test_class_var():
         c: int = 2
 
     assert list(MyModel.__fields__.keys()) == ['c']
+
+
+def test_fields_set():
+    class MyModel(BaseModel):
+        a: int
+        b: int = 2
+
+    m = MyModel(a=5)
+    assert m.__fields_set__ == {'a'}
+
+    m.b = 2
+    assert m.__fields_set__ == {'a', 'b'}
+
+    m = MyModel(a=5, b=2)
+    assert m.__fields_set__ == {'a', 'b'}
+
+
+def test_skip_defaults_dict():
+    class MyModel(BaseModel):
+        a: int
+        b: int = 2
+
+    m = MyModel(a=5)
+    assert m.dict(skip_defaults=True) == {"a": 5}
+
+    m = MyModel(a=5, b=2)
+    assert m.dict(skip_defaults=True) == {"a": 5, "b": 2}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -24,21 +24,21 @@ def test_fails():
 
 
 def test_json():
-    assert Model.parse_raw('{"a": 12, "b": 8}') == Model.construct(a=12, b=8)
+    assert Model.parse_raw('{"a": 12, "b": 8}') == Model(a=12, b=8)
 
 
 def test_json_ct():
-    assert Model.parse_raw('{"a": 12, "b": 8}', content_type='application/json') == Model.construct(a=12, b=8)
+    assert Model.parse_raw('{"a": 12, "b": 8}', content_type='application/json') == Model(a=12, b=8)
 
 
 def test_pickle_ct():
     data = pickle.dumps(dict(a=12, b=8))
-    assert Model.parse_raw(data, content_type='application/pickle', allow_pickle=True) == Model.construct(a=12, b=8)
+    assert Model.parse_raw(data, content_type='application/pickle', allow_pickle=True) == Model(a=12, b=8)
 
 
 def test_pickle_proto():
     data = pickle.dumps(dict(a=12, b=8))
-    assert Model.parse_raw(data, proto=Protocol.pickle, allow_pickle=True) == Model.construct(a=12, b=8)
+    assert Model.parse_raw(data, proto=Protocol.pickle, allow_pickle=True) == Model(a=12, b=8)
 
 
 def test_pickle_not_allowed():
@@ -64,22 +64,22 @@ def test_bad_proto():
 def test_file_json(tmpdir):
     p = tmpdir.join('test.json')
     p.write('{"a": 12, "b": 8}')
-    assert Model.parse_file(str(p)) == Model.construct(a=12, b=8)
+    assert Model.parse_file(str(p)) == Model(a=12, b=8)
 
 
 def test_file_json_no_ext(tmpdir):
     p = tmpdir.join('test')
     p.write('{"a": 12, "b": 8}')
-    assert Model.parse_file(str(p)) == Model.construct(a=12, b=8)
+    assert Model.parse_file(str(p)) == Model(a=12, b=8)
 
 
 def test_file_pickle(tmpdir):
     p = tmpdir.join('test.pkl')
     p.write_binary(pickle.dumps(dict(a=12, b=8)))
-    assert Model.parse_file(str(p), allow_pickle=True) == Model.construct(a=12, b=8)
+    assert Model.parse_file(str(p), allow_pickle=True) == Model(a=12, b=8)
 
 
 def test_file_pickle_no_ext(tmpdir):
     p = tmpdir.join('test')
     p.write_binary(pickle.dumps(dict(a=12, b=8)))
-    assert Model.parse_file(str(p), content_type='application/pickle', allow_pickle=True) == Model.construct(a=12, b=8)
+    assert Model.parse_file(str(p), content_type='application/pickle', allow_pickle=True) == Model(a=12, b=8)


### PR DESCRIPTION
## Change Summary

Tracking when default arguments are override and allows a `skip_defaults` kwarg in the `dict` method. 

A problem that I have not yet solved is that a BaseModel goes through the `dict_validator` and is then passed back into `BaseModel.validate` after being cast to a dict, this does not allow the `__fields_set__` to come through at the moment and recursive models do not work. Any suggestions here?

```
make benchmark-pydantic
Before:           pydantic best=29.726μs/iter avg=30.439μs/iter stdev=0.563μs/iter
After:            pydantic best=29.061μs/iter avg=29.695μs/iter stdev=0.473μs/iter
```
## Related issue number

Discussion in #378.

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`