### PR TITLE
add py.typed marker file for PEP-561 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,9 @@ setup(
     url='https://github.com/samuelcolvin/pydantic',
     license='MIT',
     packages=['pydantic'],
+    package_data={'pydantic': ['py.typed']},
     python_requires='>=3.6',
-    zip_safe=True,
+    zip_safe=False,  # https://mypy.readthedocs.io/en/latest/installed_packages.html
     install_requires=[
         'dataclasses>=0.6;python_version<"3.7"'
     ],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

[PEP-561](https://www.python.org/dev/peps/pep-0561/) specifies way for packages to mark them as having type information. As of v0.19 pydantic has improved inline type hints which can be utilized by mypy and similar tools.

Running `python setup.py sdist bdist_wheel` includes the `py.typed` file in both distributions.

HISTORY.rst changes needed for this, or something else missing?

## Related issue number

Closes #390

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`