### PR TITLE
Fix `extra` behaviour for multiple inheritance/mix-ins

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.19.1 (unreleased)
+....................
+* Fix ``extra`` behaviour for multiple inheritance/mix-ins, #394 by @YaraslauZhylko
+
 v0.19.0 (2019-02-04)
 ....................
 * Support ``Callable`` type hint, fix #279 by @proofit404

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -112,7 +112,7 @@ def set_extra(config: BaseConfig, cls_name: str) -> None:
             warnings.warn(
                 f'{cls_name}: "allow_extra" is deprecated and replaced by "extra", see {EXTRA_LINK}', DeprecationWarning
             )
-    else:
+    elif not isinstance(config.extra, Extra):
         try:
             config.extra = Extra(config.extra)
         except ValueError:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -720,3 +720,58 @@ def test_illegal_extra_value():
 
             class Config:
                 extra = 'foo'
+
+
+def test_multiple_inheritance_config():
+    class Parent(BaseModel):
+        class Config:
+            allow_mutation = False
+            extra = Extra.forbid
+
+    class Mixin(BaseModel):
+        class Config:
+            use_enum_values = True
+
+    class Child(Mixin, Parent):
+        class Config:
+            allow_population_by_alias = True
+
+    assert BaseModel.__config__.allow_mutation is True
+    assert BaseModel.__config__.allow_population_by_alias is False
+    assert BaseModel.__config__.extra is Extra.ignore
+    assert BaseModel.__config__.use_enum_values is False
+
+    assert Parent.__config__.allow_mutation is False
+    assert Parent.__config__.allow_population_by_alias is False
+    assert Parent.__config__.extra is Extra.forbid
+    assert Parent.__config__.use_enum_values is False
+
+    assert Mixin.__config__.allow_mutation is True
+    assert Mixin.__config__.allow_population_by_alias is False
+    assert Mixin.__config__.extra is Extra.ignore
+    assert Mixin.__config__.use_enum_values is True
+
+    assert Child.__config__.allow_mutation is False
+    assert Child.__config__.allow_population_by_alias is True
+    assert Child.__config__.extra is Extra.forbid
+    assert Child.__config__.use_enum_values is True
+
+
+def test_multiple_inheritance_config_legacy_extra():
+    with pytest.warns(DeprecationWarning, match='Parent: "ignore_extra" and "allow_extra" are deprecated and'):
+
+        class Parent(BaseModel):
+            class Config:
+                allow_extra = False
+                ignore_extra = False
+
+        class Mixin(BaseModel):
+            pass
+
+        class Child(Mixin, Parent):
+            pass
+
+    assert BaseModel.__config__.extra is Extra.ignore
+    assert Parent.__config__.extra is Extra.forbid
+    assert Mixin.__config__.extra is Extra.ignore
+    assert Child.__config__.extra is Extra.forbid


### PR DESCRIPTION
## Change Summary

New `Config.extra` supports both `Enum` and `str` values. And `set_extra` method always tries to convert the value to make sure it is an `Enum`.

But this leads to `extra` being re-constructed/re-assigned each time `BaseModel` is inherited from (even it it was not set in child classes `Config`) thus breaking `extra` inheritance when using mix-ins/multiple inheritance.

So `Config.extra` conversion/re-assignment was limited only to cases when `extra` is not an instance of `Extra` enum.

Rationale:
* If `extra` is an `Extra` enum value, then it was either:
    - inherited from one of the base Configs (`BaseConfig` has `extra = Extra.ignore`), and does not need to be re-assigned to the topmost MRO class.
    - was set directly in the topmost MRO class, and does not need to be re-assigned either.
* if `extra` in not an `Extra` enum value, than it was certainly set in the topmost MRO class (all base classes have already done the conversion), and is safe to be converted and re-assigned without messing MRO. 

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/392

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
