### PR TITLE
Allow autocompletion of fields

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.20.0 (unreleased)
 ....................
 * fix tests for python 3.8, #396 by @samuelcolvin
+* Adds fields to the ``dir`` method for autocompletion in interactive sessions, #398 by @dgasmith
 
 v0.20.0a1 (2019-02-13)
 ......................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -14,6 +14,7 @@ from typing import (
     ClassVar,
     Dict,
     Generator,
+    List,
     Optional,
     Set,
     Tuple,
@@ -51,6 +52,7 @@ if TYPE_CHECKING:  # pragma: no cover
     ConfigType = Type['BaseConfig']
     DictAny = Dict[Any, Any]
     SetStr = Set[str]
+    ListStr = List[str]
 
 
 class Extra(str, Enum):
@@ -494,6 +496,11 @@ class BaseModel(metaclass=MetaModel):
 
     def __str__(self) -> str:
         return self.to_string()
+
+    def __dir__(self) -> 'ListStr':
+        ret = list(object.__dir__(self))
+        ret.extend(self.__values__.keys())
+        return ret
 
 
 def create_model(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -559,3 +559,16 @@ def test_skip_defaults_recursive():
     assert m.dict() == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
     assert m.dict(skip_defaults=True) == {'c': 5, 'e': {'a': 0}}
     assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
+
+
+def test_dir_fields():
+    class MyModel(BaseModel):
+        attribute_a: int
+        attribute_b: int = 2
+
+    m = MyModel(attribute_a=5)
+
+    assert "dict" in dir(m)
+    assert "json" in dir(m)
+    assert "attribute_a" in dir(m)
+    assert "attribute_b" in dir(m)


### PR DESCRIPTION
## Change Summary

Modifies the `__dir__` method to show fields as well as canonical functions and attributes. As the `__dir__` method is explicitly for interactive use (see the [docs](https://docs.python.org/3/library/functions.html#dir)) this should not effect other areas of pydantic and as such is implemented in a very straightforward manner. It is also possible to hide metafields and the `Config` object as well if desired.

Use case: Our users will often handle pydantic objects in Jupyter notebooks and interactive interpreters where this feature is quite useful when exploring objects that they are not familiar with.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
