### PR TITLE
Fix type hints of parse_obj and similar methods

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.20.1 (unreleased)
+....................
+* fix type hints of ``parse_obj`` and similar methods, #405 by @erosennin
+
 v0.20.0 (2019-02-18)
 ....................
 * fix tests for python 3.8, #396 by @samuelcolvin

--- a/tests/mypy_test_success.py
+++ b/tests/mypy_test_success.py
@@ -3,6 +3,7 @@ Test pydantic's compliance with mypy.
 
 Do a little skipping about with types to demonstrate its usage.
 """
+import json
 from datetime import datetime
 from typing import List, Optional
 
@@ -45,6 +46,32 @@ assert m.first_name == 'Woof', m.first_name
 assert m.last_name == 'Woof', m.last_name
 assert m.signup_ts == datetime(2017, 6, 7), m.signup_ts
 assert day_of_week(m.signup_ts) == 3
+
+
+data = {'age': 10, 'first_name': 'Alena', 'last_name': 'Sousova', 'list_of_ints': [410]}
+m_from_obj = Model.parse_obj(data)
+
+assert isinstance(m_from_obj, Model)
+assert m_from_obj.age == 10
+assert m_from_obj.first_name == data['first_name']
+assert m_from_obj.last_name == data['last_name']
+assert m_from_obj.list_of_ints == data['list_of_ints']
+
+m_from_raw = Model.parse_raw(json.dumps(data))
+
+assert isinstance(m_from_raw, Model)
+assert m_from_raw.age == m_from_obj.age
+assert m_from_raw.first_name == m_from_obj.first_name
+assert m_from_raw.last_name == m_from_obj.last_name
+assert m_from_raw.list_of_ints == m_from_obj.list_of_ints
+
+m_copy = m_from_obj.copy()
+
+assert isinstance(m_from_raw, Model)
+assert m_copy.age == m_from_obj.age
+assert m_copy.first_name == m_from_obj.first_name
+assert m_copy.last_name == m_from_obj.last_name
+assert m_copy.list_of_ints == m_from_obj.list_of_ints
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Methods like `BaseModel.parse_obj()` or `BaseModel.copy()` have their return type specified as `BaseModel`. Because of that, valid code like this:

```python
from pydantic import BaseModel

class User(BaseModel):
    id: int
    name: str

u = User.parse_obj({
    'id': 11,
    'name': 'Acedia',
})

print(u.id, u.name)

```

does not type check:

```
example.py:12: error: "BaseModel" has no attribute "id"
example.py:12: error: "BaseModel" has no attribute "name"
```

This PR fixes that.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
