### PR TITLE
Fix the type hint of ValidationError.json

### DIFF
--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -61,7 +61,7 @@ class ValidationError(ValueError):
     def errors(self) -> List[Dict[str, Any]]:
         return list(flatten_errors(self.raw_errors))
 
-    def json(self, *, indent: int = 2) -> str:
+    def json(self, *, indent: Union[None, int, str] = 2) -> str:
         return json.dumps(self.errors(), indent=indent)
 
     def __str__(self) -> str:


### PR DESCRIPTION
As per the json.dumps documentation.

<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

This changes the type hint of `indent` to accept any of `None`, `int` and `str` in accordance with the [documentation](https://docs.python.org/3.5/library/json.html#json.dump) of `json.dumps`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
