### PR TITLE
fix typo in `NoneIsNotAllowedError` message

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.20.2 (unreleased)
+....................
+* fix typo in `NoneIsNotAllowedError` message, #414 by @YaraslauZhylko
+
 v0.20.1 (2019-02-26)
 ....................
 * fix type hints of ``parse_obj`` and similar methods, #405 by @erosennin

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -39,7 +39,7 @@ class ExtraError(PydanticValueError):
 
 class NoneIsNotAllowedError(PydanticTypeError):
     code = 'none.not_allowed'
-    msg_template = 'none is not an allow value'
+    msg_template = 'none is not an allowed value'
 
 
 class NoneIsAllowedError(PydanticTypeError):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -33,8 +33,8 @@ def test_str_bytes():
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
     assert exc_info.value.errors() == [
-        {'loc': ('v',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
-        {'loc': ('v',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
+        {'loc': ('v',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
+        {'loc': ('v',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
 
 
@@ -73,7 +73,7 @@ def test_union_int_str():
         Model(v=None)
     assert exc_info.value.errors() == [
         {'loc': ('v',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-        {'loc': ('v',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
+        {'loc': ('v',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
 
 
@@ -275,7 +275,7 @@ def test_list_unions():
         Model(v=[1, 2, None])
     assert exc_info.value.errors() == [
         {'loc': ('v', 2), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-        {'loc': ('v', 2), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
+        {'loc': ('v', 2), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
 
 
@@ -551,7 +551,7 @@ def test_string_none():
     with pytest.raises(ValidationError) as exc_info:
         Model(a=None)
     assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'}
+        {'loc': ('a',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}
     ]
 
 

--- a/tests/test_error_wrappers.py
+++ b/tests/test_error_wrappers.py
@@ -21,7 +21,7 @@ from pydantic.error_wrappers import ValidationError, flatten_errors, get_exc_typ
                 {'loc': ('d',), 'msg': 'value is not a valid uuid', 'type': 'type_error.uuid'},
                 {'loc': ('e', '__key__'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
                 {'loc': ('f', 0), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-                {'loc': ('f', 0), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
+                {'loc': ('f', 0), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
                 {
                     'loc': ('g',),
                     'msg': 'uuid version 1 expected',
@@ -107,7 +107,7 @@ from pydantic.error_wrappers import ValidationError, flatten_errors, get_exc_typ
       "f",
       0
     ],
-    "msg": "none is not an allow value",
+    "msg": "none is not an allowed value",
     "type": "type_error.none.not_allowed"
   },
   {
@@ -153,7 +153,7 @@ e -> __key__
 f -> 0
   value is not a valid integer (type=type_error.integer)
 f -> 0
-  none is not an allow value (type=type_error.none.not_allowed)
+  none is not an allowed value (type=type_error.none.not_allowed)
 g
   uuid version 1 expected (type=value_error.uuid.version; required_version=1)
 h

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -112,8 +112,12 @@ def test_nullable_strings_fails():
             required_bytes_none_value=None,
         )
     assert exc_info.value.errors() == [
-        {'loc': ('required_str_value',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
-        {'loc': ('required_bytes_value',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
+        {'loc': ('required_str_value',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
+        {
+            'loc': ('required_bytes_value',),
+            'msg': 'none is not an allowed value',
+            'type': 'type_error.none.not_allowed',
+        },
     ]
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -128,7 +128,7 @@ def test_dsn_no_driver():
     with pytest.raises(ValidationError) as exc_info:
         DsnModel(db_driver=None)
     assert exc_info.value.errors() == [
-        {'loc': ('db_driver',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'},
+        {'loc': ('db_driver',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
         {'loc': ('dsn',), 'msg': '"driver" field may not be empty', 'type': 'value_error.dsn.driver_is_empty'},
     ]
 

--- a/tests/test_types_url_str.py
+++ b/tests/test_types_url_str.py
@@ -112,7 +112,7 @@ def test_url_str_absolute_success(value):
                 }
             ],
         ),
-        (None, [{'loc': ('v',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'}]),
+        (None, [{'loc': ('v',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}]),
     ],
 )
 def test_url_str_absolute_fails(value, errors):
@@ -187,7 +187,7 @@ def test_url_str_relative_success(value):
                 }
             ],
         ),
-        (None, [{'loc': ('v',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'}]),
+        (None, [{'loc': ('v',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}]),
     ],
 )
 def test_url_str_relative_fails(value, errors):
@@ -245,7 +245,7 @@ def test_url_str_dont_require_tld_success(value):
                 }
             ],
         ),
-        (None, [{'loc': ('v',), 'msg': 'none is not an allow value', 'type': 'type_error.none.not_allowed'}]),
+        (None, [{'loc': ('v',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}]),
     ],
 )
 def test_url_str_dont_require_tld_fails(value, errors):


### PR DESCRIPTION
## Change Summary

Fixed type/mistake in an incorrect `NoneIsNotAllowedError` message.

## Related issue number

*None*

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
