### PR TITLE
Fix JSON serialization for ipaddress types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ v0.23 (unreleased)
 * ``IntEnum`` support, #444 by @potykion
 * fix ``ForwardRef`` collection bug, #450 by @tigerwings
 * Support specialized ``ClassVars``, #455 by @tyrylu
+* fix JSON serialization for ``ipaddress`` types, #333 by @pilosus
 
 v0.22 (2019-03-29)
 ....................

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -1,6 +1,7 @@
 import datetime
 from decimal import Decimal
 from enum import Enum
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from types import GeneratorType
 from typing import Any, Callable, Dict, Type, Union
 from uuid import UUID
@@ -13,6 +14,12 @@ def isoformat(o: Union[datetime.date, datetime.time]) -> str:
 
 
 ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
+    IPv4Address: str,
+    IPv6Address: str,
+    IPv4Interface: str,
+    IPv6Interface: str,
+    IPv4Network: str,
+    IPv6Network: str,
     UUID: str,
     datetime.datetime: isoformat,
     datetime.date: isoformat,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from decimal import Decimal
 from enum import Enum
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from uuid import UUID
 
 import pytest
@@ -19,6 +20,12 @@ class MyEnum(Enum):
     'input,output',
     [
         (UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8'), '"ebcdab58-6eb8-46fb-a190-d07a33e9eac8"'),
+        (IPv4Address('192.168.0.1'), '"192.168.0.1"'),
+        (IPv6Address('::1:0:1'), '"::1:0:1"'),
+        (IPv4Interface('192.168.0.0/24'), '"192.168.0.0/24"'),
+        (IPv6Interface('2001:db00::/120'), '"2001:db00::/120"'),
+        (IPv4Network('192.168.0.0/24'), '"192.168.0.0/24"'),
+        (IPv6Network('2001:db00::/120'), '"2001:db00::/120"'),
         (datetime.datetime(2032, 1, 1, 1, 1), '"2032-01-01T01:01:00"'),
         (datetime.datetime(2032, 1, 1, 1, 1, tzinfo=datetime.timezone.utc), '"2032-01-01T01:01:00+00:00"'),
         (datetime.datetime(2032, 1, 1), '"2032-01-01T00:00:00"'),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Fix JSON serialization for ``IPv{4,6}{Address,Network,Interface}`` types

<!-- Please give a short summary of the changes. -->

## Related issue number

#333 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
