### PR TITLE
Update sub_types when calling update_forward_refs()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.x (xxxx-xx-xx)
+..................
+* fix handling ``ForwardRef`` in sub-types, like ``Union``, #464 by @tiangolo
+
 v0.23 (2019-04-04)
 ..................
 * improve documentation for contributing section, #441 by @pilosus

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -457,6 +457,11 @@ class BaseModel(metaclass=MetaModel):
             if type(f.type_) == ForwardRef:
                 f.type_ = f.type_._evaluate(globalns, localns or None)  # type: ignore
                 f.prepare()
+            if f.sub_fields:
+                for sub_f in f.sub_fields:
+                    if type(sub_f.type_) == ForwardRef:
+                        sub_f.type_ = sub_f.type_._evaluate(globalns, localns or None)  # type: ignore
+                        sub_f.prepare()
 
     def __iter__(self) -> 'AnyGenerator':
         """

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -40,6 +40,7 @@ from .utils import (
     is_classvar,
     resolve_annotations,
     truncate,
+    update_field_forward_refs,
     validate_field_name,
 )
 
@@ -211,18 +212,6 @@ class MetaModel(ABCMeta):
 
 
 _missing = object()
-
-
-def update_field_forward_refs(field: Field, globalns: Any, localns: Any) -> None:
-    """
-    Try to update ForwardRefs on fields based on this Model, globalns and localns.
-    """
-    if type(field.type_) == ForwardRef:
-        field.type_ = field.type_._evaluate(globalns, localns or None)  # type: ignore
-        field.prepare()
-    if field.sub_fields:
-        for sub_f in field.sub_fields:
-            update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
 
 
 class BaseModel(metaclass=MetaModel):

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -29,6 +29,7 @@ except ImportError:
 
 if TYPE_CHECKING:  # pragma: no cover
     from .main import BaseModel  # noqa: F401
+    from .main import Field  # noqa: F401
 
 if sys.version_info < (3, 7):
     from typing import Callable
@@ -276,3 +277,15 @@ def _check_classvar(v: AnyType) -> bool:
 
 def is_classvar(ann_type: AnyType) -> bool:
     return _check_classvar(ann_type) or _check_classvar(getattr(ann_type, '__origin__', None))
+
+
+def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> None:
+    """
+    Try to update ForwardRefs on fields based on this Field, globalns and localns.
+    """
+    if type(field.type_) == ForwardRef:
+        field.type_ = field.type_._evaluate(globalns, localns or None)  # type: ignore
+        field.prepare()
+    if field.sub_fields:
+        for sub_f in field.sub_fields:
+            update_field_forward_refs(sub_f, globalns=globalns, localns=localns)

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -206,5 +206,43 @@ Node.update_forward_refs()
     data = {"value": 3, "left": {"a": "foo"}, "right": {"value": 5, "left": {"a": "bar"}, "right": {"a": "buzz"}}}
 
     node = Node(**data)
-    assert isinstance(node.left, Leaf), str(type(node.left))
-    assert isinstance(node.right, Node), str(type(node.right))
+    assert isinstance(node.left, Leaf)
+    assert isinstance(node.right, Node)
+
+
+@skip_not_37
+def test_forward_ref_nested_sub_types(create_module):
+    module = create_module(
+        """
+from typing import ForwardRef, Tuple, Union
+
+from pydantic import BaseModel
+
+
+class Leaf(BaseModel):
+    a: str
+
+
+TreeType = Union[Union[Tuple[ForwardRef('Node'), str], int], Leaf]
+
+
+class Node(BaseModel):
+    value: int
+    left: TreeType
+    right: TreeType
+
+
+Node.update_forward_refs()
+    """
+    )
+    Node = module.Node
+    Leaf = module.Leaf
+    data = {
+        "value": 3,
+        "left": {"a": "foo"},
+        "right": [{"value": 5, "left": {"a": "bar"}, "right": {"a": "buzz"}}, "test"],
+    }
+
+    node = Node(**data)
+    assert isinstance(node.left, Leaf)
+    assert isinstance(node.right[0], Node)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Update sub_types when calling `update_forward_refs()`

<!-- Please give a short summary of the changes. -->

`update_forward_refs()` currently updates a model's types by checking if they are `ForwardRef`.

This PR makes it also check sub-types, as would be needed for types like `Union[ForwardRef('Node'), Leaf]`.

## Related issue number

#404 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
