### PR TITLE
Load only fields

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+v0.24
+.....
+
+* ``load_only`` field of BaseConfig, #471 by @Paul-Ilyin
+
 v0.23 (2019-04-04)
 ..................
 * improve documentation for contributing section, #441 by @pilosus

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -545,6 +545,7 @@ Options:
     value is instance of that type). If False - RuntimeError will be raised on model declaration (default: ``False``)
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
+:load_only: set of fields which should not be serialized in dict() method, e.g. passwords and fields for internal use.
 
 .. warning::
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -78,6 +78,7 @@ class BaseConfig:
     error_msg_templates: Dict[str, str] = {}
     arbitrary_types_allowed = False
     json_encoders: Dict[AnyType, AnyCallable] = {}
+    load_only: 'SetStr' = set()
 
     @classmethod
     def get_field_schema(cls, name: str) -> Dict[str, str]:
@@ -471,6 +472,11 @@ class BaseModel(metaclass=MetaModel):
     def _calculate_keys(
         self, include: 'SetStr' = None, exclude: Optional['SetStr'] = None, skip_defaults: bool = False
     ) -> Optional['SetStr']:
+        if self.__config__.load_only:
+            if exclude is None:
+                exclude = self.Config.load_only
+            else:
+                exclude.update(self.Config.load_only)
 
         if include is None and exclude is None and skip_defaults is False:
             return None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -597,3 +597,17 @@ def test_load_only():
     model = OuterModel(inner=InnerModel(a=2, b="str_b"), a=5, b="str_b")
 
     assert model.dict() == {"inner": {"a": 2}, "b": "str_b"}
+
+
+def test_load_only_with_exclude():
+    class MyModel(BaseModel):
+        a: int
+        b: bool
+        c: int
+
+        class Config:
+            load_only = {"a"}
+
+    model = MyModel(a=5, b=True, c=10)
+
+    assert model.dict(exclude={"b"}) == {"c": 10}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -576,3 +576,24 @@ def test_dir_fields():
     assert "json" in dir(m)
     assert "attribute_a" in dir(m)
     assert "attribute_b" in dir(m)
+
+
+def test_load_only():
+    class InnerModel(BaseModel):
+        a: int
+        b: str
+
+        class Config:
+            load_only = {"b"}
+
+    class OuterModel(BaseModel):
+        inner: InnerModel
+        a: int
+        b: str
+
+        class Config:
+            load_only = {"a"}
+
+    model = OuterModel(inner=InnerModel(a=2, b="str_b"), a=5, b="str_b")
+
+    assert model.dict() == {"inner": {"a": 2}, "b": "str_b"}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Sometimes it is useful to make some fields "load_only". For example, if a model has a password field or some fields should not be serialized as they intended only for internal use. 
Passing field names as exclude argument to dict() method does not handle the cases when we want to exclude some fields in nested models.
To use the new feature, simply add load_only field to model's config class:
```
class MyModel(BaseModel):
    a: int
    b: bool
    c: int

    class Config:
        load_only = {"a"}
```
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`