### PR TITLE
Fix ISO 8601 timedelta spec given in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -437,7 +437,7 @@ types:
   * ``str``, following formats work:
 
     * ``[-][DD ][HH:MM]SS[.ffffff]``
-    * ``[±]P[DD]T[HH]H[MM]M[SS]S`` (ISO 8601 format for timedelta)
+    * ``[±]P[DD]DT[HH]H[MM]M[SS]S`` (ISO 8601 format for timedelta)
 
 
 .. literalinclude:: examples/datetime_example.py


### PR DESCRIPTION
## Change Summary

The ISO 8601 format for a timedelta ``[±]P[DD]T[HH]H[MM]M[SS]S`` is missing a literal ``D`` after the symbol for the number of days. This PR fixes this.

NB the corresponding code snippet is correct, and needs no change.

## Related issue number

N/A

## Checklist

N/A, since the change is so minor, and only affects the documentation.