### PR TITLE
Fix dict with extra keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 v0.25 (unreleased)
 ..................
 * Improve documentation on self-referencing models and annotations, #487 by @theenglishway
-* fix ``.dict()`` with extra keys, #489 by @JaewonKim
+* fix ``.dict()`` with extra keys, #490 by @JaewonKim
 
 v0.24 (2019-04-23)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.25 (unreleased)
 ..................
 * Improve documentation on self-referencing models and annotations, #487 by @theenglishway
+* fix ``.dict()`` with extra keys, #489 by @JaewonKim
 
 v0.24 (2019-04-23)
 ..................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -289,7 +289,7 @@ class BaseModel(metaclass=MetaModel):
 
     def _get_key_factory(self, by_alias: bool) -> Callable[..., str]:
         if by_alias:
-            return lambda fields, key: fields[key].alias
+            return lambda fields, key: fields[key].alias if key in fields else key
 
         return lambda _, key: key
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, List
 
 import pytest
 
-from pydantic import BaseModel, Extra, NoneBytes, NoneStr, Required, ValidationError, constr
+from pydantic import BaseConfig, BaseModel, Extra, NoneBytes, NoneStr, Required, Schema, ValidationError, constr
 
 
 def test_success():
@@ -576,3 +576,15 @@ def test_dir_fields():
     assert "json" in dir(m)
     assert "attribute_a" in dir(m)
     assert "attribute_b" in dir(m)
+
+
+def test_dict_with_extra_keys():
+    class MyModel(BaseModel):
+        a: str = Schema(None, alias='alias_a')
+
+        class Config(BaseConfig):
+            extra = Extra.allow
+
+    m = MyModel(extra_key='extra')
+    assert m.dict() == {'a': None, 'extra_key': 'extra'}
+    assert m.dict(by_alias=True) == {'alias_a': None, 'extra_key': 'extra'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, List
 
 import pytest
 
-from pydantic import BaseConfig, BaseModel, Extra, NoneBytes, NoneStr, Required, Schema, ValidationError, constr
+from pydantic import BaseModel, Extra, NoneBytes, NoneStr, Required, Schema, ValidationError, constr
 
 
 def test_success():
@@ -582,7 +582,7 @@ def test_dict_with_extra_keys():
     class MyModel(BaseModel):
         a: str = Schema(None, alias='alias_a')
 
-        class Config(BaseConfig):
+        class Config:
             extra = Extra.allow
 
     m = MyModel(extra_key='extra')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary
This will fix key error that occurs when calling `model.dict(by_alias=True)` with the model contains extra keys.

## Related issue number
Resolves #488

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
