### PR TITLE
Fix __fields_set__ not using alias field names (#517)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,10 @@ v0.26 (unreleased)
 ..................
 * fix to schema generation for ``IPvAnyAddress``, ``IPvAnyInterface``, ``IPvAnyNetwork`` #498 by @pilosus
 * fix variable length tuples support, #495 by @pilosus
-* fix ``.dict(skip_keys=True)`` skipping values set via alias, #517 by @sommd
+* **Breaking Change:** fix ``.dict(skip_keys=True)`` skipping values set via alias (this involves changing
+  ``validate_model()`` to always returns ``Tuple[Dict[str, Any], Set[str], Optional[ValidationError]]``), #517 by @sommd
+
+
 
 v0.25 (2019-05-05)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.26 (unreleased)
 ..................
 * fix to schema generation for ``IPvAnyAddress``, ``IPvAnyInterface``, ``IPvAnyNetwork`` #498 by @pilosus
 * fix variable length tuples support, #495 by @pilosus
+* fix ``.dict(skip_keys=True)`` skipping values set via alias, #517 by @sommd
 
 v0.25 (2019-05-05)
 ..................

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def _pydantic_post_init(self: 'DataclassType') -> None:
-    d = validate_model(self.__pydantic_model__, self.__dict__, cls=self.__class__)
+    d = validate_model(self.__pydantic_model__, self.__dict__, cls=self.__class__)[0]
     object.__setattr__(self, '__dict__', d)
     object.__setattr__(self, '__initialised__', True)
     if self.__post_init_original__:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -232,8 +232,9 @@ class BaseModel(metaclass=MetaModel):
         if TYPE_CHECKING:  # pragma: no cover
             self.__values__: Dict[str, Any] = {}
             self.__fields_set__: 'SetStr' = set()
-        object.__setattr__(self, '__values__', self._process_values(data))
-        object.__setattr__(self, '__fields_set__', self._process_fields(data))
+        values, fields_set, _ = validate_model(self, data)
+        object.__setattr__(self, '__values__', values)
+        object.__setattr__(self, '__fields_set__', fields_set)
 
     @no_type_check
     def __getattr__(self, name):
@@ -429,21 +430,6 @@ class BaseModel(metaclass=MetaModel):
             with change_exception(DictError, TypeError, ValueError):
                 return cls(**dict(value))  # type: ignore
 
-    def _process_values(self, input_data: Any) -> 'DictStrAny':
-        # (casting here is slow so use ignore)
-        return validate_model(self, input_data)  # type: ignore
-
-    def _process_fields(self, input_data: Any) -> 'SetStr':
-        fields = set()
-        for name, field in self.__fields__.items():
-            if name in input_data or field.alias in input_data:
-                fields.add(name)
-
-        if self.__config__.extra is Extra.allow:
-            fields |= input_data.keys()
-
-        return fields
-
     @classmethod
     def _get_value(cls, v: Any, by_alias: bool, skip_defaults: bool) -> Any:
         if isinstance(v, BaseModel):
@@ -583,13 +569,14 @@ def create_model(  # noqa: C901 (ignore complexity)
 
 def validate_model(  # noqa: C901 (ignore complexity)
     model: Union[BaseModel, Type[BaseModel]], input_data: 'DictStrAny', raise_exc: bool = True, cls: 'ModelOrDc' = None
-) -> Union['DictStrAny', Tuple['DictStrAny', Optional[ValidationError]]]:
+) -> Tuple['DictStrAny', 'SetStr', Optional[ValidationError]]:
     """
     validate data against a model.
     """
     values = {}
     errors = []
     names_used = set()
+    fields_set = set()
     config = model.__config__
     check_extra = config.extra is not Extra.ignore
 
@@ -614,8 +601,11 @@ def validate_model(  # noqa: C901 (ignore complexity)
             if not model.__config__.validate_all and not field.validate_always:
                 values[name] = value
                 continue
-        elif check_extra:
-            names_used.add(field.name if using_name else field.alias)
+        else:
+            fields_set.add(name)
+
+            if check_extra:
+                names_used.add(field.name if using_name else field.alias)
 
         v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls or model.__class__)  # type: ignore
         if isinstance(errors_, ErrorWrapper):
@@ -627,6 +617,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
 
     if check_extra:
         extra = input_data.keys() - names_used
+        fields_set |= extra
         if extra:
             if config.extra is Extra.allow:
                 for f in extra:
@@ -636,8 +627,8 @@ def validate_model(  # noqa: C901 (ignore complexity)
                     errors.append(ErrorWrapper(ExtraError(), loc=f, config=config))
 
     if not raise_exc:
-        return values, ValidationError(errors) if errors else None
+        return values, fields_set, ValidationError(errors) if errors else None
 
     if errors:
         raise ValidationError(errors)
-    return values
+    return values, fields_set, None

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -575,7 +575,9 @@ def validate_model(  # noqa: C901 (ignore complexity)
     """
     values = {}
     errors = []
+    # input_data names, possibly alias
     names_used = set()
+    # field names, never aliases
     fields_set = set()
     config = model.__config__
     check_extra = config.extra is not Extra.ignore

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -434,15 +434,12 @@ class BaseModel(metaclass=MetaModel):
         return validate_model(self, input_data)  # type: ignore
 
     def _process_fields(self, input_data: Any) -> 'SetStr':
-        config = self.__config__
-        populate_by_alias = config.allow_population_by_alias
-
         fields = set()
         for name, field in self.__fields__.items():
-            if name in input_data or populate_by_alias and field.alias in input_data:
+            if name in input_data or field.alias in input_data:
                 fields.add(name)
 
-        if config.extra is Extra.allow:
+        if self.__config__.extra is Extra.allow:
             fields |= input_data.keys()
 
         return fields

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -603,7 +603,6 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 continue
         else:
             fields_set.add(name)
-
             if check_extra:
                 names_used.add(field.name if using_name else field.alias)
 
@@ -617,8 +616,8 @@ def validate_model(  # noqa: C901 (ignore complexity)
 
     if check_extra:
         extra = input_data.keys() - names_used
-        fields_set |= extra
         if extra:
+            fields_set |= extra
             if config.extra is Extra.allow:
                 for f in extra:
                     values[f] = input_data[f]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -601,7 +601,11 @@ def test_return_errors_ok():
         foo: int
         bar: List[int]
 
-    assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}) == ({'foo': 123, 'bar': [1, 2, 3]}, {'foo', 'bar'}, None)
+    assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}) == (
+        {'foo': 123, 'bar': [1, 2, 3]},
+        {'foo', 'bar'},
+        None,
+    )
     d, f, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
     assert d == {'foo': 123, 'bar': [1, 2, 3]}
     assert f == {'foo', 'bar'}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -601,9 +601,10 @@ def test_return_errors_ok():
         foo: int
         bar: List[int]
 
-    assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}) == {'foo': 123, 'bar': [1, 2, 3]}
-    d, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
+    assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}) == ({'foo': 123, 'bar': [1, 2, 3]}, {'foo', 'bar'}, None)
+    d, f, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
     assert d == {'foo': 123, 'bar': [1, 2, 3]}
+    assert f == {'foo', 'bar'}
     assert e is None
 
 
@@ -612,12 +613,14 @@ def test_return_errors_error():
         foo: int
         bar: List[int]
 
-    d, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 'x')}, False)
+    d, f, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 'x')}, False)
     assert d == {'foo': 123}
+    assert f == {'foo', 'bar'}
     assert e.errors() == [{'loc': ('bar', 2), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}]
 
-    d, e = validate_model(Model, {'bar': (1, 2, 3)}, False)
+    d, f, e = validate_model(Model, {'bar': (1, 2, 3)}, False)
     assert d == {'bar': [1, 2, 3]}
+    assert f == {'bar'}
     assert e.errors() == [{'loc': ('foo',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -598,6 +598,35 @@ def test_skip_defaults_recursive():
     assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
 
 
+def test_dict_skip_defaults_populated_by_alias():
+    class MyModel(BaseModel):
+        class Config:
+            allow_population_by_alias = True
+
+        a: str = Schema("default", alias="alias_a")
+        b: str = Schema("default", alias="alias_b")
+
+    m = MyModel(alias_a="a")
+
+    assert m.dict(skip_defaults=True) == {"a": "a"}
+    assert m.dict(skip_defaults=True, by_alias=True) == {"alias_a": "a"}
+
+
+def test_dict_skip_defaults_populated_by_alias_with_extra():
+    class MyModel(BaseModel):
+        class Config:
+            allow_population_by_alias = True
+            extra = "allow"
+
+        a: str = Schema("default", alias="alias_a")
+        b: str = Schema("default", alias="alias_b")
+
+    m = MyModel(alias_a="a", c="c")
+
+    assert m.dict(skip_defaults=True) == {"a": "a", "c": "c"}
+    assert m.dict(skip_defaults=True, by_alias=True) == {"alias_a": "a", "c": "c"}
+
+
 def test_dir_fields():
     class MyModel(BaseModel):
         attribute_a: int

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -603,28 +603,28 @@ def test_dict_skip_defaults_populated_by_alias():
         class Config:
             allow_population_by_alias = True
 
-        a: str = Schema("default", alias="alias_a")
-        b: str = Schema("default", alias="alias_b")
+        a: str = Schema('default', alias='alias_a')
+        b: str = Schema('default', alias='alias_b')
 
-    m = MyModel(alias_a="a")
+    m = MyModel(alias_a='a')
 
-    assert m.dict(skip_defaults=True) == {"a": "a"}
-    assert m.dict(skip_defaults=True, by_alias=True) == {"alias_a": "a"}
+    assert m.dict(skip_defaults=True) == {'a': 'a'}
+    assert m.dict(skip_defaults=True, by_alias=True) == {'alias_a': 'a'}
 
 
 def test_dict_skip_defaults_populated_by_alias_with_extra():
     class MyModel(BaseModel):
         class Config:
             allow_population_by_alias = True
-            extra = "allow"
+            extra = 'allow'
 
-        a: str = Schema("default", alias="alias_a")
-        b: str = Schema("default", alias="alias_b")
+        a: str = Schema('default', alias='alias_a')
+        b: str = Schema('default', alias='alias_b')
 
-    m = MyModel(alias_a="a", c="c")
+    m = MyModel(alias_a='a', c='c')
 
-    assert m.dict(skip_defaults=True) == {"a": "a", "c": "c"}
-    assert m.dict(skip_defaults=True, by_alias=True) == {"alias_a": "a", "c": "c"}
+    assert m.dict(skip_defaults=True) == {'a': 'a', 'c': 'c'}
+    assert m.dict(skip_defaults=True, by_alias=True) == {'alias_a': 'a', 'c': 'c'}
 
 
 def test_dir_fields():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -600,11 +600,11 @@ def test_skip_defaults_recursive():
 
 def test_dict_skip_defaults_populated_by_alias():
     class MyModel(BaseModel):
-        class Config:
-            allow_population_by_alias = True
-
         a: str = Schema('default', alias='alias_a')
         b: str = Schema('default', alias='alias_b')
+
+        class Config:
+            allow_population_by_alias = True
 
     m = MyModel(alias_a='a')
 
@@ -614,12 +614,11 @@ def test_dict_skip_defaults_populated_by_alias():
 
 def test_dict_skip_defaults_populated_by_alias_with_extra():
     class MyModel(BaseModel):
-        class Config:
-            allow_population_by_alias = True
-            extra = 'allow'
-
         a: str = Schema('default', alias='alias_a')
         b: str = Schema('default', alias='alias_b')
+
+        class Config:
+            extra = 'allow'
 
     m = MyModel(alias_a='a', c='c')
 


### PR DESCRIPTION
fix #517

<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Basically, instead of just setting `__fields_set__` from `input_data.keys()` (which could contain aliases instead of the field names), it checks all the fields and adds the field's name if it or the alias is in `input_data`. Not sure if this is the best way to do this.

## Related issue number

#517 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
