### PR TITLE
Add support for arbitrary class instances

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ v0.26 (unreleased)
 * fix return type hint for ``create_model``, #526 by @dmontagu
 * **Breaking Change:** fix ``.dict(skip_keys=True)`` skipping values set via alias (this involves changing
   ``validate_model()`` to always returns ``Tuple[Dict[str, Any], Set[str], Optional[ValidationError]]``), #517 by @sommd
+* add support for arbitrary class instances, by @tiangolo
 
 v0.25 (2019-05-05)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ v0.26 (unreleased)
 * fix return type hint for ``create_model``, #526 by @dmontagu
 * **Breaking Change:** fix ``.dict(skip_keys=True)`` skipping values set via alias (this involves changing
   ``validate_model()`` to always returns ``Tuple[Dict[str, Any], Set[str], Optional[ValidationError]]``), #517 by @sommd
-* add support for arbitrary class instances, by @tiangolo
+* add support for arbitrary class instances, #520 by @tiangolo
 
 v0.25 (2019-05-05)
 ..................

--- a/docs/examples/class_instance.py
+++ b/docs/examples/class_instance.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+class DatabaseFoo:
+    def __init__(self, count, size=None):
+        self.count = count
+        self.size = size
+
+class Foo(BaseModel):
+    count: int = ...
+    size: float = None
+
+database_foo = DatabaseFoo(count=2, size=4.2)
+m = Foo(database_foo)
+print(m)
+# Foo count=2 size=4.2
+print(m.dict())
+# {'count': 2, 'size': 4.2}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -273,6 +273,24 @@ and pydantic versions).
 
 (This script is complete, it should run "as is")
 
+.. _arbitrary_class_instances:
+
+Arbitrary Class Instances
+.........................
+
+The same way key-value pairs can be passed as keyword arguments at model creation, or ``dict`` s
+can be unpacked (with ``**data`` ), you can pass an instance of any arbitrary class as a single first argument.
+
+The instance object must have attributes for the fields declared in the model.
+
+This makes it compatible with virtually every object/document relational mapper and many other tools.
+
+.. literalinclude:: examples/class_instance.py
+
+(This script is complete, it should run "as is")
+
+Everything described in the documentation is also compatible. Including field validators, Recursive Models, etc.
+
 .. _schema:
 
 Schema Creation

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def _pydantic_post_init(self: 'DataclassType') -> None:
-    d = validate_model(self.__pydantic_model__, self.__dict__, cls=self.__class__)[0]
-    object.__setattr__(self, '__dict__', d)
+    d = validate_model(self.__pydantic_model__, self.__dict__, cls=self.__class__)
+    object.__setattr__(self, '__dict__', d[0])
     object.__setattr__(self, '__initialised__', True)
     if self.__post_init_original__:
         self.__post_init_original__()

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -60,10 +60,6 @@ class DictError(PydanticTypeError):
     msg_template = 'value is not a valid dict'
 
 
-class ExtractModelError(PydanticTypeError):
-    msg_template = 'model fields cannot be extracted from value'
-
-
 class DSNDriverIsEmptyError(PydanticValueError):
     code = 'dsn.driver_is_empty'
     msg_template = '"driver" field may not be empty'

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -60,6 +60,10 @@ class DictError(PydanticTypeError):
     msg_template = 'value is not a valid dict'
 
 
+class ExtractModelError(PydanticTypeError):
+    msg_template = 'model fields cannot be extracted from value'
+
+
 class DSNDriverIsEmptyError(PydanticValueError):
     code = 'dsn.driver_is_empty'
     msg_template = '"driver" field may not be empty'

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -602,14 +602,12 @@ def validate_model(  # noqa: C901 (ignore complexity)
             )
 
         value = _get_input_value(input_data, field.alias)
-        if value is not _missing:
-            fields_set.add(field.alias)
         using_name = False
         if value is _missing and config.allow_population_by_alias and field.alt_alias:
             value = _get_input_value(input_data, field.name)
             using_name = True
-            if value is not _missing:
-                fields_set.add(field.name)
+        if value is not _missing:
+            fields_set.add(field.name)
 
         if value is _missing:
             if field.required:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -232,9 +232,9 @@ class BaseModel(metaclass=MetaModel):
             self.__values__: Dict[str, Any] = {}
             self.__fields_set__: 'SetStr' = set()
         if not data and args:
-            values, fields_set = self._process_values(args[0])
+            values, fields_set, _ = validate_model(self, args[0])
         else:
-            values, fields_set = self._process_values(data)
+            values, fields_set, _ = validate_model(self, data)
         object.__setattr__(self, '__values__', values)
         object.__setattr__(self, '__fields_set__', fields_set)
 
@@ -592,7 +592,6 @@ def validate_model(  # noqa: C901 (ignore complexity)
     fields_set = set()
     config = model.__config__
     check_extra = config.extra is not Extra.ignore
-    fields_set = set()
 
     for name, field in model.__fields__.items():
         if type(field.type_) == ForwardRef:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -27,7 +27,7 @@ from typing import (
 
 from .class_validators import ValidatorGroup, extract_validators, inherit_validators
 from .error_wrappers import ErrorWrapper, ValidationError
-from .errors import ConfigError, ExtractModelError, ExtraError, MissingError
+from .errors import ConfigError, ExtraError, MissingError
 from .fields import Field
 from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
@@ -572,10 +572,7 @@ def _get_input_value(input_data: Any, key: str) -> Any:
     try:
         return input_data.get(key, _missing)
     except AttributeError:
-        try:
-            return getattr(input_data, key, _missing)
-        except AttributeError as e:
-            raise ExtractModelError from e
+        return getattr(input_data, key, _missing)
 
 
 def validate_model(  # noqa: C901 (ignore complexity)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -227,11 +227,14 @@ class BaseModel(metaclass=MetaModel):
     Config = BaseConfig
     __slots__ = ('__values__', '__fields_set__')
 
-    def __init__(self, _object: Any = None, **data: Any) -> None:
+    def __init__(self, *args: Any, **data: Any) -> None:
         if TYPE_CHECKING:  # pragma: no cover
             self.__values__: Dict[str, Any] = {}
             self.__fields_set__: 'SetStr' = set()
-        values, fields_set, _ = validate_model(self, data)
+        if not data and args:
+            values, fields_set = self._process_values(args[0])
+        else:
+            values, fields_set = self._process_values(data)
         object.__setattr__(self, '__values__', values)
         object.__setattr__(self, '__fields_set__', fields_set)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -604,12 +604,8 @@ def test_return_errors_ok():
         foo: int
         bar: List[int]
 
-    assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}) == (
-        {'foo': 123, 'bar': [1, 2, 3]},
-        {'foo', 'bar'},
-        None,
-    )
-    d, f, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
+    assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)})[0] == {'foo': 123, 'bar': [1, 2, 3]}
+    d, _, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
     assert d == {'foo': 123, 'bar': [1, 2, 3]}
     assert f == {'foo', 'bar'}
     assert e is None

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -605,7 +605,7 @@ def test_return_errors_ok():
         bar: List[int]
 
     assert validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)})[0] == {'foo': 123, 'bar': [1, 2, 3]}
-    d, _, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
+    d, f, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 3)}, False)
     assert d == {'foo': 123, 'bar': [1, 2, 3]}
     assert f == {'foo', 'bar'}
     assert e is None

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -247,7 +247,6 @@ def test_recursive_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=['x'])
-    print(exc_info.value.errors())
     assert exc_info.value.errors() == [
         {'loc': ('v', 0, 'name'), 'msg': 'field required', 'type': 'value_error.missing'},
         {'loc': ('v', 0, 'count'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -247,7 +247,11 @@ def test_recursive_list():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=['x'])
-    assert exc_info.value.errors() == [{'loc': ('v', 0), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
+    print(exc_info.value.errors())
+    assert exc_info.value.errors() == [
+        {'loc': ('v', 0, 'name'), 'msg': 'field required', 'type': 'value_error.missing'},
+        {'loc': ('v', 0, 'count'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
 
 
 def test_recursive_list_error():

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -111,9 +111,9 @@ Foo.update_forward_refs()
     }
 
     with pytest.raises(ValidationError) as exc_info:
-        module.Foo(b={'a': '321'}, c=[{'b': 234}], d={'bar': {'a': 345}})
+        module.Foo(b={'a': '321'}, c=[{'a': "foo"}], d={'bar': {'a': 345}})
     assert exc_info.value.errors() == [
-        {'loc': ('c', 0, 'b'), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}
+        {'loc': ('c', 0, 'a'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Add support for arbitrary class instances.

From the new docs:

```Python
from pydantic import BaseModel

class DatabaseFoo:
    def __init__(self, count, size=None):
        self.count = count
        self.size = size

class Foo(BaseModel):
    count: int = ...
    size: float = None

database_foo = DatabaseFoo(count=2, size=4.2)
m = Foo(database_foo)
print(m)
# Foo count=2 size=4.2
print(m.dict())
# {'count': 2, 'size': 4.2}
```

This makes Pydantic compatible with virtually all ORMs and many other tools.

A Pydantic model would be able to receive a SQLAlchemy model, a MongoEngine (MongoDB) model, etc.

It doesn't make any assumption about the underlying data, nor any compromise with any third party library.

I also tried to minimize the code change surface and the code flow alterations. So, using it as normally should be close to unaltered, but this new use case would be supported too.

---

This solves several things requested by FastAPI users (I think some have requested similar things here too).

I planned and started the code initially in FastAPI directly but I ended up having to duplicate most of the `Field` validation functions, after trying several different things, to modify a single line in them. It would become a lot of code duplication and desynchronization with the upstream code here in Pydantic. So, I thought it could be added here.

<!-- Please give a short summary of the changes. -->

## Related issue number

Slightly related to #491 

Related to/fixes in FastAPI:

https://github.com/tiangolo/fastapi/issues/218
https://github.com/tiangolo/fastapi/issues/214
https://github.com/tiangolo/fastapi/issues/194
https://github.com/tiangolo/fastapi/issues/84

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
