### PR TITLE
Change return type hint for create_model

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.26 (unreleased)
 ..................
 * fix to schema generation for ``IPvAnyAddress``, ``IPvAnyInterface``, ``IPvAnyNetwork`` #498 by @pilosus
 * fix variable length tuples support, #495 by @pilosus
+* fix return type hint for ``create_model``, #526 by @dmontagu
 
 v0.25 (2019-05-05)
 ..................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -526,7 +526,7 @@ def create_model(  # noqa: C901 (ignore complexity)
     __module__: Optional[str] = None,
     __validators__: Dict[str, classmethod] = None,
     **field_definitions: Any,
-) -> BaseModel:
+) -> Type[BaseModel]:
     """
     Dynamically create a model.
     :param model_name: name of the created model

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -571,7 +571,7 @@ def create_model(  # noqa: C901 (ignore complexity)
     if __config__:
         namespace['Config'] = inherit_config(__config__, BaseConfig)
 
-    return type(model_name, (__base__,), namespace)  # type: ignore
+    return type(model_name, (__base__,), namespace)
 
 
 def validate_model(  # noqa: C901 (ignore complexity)


### PR DESCRIPTION
Described in https://github.com/samuelcolvin/pydantic/issues/525

## Change Summary

Fix the return type of `create_model`

## Related issue number

Issue #525