### PR TITLE
Fix JSON Schema for list, tuple, and set, improving interoperability

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.xx (xxxx-xx-xx)
+..................
+* fix JSON Schema for ``list``, ``tuple``, and ``set``, by @tiangolo
+
 v0.26 (2019-05-22)
 ..................
 * fix to schema generation for ``IPvAnyAddress``, ``IPvAnyInterface``, ``IPvAnyNetwork`` #498 by @pilosus

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 v0.xx (xxxx-xx-xx)
 ..................
-* fix JSON Schema for ``list``, ``tuple``, and ``set``, by @tiangolo
+* fix JSON Schema for ``list``, ``tuple``, and ``set``, #540 by @tiangolo
 
 v0.26 (2019-05-22)
 ..................

--- a/docs/schema_mapping.py
+++ b/docs/schema_mapping.py
@@ -46,21 +46,21 @@ table = [
     [
         'list',
         'array',
-        '',
+        '{"items": {}}',
         'JSON Schema Core',
         ''
     ],
     [
         'tuple',
         'array',
-        '',
+        '{"items": {}}',
         'JSON Schema Core',
         ''
     ],
     [
         'set',
         'array',
-        '{"uniqueItems": true}',
+        '{"items": {}, {"uniqueItems": true}',
         'JSON Schema Validation',
         ''
     ],

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -625,9 +625,9 @@ field_class_to_schema_enum_enabled: Tuple[Tuple[Any, Dict[str, Any]], ...] = (
     (UUID, {'type': 'string', 'format': 'uuid'}),
     (NameEmail, {'type': 'string', 'format': 'name-email'}),
     (dict, {'type': 'object'}),
-    (list, {'type': 'array'}),
-    (tuple, {'type': 'array'}),
-    (set, {'type': 'array', 'uniqueItems': True}),
+    (list, {'type': 'array', 'items': {}}),
+    (tuple, {'type': 'array', 'items': {}}),
+    (set, {'type': 'array', 'items': {}, 'uniqueItems': True}),
 )
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -277,7 +277,7 @@ def test_set():
         'type': 'object',
         'properties': {
             'a': {'title': 'A', 'type': 'array', 'uniqueItems': True, 'items': {'type': 'integer'}},
-            'b': {'title': 'B', 'type': 'array', 'uniqueItems': True},
+            'b': {'title': 'B', 'type': 'array', 'items': {}, 'uniqueItems': True},
         },
         'required': ['a', 'b'],
     }
@@ -308,7 +308,7 @@ def test_const_false():
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
-        (tuple, None),
+        (tuple, {}),
         (
             Tuple[str, int, Union[str, int, float], float],
             [
@@ -370,7 +370,7 @@ def test_list():
     assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'array'}},
+        'properties': {'a': {'title': 'A', 'type': 'array', 'items': {}}},
         'required': ['a'],
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Fix JSON Schema for plain `list`, `tuple`, and `set`. Adding `{"items": {}}`.

This makes the schemas for these "plain" sequence types (instead of `List[some_type]`) compatible with OpenAPI while keeping compatible with JSON Schema.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
