### PR TITLE
Add cattrs benchmark

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -5,3 +5,4 @@ django               # pyup: ignore
 djangorestframework  # pyup: ignore
 #marshmallow          # pyup: ignore
 toastedmarshmallow   # pyup: ignore
+cattrs               # pyup: ignore

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -35,6 +35,11 @@ try:
 except Exception:
     TestToastedMarshmallow = None
 
+try:
+    from test_cattrs import TestCattrs
+except Exception as e:
+    TestCattrs = None
+
 PUNCTUATION = ' \t\n!"#$%&\'()*+,-./'
 LETTERS = string.ascii_letters
 UNICODE = '\xa0\xad¡¢£¤¥¦§¨©ª«¬ ®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
@@ -44,7 +49,7 @@ random = random.SystemRandom()
 # in order of performance for csv
 other_tests = [
     t for t in
-    [TestToastedMarshmallow, TestMarshmallow, TestTrafaret, TestDRF]
+    [TestCattrs, TestToastedMarshmallow, TestMarshmallow, TestTrafaret, TestDRF]
     if t is not None
 ]
 

--- a/benchmarks/test_cattrs.py
+++ b/benchmarks/test_cattrs.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+from typing import List, Optional
+
+import attr
+import cattr
+from attr.validators import deep_iterable, instance_of, optional
+from pydantic.datetime_parse import parse_datetime
+from test_pydantic import TestPydantic
+
+
+cattr.register_structure_hook(datetime, lambda o, t: parse_datetime(o))
+
+
+# Handles optional fields
+def structure_attrs_fromdict(obj, cl):
+    # type: (Mapping, Type) -> Any
+    """Instantiate an attrs class from a mapping (dict) that ignores unknown
+    fields `cattr issue <https://github.com/Tinche/cattrs/issues/35>`_"""
+    # For public use.
+
+    # conv_obj = obj.copy()  # Dict of converted parameters.
+    conv_obj = dict()  # Start fresh
+
+    # dispatch = self._structure_func.dispatch
+    dispatch = cattr.global_converter._structure_func.dispatch  # Ugly I know
+    for a in cl.__attrs_attrs__:
+        # We detect the type by metadata.
+        type_ = a.type
+        if type_ is None:
+            # No type.
+            continue
+        name = a.name
+        try:
+            val = obj[name]
+        except KeyError:
+            continue
+        if val is None:
+            conv_obj[name] = val
+        else:
+            conv_obj[name] = dispatch(type_)(val, type_)
+    return cl(**conv_obj)
+
+
+def max_length(max_length: int):
+    def validator(inst, attr, value):
+        if len(value) > max_length:
+            raise ValueError("Too long")
+
+    return validator
+
+
+def min_length(min_length: int):
+    def validator(inst, attr, value):
+        if len(value) < min_length:
+            raise ValueError("Too short")
+
+    return validator
+
+
+def is_positive(inst, attr, value):
+    if value <= 0:
+        raise ValueError("Not positive")
+
+
+class TestCattrs:
+    package = 'cattrs'
+
+    def __init__(self, allow_extra):
+        @attr.dataclass
+        class Location:
+            latitude: Optional[float] = attr.ib(default=None, validator=optional(instance_of(float)))
+            longitude: Optional[float] = attr.ib(default=None, validator=optional(instance_of(float)))
+
+        @attr.dataclass
+        class Skill:
+            subject: str = attr.ib(validator=instance_of(str))
+            subject_id: int = attr.ib(validator=instance_of(int))
+            category: str = attr.ib(validator=instance_of(str))
+            qual_level: str = attr.ib(validator=instance_of(str))
+            qual_level_id: int = attr.ib(validator=instance_of(int))
+            qual_level_ranking: float = attr.ib(default=0, validator=instance_of(float))
+
+        @attr.dataclass
+        class Model:
+            id: int = attr.ib(validator=instance_of(int))
+            client_name: str = attr.ib(validator=[instance_of(str), max_length(255)])
+            sort_index: float = attr.ib(validator=instance_of(float))
+            grecaptcha_response: str = attr.ib(validator=[instance_of(str), min_length(20), max_length(1000)])
+            location: Optional[Location] = attr.ib(default=None, validator=optional(instance_of(Location)))
+            contractor: Optional[int] = attr.ib(default=None, validator=optional([instance_of(int), is_positive]))
+            upstream_http_referrer: Optional[str] = attr.ib(
+                default=None,
+                validator=optional([instance_of(str), max_length(1023)])
+            )
+            client_phone: Optional[str] = attr.ib(default=None, validator=optional([instance_of(str), max_length(255)]))
+            last_updated: Optional[datetime] = attr.ib(default=None, validator=optional(instance_of(datetime)))
+            skills: List[Skill] = attr.ib(
+                factory=list,
+                validator=deep_iterable(instance_of(Skill), iterable_validator=None)
+            )
+
+        if allow_extra:
+            cattr.register_structure_hook(Model, structure_attrs_fromdict)
+            cattr.register_structure_hook(Location, structure_attrs_fromdict)
+            cattr.register_structure_hook(Skill, structure_attrs_fromdict)
+        self.model = Model
+
+    def validate(self, data):
+        try:
+            return True, cattr.structure(data, self.model)
+        except ValueError as e:
+            return False, str(e)
+        except TypeError as e:
+            return False, str(e)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Adds a benchmark against [attrs](https://github.com/python-attrs/attrs)+[cattrs](https://github.com/Tinche/cattrs).

I checked, and each of the test cases in the benchmark has the same outcome in this `cattrs` benchmark as in the original pydantic benchmark, so I think I set up all appropriate validations.

The benchmark has only been tested to work with Python 3.7.

On my computer, I get the following results:
```
...
pydantic time=2.071s, success=50.60%
pydantic best=1.728s, avg=2.189s, stdev=0.294s

...
cattrs time=0.834s, success=50.60%
cattrs best=0.533s, avg=0.700s, stdev=0.133s
```
`attrs`+`cattrs` is obviously lacking a lot of built-in functionality compared to `pydantic`, so even if it is faster I'm not sure it would make sense to use as a substitute (although I was able to replicate all the validations used in the benchmark without too much effort), but based on these numbers maybe there are some tricks `attrs`/`cattrs` are using that could help speed up `pydantic`?

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/542

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
