### PR TITLE
Urlstr failed at position x

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -79,7 +79,10 @@ class UrlSchemeError(PydanticValueError):
 
 class UrlRegexError(PydanticValueError):
     code = 'url.regex'
-    msg_template = 'url string does not match regex'
+    msg_template = 'url string does not match regex, failed at position {position}'
+
+    def __init__(self, *, position: str) -> None:
+        super().__init__(position=position)
 
 
 class EnumError(PydanticTypeError):

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -215,15 +215,11 @@ class UrlStr(str):
                 raise errors.UrlSchemeError(scheme=scheme)
 
         regex = url_regex_generator(relative=cls.relative, require_tld=cls.require_tld)
-        # if not regex.match(value):
-        #     raise errors.UrlRegexError()
 
         m = regex.match(value)
         if m.lastgroup == 'ENDURL5':
             return value
         else:
-            print(m.lastgroup)
-            print(m.lastindex)
             raise errors.UrlRegexError(position=m.lastindex)
 
         return value

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -221,8 +221,10 @@ class UrlStr(str):
         m = regex.match(value)
         if m.lastgroup == 'ENDURL5':
             return value
-        if len([n for n in m.groups() if n is not None]) < 39:
-            raise errors.UrlRegexError()
+        else:
+            print(m.lastgroup)
+            print(m.lastindex)
+            raise errors.UrlRegexError(position=m.lastindex)
 
         return value
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -215,7 +215,13 @@ class UrlStr(str):
                 raise errors.UrlSchemeError(scheme=scheme)
 
         regex = url_regex_generator(relative=cls.relative, require_tld=cls.require_tld)
-        if not regex.match(value):
+        # if not regex.match(value):
+        #     raise errors.UrlRegexError()
+
+        m = regex.match(value)
+        if m.lastgroup == 'ENDURL5':
+            return value
+        if len([n for n in m.groups() if n is not None]) < 39:
             raise errors.UrlRegexError()
 
         return value

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -198,54 +198,7 @@ def validate_field_name(bases: List[Type['BaseModel']], field_name: str) -> None
 
 @lru_cache(maxsize=None)
 def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
-    """
-    Url regex generator taken from Marshmallow library,
-    for details please follow library source code:
-        https://github.com/marshmallow-code/marshmallow/blob/298870ef6c089fb4d91efae9ca4168453ffe00d2/marshmallow/validate.py#L37
-    """
-    # original = r''.join(
-    #     (
-    #         r'^',
-    #         r'(' if relative else r'',
-    #         r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
-    #         r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
-    #         r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
-    #         r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
-    #         r'localhost|',  # localhost...
-    #         (
-    #             r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''
-    #         ),  # allow dotless hostnames
-    #         r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
-    #         r'\[[A-F0-9]*:[A-F0-9:]+\])',  # ...or ipv6
-    #         r'(?::\d+)?',  # optional port
-    #         r')?' if relative else r'',  # host is optional, allow for relative URLs
-    #         r'(?:/?|[/?]\S+)$',
-    #     )
-    # )
-    # named_r = (
-    #     r'^',
-    #     r'(' if relative else r'',
-    #     r'(?P<SCHEME>[a-z0-9\.\-\+]*)',
-    #     r'(?P<DOUBLESLASH>(:\/\/){1})',  # scheme is validated separately
-    #     r'(?P<BASICAUTH>[^:@]+?:[^:@]*?@|)',  # basic auth
-    #     r'(?P<DOMAINOPTIONS>(?P<SUBDOMAIN>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
-    #     r'(?P<EXTENSION>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
-    #     r'(?P<LOCAL>localhost)|',  # localhost...
-    #     (
-    #         r'(?P<TLD>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''),
-    #     # allow dotless hostnames
-    #     r'(?P<IPV4>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|',  # ...or ipv4
-    #     r'(?P<IPV6>\[[A-F0-9]*:[A-F0-9:]+\]))',  # ...or ipv6
-    #     r'(?P<PORT>:\d+)?',  # optional port
-    #     r')?' if relative else r'',  # host is optional, allow for relative URLs
-    #     r'(?P<ENDURL>/?|[/?]\S+)$',
-    # )
-    # tweaked = r''.join(
-    #     named_r
-    # )
-
     omg = r'^(?=(?P<SCHEME0>[a-z0-9\.\-\+]*))?(?=(?P<SCHEME1>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH1>://))?(?=(?P<SCHEME2>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH2>://)(?P<BASICAUTH2>[^:@]+?:[^:@]*?@|))?(?=(?P<SCHEME3>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH3>://)(?P<BASICAUTH3>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS3>(?P<SUBDOMAIN3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION3>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL3>localhost)|(?P<TLD3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV43>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV63>\[[A-F0-9]*:[A-F0-9:]+\])))?(?=(?P<SCHEME4>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH4>://)(?P<BASICAUTH4>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS4>(?P<SUBDOMAIN4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION4>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL4>localhost)|(?P<TLD4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV44>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV64>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT4>:\d+)?)?(?=(?P<SCHEME5>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH5>://)(?P<BASICAUTH5>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS5>(?P<SUBDOMAIN5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION5>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL5>localhost)|(?P<TLD5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV45>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV65>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT5>:\d+)?(?P<ENDURL5>/?|[/?]\S+$))?.'
-    # return re.compile(tweaked, re.IGNORECASE)
     return re.compile(omg, re.IGNORECASE)
 
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -232,9 +232,7 @@ def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
             r'(?P<DOMAIN>(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
             r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
             r'(?P<LOCAL>localhost)|',  # localhost...
-            (
-                r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''
-            ),  # allow dotless hostnames
+            (r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''),  # allow dotless hostnames
             r'(?P<IPV4>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|',  # ...or ipv4
             r'(?P<IPV6>\[[A-F0-9]*:[A-F0-9:]+\]))',  # ...or ipv6
             r'(?P<PORT>:\d+)?',  # optional port
@@ -242,10 +240,7 @@ def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
             r'(?P<ENDURL>/?|[/?]\S+)$',
         )
     )
-    return re.compile(
-        tweaked,
-        re.IGNORECASE,
-    )
+    return re.compile(tweaked, re.IGNORECASE)
 
 
 def lenient_issubclass(cls: Any, class_or_tuple: Union[AnyType, Tuple[AnyType, ...]]) -> bool:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -198,7 +198,14 @@ def validate_field_name(bases: List[Type['BaseModel']], field_name: str) -> None
 
 @lru_cache(maxsize=None)
 def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
-    omg = r'^(?=(?P<SCHEME0>[a-z0-9\.\-\+]*))?(?=(?P<SCHEME1>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH1>://))?(?=(?P<SCHEME2>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH2>://)(?P<BASICAUTH2>[^:@]+?:[^:@]*?@|))?(?=(?P<SCHEME3>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH3>://)(?P<BASICAUTH3>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS3>(?P<SUBDOMAIN3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION3>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL3>localhost)|(?P<TLD3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV43>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV63>\[[A-F0-9]*:[A-F0-9:]+\])))?(?=(?P<SCHEME4>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH4>://)(?P<BASICAUTH4>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS4>(?P<SUBDOMAIN4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION4>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL4>localhost)|(?P<TLD4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV44>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV64>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT4>:\d+)?)?(?=(?P<SCHEME5>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH5>://)(?P<BASICAUTH5>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS5>(?P<SUBDOMAIN5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION5>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL5>localhost)|(?P<TLD5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV45>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV65>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT5>:\d+)?(?P<ENDURL5>/?|[/?]\S+$))?.'
+    omg = (
+        r'^(?=(?P<SCHEME0>[a-z0-9\.\-\+]*))?'
+        + r'(?=(?P<SCHEME1>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH1>://))?'
+        + r'(?=(?P<SCHEME2>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH2>://)(?P<BASICAUTH2>[^:@]+?:[^:@]*?@|))?'
+        + r'(?=(?P<SCHEME3>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH3>://)(?P<BASICAUTH3>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS3>(?P<SUBDOMAIN3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION3>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL3>localhost)|(?P<TLD3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV43>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV63>\[[A-F0-9]*:[A-F0-9:]+\])))?'
+        + r'(?=(?P<SCHEME4>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH4>://)(?P<BASICAUTH4>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS4>(?P<SUBDOMAIN4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION4>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL4>localhost)|(?P<TLD4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV44>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV64>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT4>(:\d+)?))?'
+        + r'(?=(?P<SCHEME5>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH5>://)(?P<BASICAUTH5>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS5>(?P<SUBDOMAIN5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION5>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL5>localhost)|(?P<TLD5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV45>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV65>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT5>(:\d+)?)(?P<ENDURL5>/?|[/?]\S+))?.'
+    )
     return re.compile(omg, re.IGNORECASE)
 
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -7,7 +7,8 @@ from functools import lru_cache
 from importlib import import_module
 from textwrap import dedent
 from typing import _eval_type  # type: ignore
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Optional, Pattern, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Optional, \
+    Pattern, Tuple, Type, Union
 
 from . import errors
 
@@ -41,7 +42,6 @@ else:
 
     AnyCallable = TypingCallable[..., Any]
 
-
 PRETTY_REGEX = re.compile(r'([\w ]*?) *<(.*)> *')
 AnyType = Type[Any]
 
@@ -58,7 +58,8 @@ def validate_email(value: str) -> Tuple[str, str]:
     See RFC 5322 but treat it with suspicion, there seems to exist no universally acknowledged test for a valid email!
     """
     if email_validator is None:
-        raise ImportError('email-validator is not installed, run `pip install pydantic[email]`')
+        raise ImportError(
+            'email-validator is not installed, run `pip install pydantic[email]`')
 
     m = PRETTY_REGEX.fullmatch(value)
     name: Optional[str] = None
@@ -80,14 +81,14 @@ def _rfc_1738_quote(text: str) -> str:
 
 
 def make_dsn(
-    *,
-    driver: str,
-    user: str = None,
-    password: str = None,
-    host: str = None,
-    port: str = None,
-    name: str = None,
-    query: Dict[str, Any] = None,
+        *,
+        driver: str,
+        user: str = None,
+        password: str = None,
+        host: str = None,
+        port: str = None,
+        name: str = None,
+        query: Dict[str, Any] = None,
 ) -> str:
     """
     Create a DSN from from connection settings.
@@ -131,7 +132,8 @@ def import_string(dotted_path: str) -> Any:
     try:
         return getattr(module, class_name)
     except AttributeError as e:
-        raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute') from e
+        raise ImportError(
+            f'Module "{module_path}" does not define a "{class_name}" attribute') from e
 
 
 def truncate(v: str, *, max_len: int = 80) -> str:
@@ -170,7 +172,8 @@ ExcType = Type[Exception]
 
 
 @contextmanager
-def change_exception(raise_exc: ExcType, *except_types: ExcType) -> Generator[None, None, None]:
+def change_exception(raise_exc: ExcType, *except_types: ExcType) -> Generator[
+    None, None, None]:
     try:
         yield
     except except_types as e:
@@ -205,45 +208,53 @@ def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
         https://github.com/marshmallow-code/marshmallow/blob/298870ef6c089fb4d91efae9ca4168453ffe00d2/marshmallow/validate.py#L37
     """
     # original = r''.join(
+    #     (
+    #         r'^',
+    #         r'(' if relative else r'',
+    #         r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
+    #         r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
+    #         r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
+    #         r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
+    #         r'localhost|',  # localhost...
     #         (
-    #             r'^',
-    #             r'(' if relative else r'',
-    #             r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
-    #             r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
-    #             r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
-    #             r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
-    #             r'localhost|',  # localhost...
-    #             (
-    #                 r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''
-    #             ),  # allow dotless hostnames
-    #             r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
-    #             r'\[[A-F0-9]*:[A-F0-9:]+\])',  # ...or ipv6
-    #             r'(?::\d+)?',  # optional port
-    #             r')?' if relative else r'',  # host is optional, allow for relative URLs
-    #             r'(?:/?|[/?]\S+)$',
-    #         )
+    #             r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''
+    #         ),  # allow dotless hostnames
+    #         r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
+    #         r'\[[A-F0-9]*:[A-F0-9:]+\])',  # ...or ipv6
+    #         r'(?::\d+)?',  # optional port
+    #         r')?' if relative else r'',  # host is optional, allow for relative URLs
+    #         r'(?:/?|[/?]\S+)$',
     #     )
-    tweaked = r''.join(
-        (
-            r'^',
-            r'(' if relative else r'',
-            r'(?P<SCHEME>[a-z0-9\.\-\+]*)://',  # scheme is validated separately
-            r'(?P<BASICAUTH>[^:@]+?:[^:@]*?@|)',  # basic auth
-            r'(?P<DOMAIN>(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
-            r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
-            r'(?P<LOCAL>localhost)|',  # localhost...
-            (r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''),  # allow dotless hostnames
-            r'(?P<IPV4>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|',  # ...or ipv4
-            r'(?P<IPV6>\[[A-F0-9]*:[A-F0-9:]+\]))',  # ...or ipv6
-            r'(?P<PORT>:\d+)?',  # optional port
-            r')?' if relative else r'',  # host is optional, allow for relative URLs
-            r'(?P<ENDURL>/?|[/?]\S+)$',
-        )
-    )
-    return re.compile(tweaked, re.IGNORECASE)
+    # )
+    # named_r = (
+    #     r'^',
+    #     r'(' if relative else r'',
+    #     r'(?P<SCHEME>[a-z0-9\.\-\+]*)',
+    #     r'(?P<DOUBLESLASH>(:\/\/){1})',  # scheme is validated separately
+    #     r'(?P<BASICAUTH>[^:@]+?:[^:@]*?@|)',  # basic auth
+    #     r'(?P<DOMAINOPTIONS>(?P<SUBDOMAIN>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
+    #     r'(?P<EXTENSION>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
+    #     r'(?P<LOCAL>localhost)|',  # localhost...
+    #     (
+    #         r'(?P<TLD>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''),
+    #     # allow dotless hostnames
+    #     r'(?P<IPV4>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|',  # ...or ipv4
+    #     r'(?P<IPV6>\[[A-F0-9]*:[A-F0-9:]+\]))',  # ...or ipv6
+    #     r'(?P<PORT>:\d+)?',  # optional port
+    #     r')?' if relative else r'',  # host is optional, allow for relative URLs
+    #     r'(?P<ENDURL>/?|[/?]\S+)$',
+    # )
+    # tweaked = r''.join(
+    #     named_r
+    # )
+
+    omg = r'^(?=(?P<SCHEME0>[a-z0-9\.\-\+]*))?(?=(?P<SCHEME1>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH1>://))?(?=(?P<SCHEME2>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH2>://)(?P<BASICAUTH2>[^:@]+?:[^:@]*?@|))?(?=(?P<SCHEME3>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH3>://)(?P<BASICAUTH3>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS3>(?P<SUBDOMAIN3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION3>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL3>localhost)|(?P<TLD3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV43>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV63>\[[A-F0-9]*:[A-F0-9:]+\])))?(?=(?P<SCHEME4>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH4>://)(?P<BASICAUTH4>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS4>(?P<SUBDOMAIN4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION4>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL4>localhost)|(?P<TLD4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV44>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV64>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT4>:\d+)?)?(?=(?P<SCHEME5>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH5>://)(?P<BASICAUTH5>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS5>(?P<SUBDOMAIN5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION5>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL5>localhost)|(?P<TLD5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV45>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV65>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT5>:\d+)?(?P<ENDURL5>/?|[/?]\S+))?.'
+    # return re.compile(tweaked, re.IGNORECASE)
+    return re.compile(omg, re.IGNORECASE)
 
 
-def lenient_issubclass(cls: Any, class_or_tuple: Union[AnyType, Tuple[AnyType, ...]]) -> bool:
+def lenient_issubclass(cls: Any,
+                       class_or_tuple: Union[AnyType, Tuple[AnyType, ...]]) -> bool:
     return isinstance(cls, type) and issubclass(cls, class_or_tuple)
 
 
@@ -259,7 +270,8 @@ def in_ipython() -> bool:
         return True
 
 
-def resolve_annotations(raw_annotations: Dict[str, AnyType], module_name: Optional[str]) -> Dict[str, AnyType]:
+def resolve_annotations(raw_annotations: Dict[str, AnyType],
+                        module_name: Optional[str]) -> Dict[str, AnyType]:
     """
     Partially taken from typing.get_type_hints.
 
@@ -287,11 +299,13 @@ def is_callable_type(type_: AnyType) -> bool:
 
 
 def _check_classvar(v: AnyType) -> bool:
-    return type(v) == type(ClassVar) and (sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
+    return type(v) == type(ClassVar) and (
+                sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
 
 
 def is_classvar(ann_type: AnyType) -> bool:
-    return _check_classvar(ann_type) or _check_classvar(getattr(ann_type, '__origin__', None))
+    return _check_classvar(ann_type) or _check_classvar(
+        getattr(ann_type, '__origin__', None))
 
 
 def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> None:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -7,8 +7,7 @@ from functools import lru_cache
 from importlib import import_module
 from textwrap import dedent
 from typing import _eval_type  # type: ignore
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Optional, \
-    Pattern, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Optional, Pattern, Tuple, Type, Union
 
 from . import errors
 
@@ -58,8 +57,7 @@ def validate_email(value: str) -> Tuple[str, str]:
     See RFC 5322 but treat it with suspicion, there seems to exist no universally acknowledged test for a valid email!
     """
     if email_validator is None:
-        raise ImportError(
-            'email-validator is not installed, run `pip install pydantic[email]`')
+        raise ImportError('email-validator is not installed, run `pip install pydantic[email]`')
 
     m = PRETTY_REGEX.fullmatch(value)
     name: Optional[str] = None
@@ -81,14 +79,14 @@ def _rfc_1738_quote(text: str) -> str:
 
 
 def make_dsn(
-        *,
-        driver: str,
-        user: str = None,
-        password: str = None,
-        host: str = None,
-        port: str = None,
-        name: str = None,
-        query: Dict[str, Any] = None,
+    *,
+    driver: str,
+    user: str = None,
+    password: str = None,
+    host: str = None,
+    port: str = None,
+    name: str = None,
+    query: Dict[str, Any] = None,
 ) -> str:
     """
     Create a DSN from from connection settings.
@@ -132,8 +130,7 @@ def import_string(dotted_path: str) -> Any:
     try:
         return getattr(module, class_name)
     except AttributeError as e:
-        raise ImportError(
-            f'Module "{module_path}" does not define a "{class_name}" attribute') from e
+        raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute') from e
 
 
 def truncate(v: str, *, max_len: int = 80) -> str:
@@ -172,8 +169,7 @@ ExcType = Type[Exception]
 
 
 @contextmanager
-def change_exception(raise_exc: ExcType, *except_types: ExcType) -> Generator[
-    None, None, None]:
+def change_exception(raise_exc: ExcType, *except_types: ExcType) -> Generator[None, None, None]:
     try:
         yield
     except except_types as e:
@@ -248,13 +244,12 @@ def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
     #     named_r
     # )
 
-    omg = r'^(?=(?P<SCHEME0>[a-z0-9\.\-\+]*))?(?=(?P<SCHEME1>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH1>://))?(?=(?P<SCHEME2>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH2>://)(?P<BASICAUTH2>[^:@]+?:[^:@]*?@|))?(?=(?P<SCHEME3>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH3>://)(?P<BASICAUTH3>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS3>(?P<SUBDOMAIN3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION3>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL3>localhost)|(?P<TLD3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV43>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV63>\[[A-F0-9]*:[A-F0-9:]+\])))?(?=(?P<SCHEME4>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH4>://)(?P<BASICAUTH4>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS4>(?P<SUBDOMAIN4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION4>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL4>localhost)|(?P<TLD4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV44>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV64>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT4>:\d+)?)?(?=(?P<SCHEME5>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH5>://)(?P<BASICAUTH5>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS5>(?P<SUBDOMAIN5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION5>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL5>localhost)|(?P<TLD5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV45>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV65>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT5>:\d+)?(?P<ENDURL5>/?|[/?]\S+))?.'
+    omg = r'^(?=(?P<SCHEME0>[a-z0-9\.\-\+]*))?(?=(?P<SCHEME1>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH1>://))?(?=(?P<SCHEME2>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH2>://)(?P<BASICAUTH2>[^:@]+?:[^:@]*?@|))?(?=(?P<SCHEME3>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH3>://)(?P<BASICAUTH3>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS3>(?P<SUBDOMAIN3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION3>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL3>localhost)|(?P<TLD3>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV43>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV63>\[[A-F0-9]*:[A-F0-9:]+\])))?(?=(?P<SCHEME4>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH4>://)(?P<BASICAUTH4>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS4>(?P<SUBDOMAIN4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION4>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL4>localhost)|(?P<TLD4>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV44>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV64>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT4>:\d+)?)?(?=(?P<SCHEME5>[a-z0-9\.\-\+]*)(?P<DOUBLESLASH5>://)(?P<BASICAUTH5>[^:@]+?:[^:@]*?@|)(?P<DOMAINOPTIONS5>(?P<SUBDOMAIN5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?P<EXTENSION5>[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|(?P<LOCAL5>localhost)|(?P<TLD5>[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|(?P<IPV45>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<IPV65>\[[A-F0-9]*:[A-F0-9:]+\]))(?P<PORT5>:\d+)?(?P<ENDURL5>/?|[/?]\S+$))?.'
     # return re.compile(tweaked, re.IGNORECASE)
     return re.compile(omg, re.IGNORECASE)
 
 
-def lenient_issubclass(cls: Any,
-                       class_or_tuple: Union[AnyType, Tuple[AnyType, ...]]) -> bool:
+def lenient_issubclass(cls: Any, class_or_tuple: Union[AnyType, Tuple[AnyType, ...]]) -> bool:
     return isinstance(cls, type) and issubclass(cls, class_or_tuple)
 
 
@@ -270,8 +265,7 @@ def in_ipython() -> bool:
         return True
 
 
-def resolve_annotations(raw_annotations: Dict[str, AnyType],
-                        module_name: Optional[str]) -> Dict[str, AnyType]:
+def resolve_annotations(raw_annotations: Dict[str, AnyType], module_name: Optional[str]) -> Dict[str, AnyType]:
     """
     Partially taken from typing.get_type_hints.
 
@@ -299,13 +293,11 @@ def is_callable_type(type_: AnyType) -> bool:
 
 
 def _check_classvar(v: AnyType) -> bool:
-    return type(v) == type(ClassVar) and (
-                sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
+    return type(v) == type(ClassVar) and (sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
 
 
 def is_classvar(ann_type: AnyType) -> bool:
-    return _check_classvar(ann_type) or _check_classvar(
-        getattr(ann_type, '__origin__', None))
+    return _check_classvar(ann_type) or _check_classvar(getattr(ann_type, '__origin__', None))
 
 
 def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> None:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -204,25 +204,25 @@ def url_regex_generator(*, relative: bool, require_tld: bool) -> Pattern[str]:
     for details please follow library source code:
         https://github.com/marshmallow-code/marshmallow/blob/298870ef6c089fb4d91efae9ca4168453ffe00d2/marshmallow/validate.py#L37
     """
-    original = r''.join(
-            (
-                r'^',
-                r'(' if relative else r'',
-                r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
-                r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
-                r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
-                r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
-                r'localhost|',  # localhost...
-                (
-                    r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''
-                ),  # allow dotless hostnames
-                r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
-                r'\[[A-F0-9]*:[A-F0-9:]+\])',  # ...or ipv6
-                r'(?::\d+)?',  # optional port
-                r')?' if relative else r'',  # host is optional, allow for relative URLs
-                r'(?:/?|[/?]\S+)$',
-            )
-        )
+    # original = r''.join(
+    #         (
+    #             r'^',
+    #             r'(' if relative else r'',
+    #             r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
+    #             r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
+    #             r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
+    #             r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
+    #             r'localhost|',  # localhost...
+    #             (
+    #                 r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|' if not require_tld else r''
+    #             ),  # allow dotless hostnames
+    #             r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
+    #             r'\[[A-F0-9]*:[A-F0-9:]+\])',  # ...or ipv6
+    #             r'(?::\d+)?',  # optional port
+    #             r')?' if relative else r'',  # host is optional, allow for relative URLs
+    #             r'(?:/?|[/?]\S+)$',
+    #         )
+    #     )
     tweaked = r''.join(
         (
             r'^',

--- a/tests/test_types_url_str.py
+++ b/tests/test_types_url_str.py
@@ -37,11 +37,25 @@ def test_url_str_absolute_success(value):
     [
         (
             'http:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             'https:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             'https://example.org\\',
@@ -49,22 +63,58 @@ def test_url_str_absolute_success(value):
         ),
         (
             'ftp:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             'ftps:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             'http//example.org',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
-        ('http:///',             [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],),
+        (
+            'http:///',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
+        ),
         (
             'http:/example.org',
-            [{'loc': ('v',),
-              'msg': 'url string does not match regex, failed at position 1',
-              'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
         (
             'foo://example.org',
@@ -79,7 +129,14 @@ def test_url_str_absolute_success(value):
         ),
         (
             '../icons/logo.gif',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
         (
             'http://2001:db8::ff00:42:8329',
@@ -87,14 +144,48 @@ def test_url_str_absolute_success(value):
         ),
         (
             'http://[192.168.1.1]:8329',
-            [{'loc': ('v',),
-              'msg': 'url string does not match regex, failed at position 6',
-              'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
-
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
-        ('abc', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
-        ('..', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
-        ('/', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        (
+            'abc',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
+        (
+            '..',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
+        (
+            '/',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
         (
             ' ',
             [
@@ -153,25 +244,81 @@ def test_url_str_relative_success(value):
     [
         (
             'http//example.org',
-            [{'loc': ('v',),
-              'msg': 'url string does not match regex, failed at position 1',
-              'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
         (
             'suppliers.html',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
         (
             '../icons/logo.gif',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
         (
             '\\icons/logo.gif',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
         ),
-        ('../.../g', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
-        ('...', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
-        ('\\', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        (
+            '../.../g',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
+        (
+            '...',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
+        (
+            '\\',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
         (
             ' ',
             [
@@ -228,18 +375,49 @@ def test_url_str_dont_require_tld_success(value):
 @pytest.mark.parametrize(
     'value,errors',
     [
-        ('http//example', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        (
+            'http//example',
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 1',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 1},
+                }
+            ],
+        ),
         (
             'http://.example.org',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             'http:///foo/bar',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             'http:// /foo/bar',
-            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+            [
+                {
+                    'loc': ('v',),
+                    'msg': 'url string does not match regex, failed at position 6',
+                    'type': 'value_error.url.regex',
+                    'ctx': {'position': 6},
+                }
+            ],
         ),
         (
             '',

--- a/tests/test_types_url_str.py
+++ b/tests/test_types_url_str.py
@@ -37,11 +37,11 @@ def test_url_str_absolute_success(value):
     [
         (
             'http:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             'https:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             'https://example.org\\',
@@ -49,20 +49,22 @@ def test_url_str_absolute_success(value):
         ),
         (
             'ftp:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             'ftps:///example.com/',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             'http//example.org',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
-        ('http:///', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
+        ('http:///',             [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],),
         (
             'http:/example.org',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',),
+              'msg': 'url string does not match regex, failed at position 1',
+              'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
         (
             'foo://example.org',
@@ -77,7 +79,7 @@ def test_url_str_absolute_success(value):
         ),
         (
             '../icons/logo.gif',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
         (
             'http://2001:db8::ff00:42:8329',
@@ -85,11 +87,14 @@ def test_url_str_absolute_success(value):
         ),
         (
             'http://[192.168.1.1]:8329',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',),
+              'msg': 'url string does not match regex, failed at position 6',
+              'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
+
         ),
-        ('abc', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
-        ('..', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
-        ('/', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
+        ('abc', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        ('..', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        ('/', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
         (
             ' ',
             [
@@ -148,23 +153,25 @@ def test_url_str_relative_success(value):
     [
         (
             'http//example.org',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',),
+              'msg': 'url string does not match regex, failed at position 1',
+              'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
         (
             'suppliers.html',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
         (
             '../icons/logo.gif',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
         (
             '\\icons/logo.gif',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}],
         ),
-        ('../.../g', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
-        ('...', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
-        ('\\', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
+        ('../.../g', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        ('...', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
+        ('\\', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
         (
             ' ',
             [
@@ -221,18 +228,18 @@ def test_url_str_dont_require_tld_success(value):
 @pytest.mark.parametrize(
     'value,errors',
     [
-        ('http//example', [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}]),
+        ('http//example', [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 1', 'type': 'value_error.url.regex', 'ctx': {'position': 1}}]),
         (
             'http://.example.org',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             'http:///foo/bar',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             'http:// /foo/bar',
-            [{'loc': ('v',), 'msg': 'url string does not match regex', 'type': 'value_error.url.regex'}],
+            [{'loc': ('v',), 'msg': 'url string does not match regex, failed at position 6', 'type': 'value_error.url.regex', 'ctx': {'position': 6}}],
         ),
         (
             '',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

WIP, still some tests failing, 2 false positive, if there are some regex gurus willing to look at it I'd be please, and thought I could already open the PR maybe to get some help / feedback

Today a regexp is built in `url_regex_generator` then a match is performed which raises an exception in case there's no match, simple, efficient.
```
        if not regex.match(value):
            raise errors.UrlRegexError()
```

As @cjw296 mentionned rightfully in https://github.com/samuelcolvin/pydantic/issues/541 
1. there's no way for the end user to know why or where it failed, the PR attempts to deal with that
2. the postgres url that fails while it seemed a correct url, the PR doesn't deal with that

to sum it up, the logic is changed the following way:

 `url_regex_generator` generates a single regex which is built around the concept described here :
https://stackoverflow.com/a/23839795/3581357

in pseudo code below you have A, B, C, each one being a r-string of course
`^(?=(A))?(?=(AB))?(?=(ABC))?.`

The minor difference between the `omg` regex I ended up writing (because you'll say it when you'll read it :smile: ) and the one presented in the post above is that I'm using named groups on top of it for the validation part that follows.

The validation will test if the last named group is present in the match, if yes it means the whole string  matched and we can return the value.

If it fails we get the lastindex of the last lookahead match will be available and we raise that as an error, it will be the position of the last find in essence

I modified failing tests for urlstr to include new warning on position

## Related issue number

#541

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
