### PR TITLE
Cython line prof

### DIFF
--- a/benchmarks/get_profiler.py
+++ b/benchmarks/get_profiler.py
@@ -1,0 +1,13 @@
+"""
+At first I tried to put this function inside profile_lines.py, but I ran into very strange issues
+where the line_profiler would be recreated if imported in pydantic files (I'm still not sure why).
+
+"""
+from functools import lru_cache
+
+from line_profiler import LineProfiler
+
+
+@lru_cache()  # ensures the same instance is always returned
+def get_line_profiler():
+    return LineProfiler()

--- a/benchmarks/profile.py
+++ b/benchmarks/profile.py
@@ -1,5 +1,5 @@
 import json
-from test_pydantic import TestPydantic
+from .test_pydantic import TestPydantic
 
 with open('./benchmarks/cases.json') as f:
     cases = json.load(f)

--- a/benchmarks/profile_lines.py
+++ b/benchmarks/profile_lines.py
@@ -10,23 +10,16 @@ def get_funcs_to_profile():
     and adding the most expensive call from the line-by-line output until I had to start adding
     them to the profiler in-line (e.g., when the most expensive call is a lambda).
 
-    You can comment/uncomment each line to include/exclude the line-by-line profiling for that function.
+    You can comment/uncomment each line to exclude/include the line-by-line profiling for that function.
     """
     funcs_to_profile = []
-    funcs_to_profile += [run_tests]
-    funcs_to_profile += [test_pydantic.TestPydantic.validate]
-    funcs_to_profile += [test_pydantic.Model.__init__]
-    funcs_to_profile += [pydantic.validate_model]
-    funcs_to_profile += [pydantic.fields.Field.validate]
-    funcs_to_profile += [pydantic.fields.Field._validate_singleton]
-    funcs_to_profile += [pydantic.fields.Field._apply_validators]
-
-    # The next most expensive line was pydantic.fields._apply_validators line 432;
-    # extracting the relevant functions was easier to do in-line -- see line 430 of that file
-    #
-    # The next most expensive lines after that were lambdas; see class_validators.py line 198.
-    #
-    # The next most expensive lines were actual validators. That is where I stopped digging.
+    # funcs_to_profile += [run_tests]
+    # funcs_to_profile += [test_pydantic.TestPydantic.validate]
+    # funcs_to_profile += [test_pydantic.Model.__init__]
+    # funcs_to_profile += [pydantic.parse_model]
+    # funcs_to_profile += [pydantic.fields.Field.validate]
+    # funcs_to_profile += [pydantic.fields.Field._validate_singleton]
+    # funcs_to_profile += [pydantic.fields.Field._apply_validators]
     return funcs_to_profile
 
 

--- a/benchmarks/profile_lines.py
+++ b/benchmarks/profile_lines.py
@@ -1,0 +1,56 @@
+import pydantic
+from benchmarks import test_pydantic
+from benchmarks.get_profiler import get_line_profiler
+from benchmarks.run import run_tests
+
+
+def get_funcs_to_profile():
+    """
+    I produced this cascading list of functions by starting with run_pydantic_tests,
+    and adding the most expensive call from the line-by-line output until I had to start adding
+    them to the profiler in-line (e.g., when the most expensive call is a lambda).
+
+    You can comment/uncomment each line to include/exclude the line-by-line profiling for that function.
+    """
+    funcs_to_profile = []
+    funcs_to_profile += [run_tests]
+    funcs_to_profile += [test_pydantic.TestPydantic.validate]
+    funcs_to_profile += [test_pydantic.Model.__init__]
+    funcs_to_profile += [pydantic.validate_model]
+    funcs_to_profile += [pydantic.fields.Field.validate]
+    funcs_to_profile += [pydantic.fields.Field._validate_singleton]
+    funcs_to_profile += [pydantic.fields.Field._apply_validators]
+
+    # The next most expensive line was pydantic.fields._apply_validators line 432;
+    # extracting the relevant functions was easier to do in-line -- see line 430 of that file
+    #
+    # The next most expensive lines after that were lambdas; see class_validators.py line 198.
+    #
+    # The next most expensive lines were actual validators. That is where I stopped digging.
+    return funcs_to_profile
+
+
+def profile(
+        funcs_to_profile,
+        main_func,
+        *main_func_args,
+        **main_func_kwargs
+):
+    profiler = get_line_profiler()
+    for f in funcs_to_profile:
+        profiler.add_function(f)
+    wrapped = profiler.wrap_function(main_func)
+    wrapped(*main_func_args, **main_func_kwargs)
+    get_line_profiler().print_stats()
+
+
+def main():
+    profile(
+        funcs_to_profile=get_funcs_to_profile(),
+        main_func=run_tests,
+        tests=[test_pydantic.TestPydantic]
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/test_pydantic.py
+++ b/benchmarks/test_pydantic.py
@@ -4,41 +4,51 @@ from typing import List
 from pydantic import BaseModel, Extra, PositiveInt, ValidationError, constr
 
 
+class Model(BaseModel):
+    id: int
+    client_name: constr(max_length=255)
+    sort_index: float
+    # client_email: EmailStr = None
+    client_phone: constr(max_length=255) = None
+
+    class Location(BaseModel):
+        latitude: float = None
+        longitude: float = None
+
+    location: Location = None
+
+    contractor: PositiveInt = None
+    upstream_http_referrer: constr(max_length=1023) = None
+    grecaptcha_response: constr(min_length=20, max_length=1000)
+    last_updated: datetime = None
+
+    class Skill(BaseModel):
+        subject: str
+        subject_id: int
+        category: str
+        qual_level: str
+        qual_level_id: int
+        qual_level_ranking: float = 0
+
+    skills: List[Skill] = []
+
+    class Config:
+        extra = Extra.allow
+
+
+class ModelForbidExtra(Model):
+    class Config:
+        extra = Extra.forbid
+
+
 class TestPydantic:
     package = 'pydantic'
 
     def __init__(self, allow_extra):
-
-        class Model(BaseModel):
-            id: int
-            client_name: constr(max_length=255)
-            sort_index: float
-            # client_email: EmailStr = None
-            client_phone: constr(max_length=255) = None
-
-            class Location(BaseModel):
-                latitude: float = None
-                longitude: float = None
-            location: Location = None
-
-            contractor: PositiveInt = None
-            upstream_http_referrer: constr(max_length=1023) = None
-            grecaptcha_response: constr(min_length=20, max_length=1000)
-            last_updated: datetime = None
-
-            class Skill(BaseModel):
-                subject: str
-                subject_id: int
-                category: str
-                qual_level: str
-                qual_level_id: int
-                qual_level_ranking: float = 0
-            skills: List[Skill] = []
-
-            class Config:
-                extra = Extra.allow if allow_extra else Extra.forbid
-
-        self.model = Model
+        if allow_extra:
+            self.model = Model
+        else:
+            self.model = ModelForbidExtra
 
     def validate(self, data):
         try:

--- a/benchmarks/test_toasted_marshmallow.py
+++ b/benchmarks/test_toasted_marshmallow.py
@@ -1,5 +1,5 @@
 import toastedmarshmallow
-from test_marshmallow import TestMarshmallow
+from .test_marshmallow import TestMarshmallow
 
 
 class TestToastedMarshmallow(TestMarshmallow):

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -6,6 +6,7 @@ from itertools import chain
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type
 
+from benchmarks.get_profiler import get_line_profiler
 from .errors import ConfigError
 from .utils import AnyCallable, in_ipython
 
@@ -194,6 +195,7 @@ def _generic_validator_basic(validator: AnyCallable, sig: Signature, args: Set[s
             f'(value, values, config, field), "values", "config" and "field" are all optional.'
         )
 
+    get_line_profiler().add_function(validator)
     if has_kwargs:
         return lambda cls, v, values, field, config: validator(v, values=values, field=field, config=config)
     elif args == set():

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -423,7 +423,7 @@ class Field:
         self, v: Any, values: Dict[str, Any], loc: 'LocType', cls: Optional['ModelOrDc'], validators: 'ValidatorsList'
     ) -> 'ValidateReturn':
         for validator in validators:
-            get_line_profiler().add_function(validator)  # just adds lambdas
+            # get_line_profiler().add_function(validator)  # just adds lambdas
             # The added lambdas are from class_validators.py lines 202, 206, 214 (see that file's line 198)
             try:
                 v = validator(cls, v, values, self, self.model_config)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -19,6 +19,7 @@ from typing import (
     cast,
 )
 
+from benchmarks.get_profiler import get_line_profiler
 from . import errors as errors_
 from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
@@ -422,6 +423,8 @@ class Field:
         self, v: Any, values: Dict[str, Any], loc: 'LocType', cls: Optional['ModelOrDc'], validators: 'ValidatorsList'
     ) -> 'ValidateReturn':
         for validator in validators:
+            get_line_profiler().add_function(validator)  # just adds lambdas
+            # The added lambdas are from class_validators.py lines 202, 206, 214 (see that file's line 198)
             try:
                 v = validator(cls, v, values, self, self.model_config)
             except (ValueError, TypeError) as exc:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,11 @@
+from distutils.extension import Extension
+
+from Cython.Compiler.Options import _directive_defaults
+
+
+_directive_defaults['linetrace'] = True
+_directive_defaults['binding'] = True
+
 import re
 import sys
 from importlib.machinery import SourceFileLoader
@@ -49,13 +57,16 @@ if 'clean' not in sys.argv:
         pass
     else:
         ext_modules = cythonize(
-            [
-                'pydantic/error_wrappers.py',
-                'pydantic/errors.py',
-                'pydantic/fields.py',
-                'pydantic/parse.py',
-                'pydantic/validators.py',
-            ],
+            [Extension('.'.join(filename[:-3].split("/")),
+                       [filename],
+                       define_macros=[('CYTHON_TRACE', '1'), ('CYTHON_TRACE_NOGIL', '1')])
+             for filename in [
+                 'pydantic/error_wrappers.py',
+                 'pydantic/errors.py',
+                 'pydantic/fields.py',
+                 'pydantic/parse.py',
+                 'pydantic/validators.py',
+             ]],
             nthreads=4,
             language_level=3,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

On top of the changes present in my line_profile branch relative to master, I needed to slightly tweak the setup.py to get Cython to set the C Macros necessary for line-profiling.

This stackoverflow answer is where I figured out how to make those changes: https://stackoverflow.com/questions/28301931/how-to-profile-cython-functions-line-by-line.

Note: `Cython.Compiler.Options.directive_defaults` became `_directive_defaults`; there is probably a non-protected API for doing this now, but I didn't bother with figuring that out; directly tweaking the value in _directive_defaults accomplished the goal of getting the macros set.

(If you want to add functions to the profiler in-line in a file that gets cythonized, you'd obviously need to re-build the cython modules.)

<!-- Please give a short summary of the changes. -->

#547  

<!-- Are there any issues opened that will be resolved by merging this change? -->
