### PR TITLE
Fix issue with unspecified generic type

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.xx (xxxx-xx-xx)
 * fix JSON Schema for ``list``, ``tuple``, and ``set``, #540 by @tiangolo
 * Change `_pydantic_post_init` to execute dataclass' original `__post_init__` before
   validation, #560 by @HeavenVolkoff
+* fix handling of generic types without specified parameters, #550 by @dmontagu
 
 v0.26 (2019-05-22)
 ..................

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -386,6 +386,8 @@ def find_validators(type_: AnyType, arbitrary_types_allowed: bool = False) -> Li
             if issubclass(type_, val_type):
                 return validators
         except TypeError as e:
+            if isinstance(type_, TypeVar):
+                return []
             raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
 
     if arbitrary_types_allowed:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -370,7 +370,7 @@ _VALIDATORS: List[Tuple[AnyType, List[AnyCallable]]] = [
 
 
 def find_validators(type_: AnyType, arbitrary_types_allowed: bool = False) -> List[AnyCallable]:
-    if type_ is Any or type(type_) == ForwardRef:
+    if type_ is Any or type(type_) in (ForwardRef, TypeVar):
         return []
     if type_ is Pattern:
         return pattern_validators
@@ -386,8 +386,6 @@ def find_validators(type_: AnyType, arbitrary_types_allowed: bool = False) -> Li
             if issubclass(type_, val_type):
                 return validators
         except TypeError as e:
-            if type_.__class__ == TypeVar:  # mypy errors for isinstance(type_, TypeVar)
-                return []
             raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
 
     if arbitrary_types_allowed:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -161,6 +161,22 @@ def dict_validator(v: Any) -> Dict[Any, Any]:
         return v
 
     with change_exception(errors.DictError, TypeError, ValueError):
+        #
+        # if not isinstance(v, dict):
+        #     # (More strict than the next approach, which also fails)
+        #     raise TypeError
+        # if isinstance(v, list):
+        #    # This approach doesn't work due to:
+        #    # https://github.com/samuelcolvin/pydantic/blob/master/tests/test_types.py#L471
+        #    # https://github.com/samuelcolvin/pydantic/blob/master/tests/test_edge_cases.py#L136
+        #    raise TypeError
+        if isinstance(v, list) and len(v) == 0:
+            # This currently works, but is probably bad since it will cause errors
+            # for empty "versions" of the above way of passing params
+            raise TypeError
+
+        # https://github.com/python/cpython/blob/3.7/Objects/dictobject.c#L3196
+        # means empty list is hard to check for
         return dict(v)
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -161,22 +161,6 @@ def dict_validator(v: Any) -> Dict[Any, Any]:
         return v
 
     with change_exception(errors.DictError, TypeError, ValueError):
-        #
-        # if not isinstance(v, dict):
-        #     # (More strict than the next approach, which also fails)
-        #     raise TypeError
-        # if isinstance(v, list):
-        #    # This approach doesn't work due to:
-        #    # https://github.com/samuelcolvin/pydantic/blob/master/tests/test_types.py#L471
-        #    # https://github.com/samuelcolvin/pydantic/blob/master/tests/test_edge_cases.py#L136
-        #    raise TypeError
-        if isinstance(v, list) and len(v) == 0:
-            # This currently works, but is probably bad since it will cause errors
-            # for empty "versions" of the above way of passing params
-            raise TypeError
-
-        # https://github.com/python/cpython/blob/3.7/Objects/dictobject.c#L3196
-        # means empty list is hard to check for
         return dict(v)
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -383,11 +383,9 @@ def find_validators(type_: AnyType, arbitrary_types_allowed: bool = False) -> Li
 
     for val_type, validators in _VALIDATORS:
         try:
-            if issubclass(type_, val_type):
+            if lenient_issubclass(type_, val_type):
                 return validators
         except TypeError as e:
-            if isinstance(type_, TypeVar):
-                return []
             raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
 
     if arbitrary_types_allowed:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -383,16 +383,16 @@ def find_validators(type_: AnyType, arbitrary_types_allowed: bool = False) -> Li
 
     for val_type, validators in _VALIDATORS:
         try:
-            if lenient_issubclass(type_, val_type):
+            if issubclass(type_, val_type):
                 return validators
         except TypeError as e:
+            if type_.__class__ == TypeVar:  # mypy errors for isinstance(type_, TypeVar)
+                return []
             raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
 
     if arbitrary_types_allowed:
         return [make_arbitrary_type_validator(type_)]
     else:
-        if isinstance(type_, TypeVar):
-            return []
         raise RuntimeError(f'no validator found for {type_}')
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -391,6 +391,8 @@ def find_validators(type_: AnyType, arbitrary_types_allowed: bool = False) -> Li
     if arbitrary_types_allowed:
         return [make_arbitrary_type_validator(type_)]
     else:
+        if isinstance(type_, TypeVar):
+            return []
         raise RuntimeError(f'no validator found for {type_}')
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1548,21 +1548,3 @@ def test_generic_without_params_error():
         {'loc': ('generic_list',), 'msg': 'value is not a valid list', 'type': 'type_error.list'},
         {'loc': ('generic_dict',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'},
     ]
-
-
-# THIS TEST WILL BE REMOVED BEFORE FINAL PULL REQUEST SUBMISSION
-def test_empty_list_dict_error():  # ???
-    class Model(BaseModel):
-        generic_list: List
-        generic_dict: Dict
-
-    # This test passes -- should it fail, or is this the desired behavior? (It would make sense to me either way)
-    # It also passes if I replace Dict with Dict[int, int], so no new problems have been introduced.
-    # assert Model(generic_list=[], generic_dict=[])
-
-    # The alternate form:
-    with pytest.raises(ValidationError) as exc_info:
-        Model(generic_list=[], generic_dict=[])
-    assert exc_info.value.errors() == [
-        {'loc': ('generic_dict',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}
-    ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1551,22 +1551,18 @@ def test_generic_without_params_error():
 
 
 # THIS TEST WILL BE REMOVED BEFORE FINAL PULL REQUEST SUBMISSION
-def test_is_this_okay():  # ???
+def test_empty_list_dict_error():  # ???
     class Model(BaseModel):
         generic_list: List
-        generic_dict: Dict[int, int]
+        generic_dict: Dict
 
     # This test passes -- should it fail, or is this the desired behavior? (It would make sense to me either way)
     # It also passes if I replace Dict with Dict[int, int], so no new problems have been introduced.
-    assert Model(generic_list=[], generic_dict=[])
+    # assert Model(generic_list=[], generic_dict=[])
 
     # The alternate form:
-    # with pytest.raises(ValidationError) as exc_info:
-    #     Model(generic_list=[], generic_dict=[])
-    # assert exc_info.value.errors() == [
-    #     {
-    #         'loc': ('generic_dict',),
-    #         'msg': 'value is not a valid dict',
-    #         'type': 'type_error.dict'
-    #     }
-    # ]
+    with pytest.raises(ValidationError) as exc_info:
+        Model(generic_list=[], generic_dict=[])
+    assert exc_info.value.errors() == [
+        {'loc': ('generic_dict',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}
+    ]


### PR DESCRIPTION
With this change, models with bare `List` or `Dict` as a typehint still validate for type agreement, but don't validate the type of the parameters.

## Change Summary

Checks for TypeVar when looking up validators.
#550

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
