### PR TITLE
Fix Cython compiled check in ipython

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.28 (unreleased)
 * fix support for JSON Schema generation when using models with circular references in Python 3.7, #572 by @tiangolo
 * support ``__post_init_post_parse__`` on dataclasses, #567 by @sevaho
 * allow dumping dataclasses to JSON, #575 by @samuelcolvin and @DanielOberg
+* fix ``pydantic.compiled`` on ipython, #573 by @dmontagu and @samuelcolvin
 
 v0.27 (2019-05-30)
 ..................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -65,7 +65,10 @@ try:
 except ImportError:
     compiled: bool = False
 else:  # pragma: no cover
-    compiled = getattr(cython, "compiled", False)
+    try:
+        compiled = cython.compiled
+    except AttributeError:
+        compiled = False
 
 
 class Extra(str, Enum):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -65,7 +65,7 @@ try:
 except ImportError:
     compiled: bool = False
 else:  # pragma: no cover
-    compiled = cython.compiled
+    compiled = getattr(cython, "compiled", False)
 
 
 class Extra(str, Enum):


### PR DESCRIPTION
Addresses the issue raised in #548 related to running non-compiled in IPython
