### PR TITLE
dataclasses to json

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.28 (unreleased)
 ..................
 * support ``__post_init_post_parse__`` on dataclasses, #567 by @sevaho
+* allow dumping dataclasses to JSON, #575 by @samuelcolvin and @DanielOberg
 
 v0.27 (2019-05-30)
 ..................

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -1,4 +1,5 @@
 import datetime
+from dataclasses import asdict, is_dataclass
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -49,6 +50,8 @@ def pydantic_encoder(obj: Any) -> Any:
         return obj.value
     elif isinstance(obj, Path):
         return str(obj)
+    elif is_dataclass(obj):
+        return asdict(obj)
 
     try:
         encoder = ENCODERS_BY_TYPE[type(obj)]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import sys
+from dataclasses import dataclass as vanilla_dataclass
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -10,6 +11,7 @@ from uuid import UUID
 import pytest
 
 from pydantic import BaseModel, create_model
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.color import Color
 from pydantic.json import pydantic_encoder, timedelta_isoformat
 from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr
@@ -137,3 +139,24 @@ def test_custom_encoder_arg():
     m = Model(x=123)
     assert m.json() == '{"x": 123.0}'
     assert m.json(encoder=lambda v: '__default__') == '{"x": "__default__"}'
+
+
+def test_encode_dataclass():
+    @vanilla_dataclass
+    class Foo:
+        bar: int
+        spam: str
+
+    f = Foo(bar=123, spam='apple pie')
+    assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
+
+
+def test_encode_pydantic_dataclass():
+    @pydantic_dataclass
+    class Foo:
+        bar: int
+        spam: str
+
+    f = Foo(bar=123, spam='apple pie')
+    assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
+

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -11,8 +11,8 @@ from uuid import UUID
 import pytest
 
 from pydantic import BaseModel, create_model
-from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.color import Color
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.json import pydantic_encoder, timedelta_isoformat
 from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr
 
@@ -159,4 +159,3 @@ def test_encode_pydantic_dataclass():
 
     f = Foo(bar=123, spam='apple pie')
     assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
-


### PR DESCRIPTION
## Change Summary

support dumping dataclasses to JSON by modifying `pydantic_encoder`.

## Related issue number

replace #528

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
