### PR TITLE
Add support for Literal annotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
 - pip freeze
 
 script:
-# test without cython but with ujson, email-validator, and typing-extensions
 - python -c "import sys, pydantic; print('compiled:', pydantic.compiled); sys.exit(1 if pydantic.compiled else 0)"
 - make test
 
@@ -40,7 +39,6 @@ jobs:
     python: 3.6
     name: 'Cython: 3.6'
     script:
-    # test with cython, ujson, email-validator, and typing-extensions
     - make build-cython-trace
     - python -c "import sys, pydantic; print('compiled:', pydantic.compiled); sys.exit(0 if pydantic.compiled else 1)"
     - make test
@@ -50,7 +48,6 @@ jobs:
     python: 3.7
     name: 'Cython: 3.7'
     script:
-    # test with cython, ujson, email-validator, and typing-extensions
     - make build-cython-trace
     - python -c "import sys, pydantic; print('compiled:', pydantic.compiled); sys.exit(0 if pydantic.compiled else 1)"
     - make test
@@ -61,7 +58,6 @@ jobs:
     python: 3.6
     name: 'Without Deps 3.6'
     script:
-    # test without cython, ujson, email-validator, and typing-extensions
     - pip uninstall -y ujson email-validator typing-extensions
     - make test
     env:
@@ -70,7 +66,6 @@ jobs:
     python: 3.7
     name: 'Without Deps 3.7'
     script:
-    # test without cython, ujson, email-validator, and typing-extensions
     - pip uninstall -y ujson email-validator cython typing-extensions
     - make test
     env:
@@ -80,7 +75,6 @@ jobs:
     python: 3.7
     name: 'Benchmarks'
     script:
-    # default install skips cython compilation, need to compile for benchmarks
     - make build-cython
     - BENCHMARK_REPEATS=1 make benchmark-all
     after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 - pip freeze
 
 script:
-# test without cython but with ujson and email-validator
+# test without cython but with ujson, email-validator, and typing-extensions
 - python -c "import sys, pydantic; print('compiled:', pydantic.compiled); sys.exit(1 if pydantic.compiled else 0)"
 - make test
 
@@ -40,7 +40,7 @@ jobs:
     python: 3.6
     name: 'Cython: 3.6'
     script:
-    # test with cython, ujson and email-validator
+    # test with cython, ujson, email-validator, and typing-extensions
     - make build-cython-trace
     - python -c "import sys, pydantic; print('compiled:', pydantic.compiled); sys.exit(0 if pydantic.compiled else 1)"
     - make test
@@ -50,7 +50,7 @@ jobs:
     python: 3.7
     name: 'Cython: 3.7'
     script:
-    # test with cython, ujson and email-validator
+    # test with cython, ujson, email-validator, and typing-extensions
     - make build-cython-trace
     - python -c "import sys, pydantic; print('compiled:', pydantic.compiled); sys.exit(0 if pydantic.compiled else 1)"
     - make test
@@ -61,8 +61,8 @@ jobs:
     python: 3.6
     name: 'Without Deps 3.6'
     script:
-    # test without cython, ujson and email-validator
-    - pip uninstall -y ujson email-validator
+    # test without cython, ujson, email-validator, and typing-extensions
+    - pip uninstall -y ujson email-validator typing-extensions
     - make test
     env:
     - 'DEPS=no'
@@ -70,8 +70,8 @@ jobs:
     python: 3.7
     name: 'Without Deps 3.7'
     script:
-    # test without cython, ujson and email-validator
-    - pip uninstall -y ujson email-validator cython
+    # test without cython, ujson, email-validator, and typing-extensions
+    - pip uninstall -y ujson email-validator cython typing-extensions
     - make test
     env:
     - 'DEPS=no'

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -50,7 +50,8 @@ class NoneIsAllowedError(PydanticTypeError):
 class WrongConstantError(PydanticValueError):
     code = 'const'
 
-    def __str__(self):
+    def __str__(self) -> str:
+        assert self.ctx is not None
         given = self.ctx['given']
         permitted = ', '.join(repr(v) for v in self.ctx['permitted'])
         return f'unexpected value; given: {given!r}; permitted: {permitted}'

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -51,10 +51,8 @@ class WrongConstantError(PydanticValueError):
     code = 'const'
 
     def __str__(self) -> str:
-        assert self.ctx is not None
-        given = self.ctx['given']
-        permitted = ', '.join(repr(v) for v in self.ctx['permitted'])
-        return f'unexpected value; given: {given!r}; permitted: {permitted}'
+        permitted = ', '.join(repr(v) for v in self.ctx['permitted'])  # type: ignore
+        return f'unexpected value; permitted: {permitted}'
 
 
 class BytesError(PydanticTypeError):

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -49,7 +49,11 @@ class NoneIsAllowedError(PydanticTypeError):
 
 class WrongConstantError(PydanticValueError):
     code = 'const'
-    msg_template = 'unexpected constant value; permitted values: {allowed!r}'
+
+    def __str__(self):
+        given = self.ctx['given']
+        permitted = ', '.join(repr(v) for v in self.ctx['permitted'])
+        return f'unexpected value; given: {given!r}; permitted: {permitted}'
 
 
 class BytesError(PydanticTypeError):

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -49,7 +49,7 @@ class NoneIsAllowedError(PydanticTypeError):
 
 class WrongConstantError(PydanticValueError):
     code = 'const'
-    msg_template = 'expected constant value {const!r}'
+    msg_template = 'unexpected constant value; permitted values: {allowed!r}'
 
 
 class BytesError(PydanticTypeError):
@@ -357,7 +357,3 @@ class ColorError(PydanticValueError):
 
 class StrictBoolError(PydanticValueError):
     msg_template = 'value is not a valid boolean'
-
-
-class LiteralError(PydanticValueError):
-    msg_template = 'value was not in allowed choices: {allowed_choices!r}'

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -357,3 +357,7 @@ class ColorError(PydanticValueError):
 
 class StrictBoolError(PydanticValueError):
     msg_template = 'value is not a valid boolean'
+
+
+class LiteralError(PydanticValueError):
+    msg_template = 'value was not in allowed choices: {allowed_choices!r}'

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -23,17 +23,13 @@ from . import errors as errors_
 from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
-from .utils import (
-    AnyCallable,
-    AnyType,
-    Callable,
-    ForwardRef,
-    Literal,
-    display_as_type,
-    lenient_issubclass,
-    sequence_like,
-)
+from .utils import AnyCallable, AnyType, Callable, ForwardRef, display_as_type, lenient_issubclass, sequence_like
 from .validators import NoneType, constant_validator, dict_validator, find_validators
+
+try:
+    from typing_extensions import Literal
+except ImportError:
+    Literal = None  # type: ignore
 
 Required: Any = Ellipsis
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -19,14 +19,17 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Literal
-
 from . import errors as errors_
 from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
 from .utils import AnyCallable, AnyType, Callable, ForwardRef, display_as_type, lenient_issubclass, sequence_like
 from .validators import NoneType, constant_validator, dict_validator, find_validators
+
+try:
+    from typing_extensions import Literal
+except ImportError:
+    Literal = object()  # type: ignore
 
 Required: Any = Ellipsis
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -23,13 +23,17 @@ from . import errors as errors_
 from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
-from .utils import AnyCallable, AnyType, Callable, ForwardRef, display_as_type, lenient_issubclass, sequence_like
+from .utils import (
+    AnyCallable,
+    AnyType,
+    Callable,
+    ForwardRef,
+    Literal,
+    display_as_type,
+    lenient_issubclass,
+    sequence_like,
+)
 from .validators import NoneType, constant_validator, dict_validator, find_validators
-
-try:
-    from typing_extensions import Literal
-except ImportError:
-    Literal = object()  # type: ignore
 
 Required: Any = Ellipsis
 
@@ -192,7 +196,7 @@ class Field:
             return
         if origin is Callable:
             return
-        if origin is Literal:
+        if Literal is not None and origin is Literal:
             return
         if origin is Union:
             types_ = []

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -19,6 +19,8 @@ from typing import (
     cast,
 )
 
+from typing_extensions import Literal
+
 from . import errors as errors_
 from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
@@ -186,6 +188,8 @@ class Field:
             # field is not "typing" object eg. Union, Dict, List etc.
             return
         if origin is Callable:
+            return
+        if origin is Literal:
             return
         if origin is Union:
             types_ = []

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -27,7 +27,7 @@ import pydantic
 try:
     from typing_extensions import Literal
 except ImportError:
-    Literal = object()  # type: ignore
+    Literal = None  # type: ignore
 
 try:
     import email_validator
@@ -291,7 +291,7 @@ def is_callable_type(type_: AnyType) -> bool:
 
 
 def is_literal_type(type_: AnyType) -> bool:
-    return getattr(type_, '__origin__', None) is Literal
+    return Literal is not None and getattr(type_, '__origin__', None)
 
 
 def _check_classvar(v: AnyType) -> bool:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -25,6 +25,11 @@ from typing import (  # type: ignore
 import pydantic
 
 try:
+    from typing_extensions import Literal
+except ImportError:
+    Literal = object()  # type: ignore
+
+try:
     import email_validator
 except ImportError:
     email_validator = None
@@ -283,6 +288,10 @@ def resolve_annotations(raw_annotations: Dict[str, AnyType], module_name: Option
 
 def is_callable_type(type_: AnyType) -> bool:
     return type_ is Callable or getattr(type_, '__origin__', None) is Callable
+
+
+def is_literal_type(type_: AnyType) -> bool:
+    return getattr(type_, '__origin__', None) is Literal
 
 
 def _check_classvar(v: AnyType) -> bool:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -290,8 +290,16 @@ def is_callable_type(type_: AnyType) -> bool:
     return type_ is Callable or getattr(type_, '__origin__', None) is Callable
 
 
-def is_literal_type(type_: AnyType) -> bool:
-    return Literal is not None and getattr(type_, '__origin__', None)
+if sys.version_info >= (3, 7):
+
+    def is_literal_type(type_: AnyType) -> bool:
+        return Literal is not None and getattr(type_, '__origin__', None) is Literal
+
+
+else:
+
+    def is_literal_type(type_: AnyType) -> bool:
+        return Literal is not None and hasattr(type_, '__values__') and type_ == Literal[type_.__values__]
 
 
 def _check_classvar(v: AnyType) -> bool:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -149,7 +149,7 @@ def constant_validator(v: 'Any', field: 'Field') -> 'Any':
     Schema.
     """
     if v != field.default:
-        raise errors.WrongConstantError(given=v, allowed=[field.default])
+        raise errors.WrongConstantError(given=v, permitted=[field.default])
 
     return v
 
@@ -344,9 +344,11 @@ def callable_validator(v: Any) -> AnyCallable:
 
 
 def make_literal_validator(allowed_choices: Tuple[Any, ...]) -> Callable[[Any], Any]:
+    allowed_choices_set = set(allowed_choices)
+
     def literal_validator(v: Any) -> Any:
-        if v not in allowed_choices:
-            raise errors.WrongConstantError(allowed=list(allowed_choices))
+        if v not in allowed_choices_set:
+            raise errors.WrongConstantError(given=v, permitted=list(allowed_choices))
         return v
 
     return literal_validator

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -444,7 +444,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         yield callable_validator
         return
     if is_literal_type(type_):
-        yield make_literal_validator(type_.__args__)
+        yield make_literal_validator(getattr(type_, '__args__', getattr(type_, '__values__')))
         return
 
     supertype = _find_supertype(type_)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal, DecimalException
@@ -343,7 +344,11 @@ def callable_validator(v: Any) -> AnyCallable:
     raise errors.CallableError(value=v)
 
 
-def make_literal_validator(allowed_choices: Tuple[Any, ...]) -> Callable[[Any], Any]:
+def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
+    if sys.version_info >= (3, 7):
+        allowed_choices = type_.__args__
+    else:
+        allowed_choices = type_.__values__
     allowed_choices_set = set(allowed_choices)
 
     def literal_validator(v: Any) -> Any:
@@ -444,7 +449,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         yield callable_validator
         return
     if is_literal_type(type_):
-        yield make_literal_validator(getattr(type_, '__args__', getattr(type_, '__values__')))
+        yield make_literal_validator(type_)
         return
 
     supertype = _find_supertype(type_)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -346,14 +346,14 @@ def callable_validator(v: Any) -> AnyCallable:
 
 def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
     if sys.version_info >= (3, 7):
-        allowed_choices = type_.__args__
+        permitted_choices = type_.__args__
     else:
-        allowed_choices = type_.__values__
-    allowed_choices_set = set(allowed_choices)
+        permitted_choices = type_.__values__
+    allowed_choices_set = set(permitted_choices)
 
     def literal_validator(v: Any) -> Any:
         if v not in allowed_choices_set:
-            raise errors.WrongConstantError(given=v, permitted=allowed_choices)
+            raise errors.WrongConstantError(given=v, permitted=permitted_choices)
         return v
 
     return literal_validator

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -353,7 +353,7 @@ def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
 
     def literal_validator(v: Any) -> Any:
         if v not in allowed_choices_set:
-            raise errors.WrongConstantError(given=v, permitted=list(allowed_choices))
+            raise errors.WrongConstantError(given=v, permitted=allowed_choices)
         return v
 
     return literal_validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 ujson==1.35
 email-validator==1.0.4
 dataclasses==0.6; python_version < '3.7'
+typing-extensions==3.7.2

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     extras_require={
         'ujson': ['ujson>=1.35'],
         'email': ['email-validator>=1.0.3'],
-        'typing_extensions': ['typing_extensions']
+        'typing_extensions': ['typing-extensions>=3.7.2']
     },
     ext_modules=ext_modules,
 )

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
     extras_require={
         'ujson': ['ujson>=1.35'],
         'email': ['email-validator>=1.0.3'],
+        'typing_extensions': ['typing_extensions']
     },
     ext_modules=ext_modules,
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -391,9 +391,9 @@ def test_const_with_wrong_value():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'expected constant value 3',
+            'msg': 'unexpected constant value; permitted values: [3]',
             'type': 'value_error.const',
-            'ctx': {'given': 4, 'const': 3},
+            'ctx': {'given': 4, 'allowed': [3]},
         }
     ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -391,7 +391,7 @@ def test_const_with_wrong_value():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'unexpected value; given: 4; permitted: 3',
+            'msg': 'unexpected value; permitted: 3',
             'type': 'value_error.const',
             'ctx': {'given': 4, 'permitted': [3]},
         }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -391,9 +391,9 @@ def test_const_with_wrong_value():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'unexpected constant value; permitted values: [3]',
+            'msg': 'unexpected value; given: 4; permitted: 3',
             'type': 'value_error.const',
-            'ctx': {'given': 4, 'allowed': [3]},
+            'ctx': {'given': 4, 'permitted': [3]},
         }
     ]
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -49,6 +49,10 @@ try:
 except ImportError:
     email_validator = None
 
+try:
+    import typing_extensions
+except ImportError:
+    typing_extensions = None
 
 class ConBytesModel(BaseModel):
     v: conbytes(max_length=10) = b'foobar'
@@ -1664,6 +1668,7 @@ def test_generic_without_params_error():
     ]
 
 
+@pytest.mark.skipif(not typing_extensions, reason='typing_extensions not installed')
 def test_literal_single():
     class Model(BaseModel):
         a: Literal['a']
@@ -1681,6 +1686,7 @@ def test_literal_single():
     ]
 
 
+@pytest.mark.skipif(not typing_extensions, reason='typing_extensions not installed')
 def test_literal_multiple():
     class Model(BaseModel):
         a_or_b: Literal['a', 'b']

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -10,7 +10,6 @@ from typing import Dict, Iterator, List, NewType, Pattern, Sequence, Set, Tuple
 from uuid import UUID
 
 import pytest
-from typing_extensions import Literal
 
 from pydantic import (
     DSN,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -53,6 +53,7 @@ try:
 except ImportError:
     typing_extensions = None
 
+
 class ConBytesModel(BaseModel):
     v: conbytes(max_length=10) = b'foobar'
 
@@ -1670,7 +1671,7 @@ def test_generic_without_params_error():
 @pytest.mark.skipif(not typing_extensions, reason='typing_extensions not installed')
 def test_literal_single():
     class Model(BaseModel):
-        a: Literal['a']
+        a: typing_extensions.Literal['a']
 
     Model(a='a')
     with pytest.raises(ValidationError) as exc_info:
@@ -1678,9 +1679,9 @@ def test_literal_single():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'unexpected constant value; permitted values: [\'a\']',
+            'msg': 'unexpected value; given: \'b\'; permitted: \'a\'',
             'type': 'value_error.const',
-            'ctx': {'allowed': ['a']},
+            'ctx': {'given': 'b', 'permitted': ['a']},
         }
     ]
 
@@ -1688,7 +1689,7 @@ def test_literal_single():
 @pytest.mark.skipif(not typing_extensions, reason='typing_extensions not installed')
 def test_literal_multiple():
     class Model(BaseModel):
-        a_or_b: Literal['a', 'b']
+        a_or_b: typing_extensions.Literal['a', 'b']
 
     Model(a_or_b='a')
     Model(a_or_b='b')
@@ -1697,8 +1698,8 @@ def test_literal_multiple():
     assert exc_info.value.errors() == [
         {
             'loc': ('a_or_b',),
-            'msg': 'unexpected constant value; permitted values: [\'a\', \'b\']',
+            'msg': 'unexpected value; given: \'c\'; permitted: \'a\', \'b\'',
             'type': 'value_error.const',
-            'ctx': {'allowed': ['a', 'b']},
+            'ctx': {'given': 'c', 'permitted': ['a', 'b']},
         }
     ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1679,7 +1679,7 @@ def test_literal_single():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'unexpected value; permitted: \'a\'',
+            'msg': "unexpected value; permitted: 'a'",
             'type': 'value_error.const',
             'ctx': {'given': 'b', 'permitted': ('a',)},
         }
@@ -1698,7 +1698,7 @@ def test_literal_multiple():
     assert exc_info.value.errors() == [
         {
             'loc': ('a_or_b',),
-            'msg': 'unexpected value; permitted: \'a\', \'b\'',
+            'msg': "unexpected value; permitted: 'a', 'b'",
             'type': 'value_error.const',
             'ctx': {'given': 'c', 'permitted': ('a', 'b')},
         }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1679,9 +1679,9 @@ def test_literal_single():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'unexpected value; given: \'b\'; permitted: \'a\'',
+            'msg': 'unexpected value; permitted: \'a\'',
             'type': 'value_error.const',
-            'ctx': {'given': 'b', 'permitted': ['a']},
+            'ctx': {'given': 'b', 'permitted': ('a',)},
         }
     ]
 
@@ -1698,8 +1698,8 @@ def test_literal_multiple():
     assert exc_info.value.errors() == [
         {
             'loc': ('a_or_b',),
-            'msg': 'unexpected value; given: \'c\'; permitted: \'a\', \'b\'',
+            'msg': 'unexpected value; permitted: \'a\', \'b\'',
             'type': 'value_error.const',
-            'ctx': {'given': 'c', 'permitted': ['a', 'b']},
+            'ctx': {'given': 'c', 'permitted': ('a', 'b')},
         }
     ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1674,9 +1674,9 @@ def test_literal_single():
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),
-            'msg': 'value was not in allowed choices: (\'a\',)',
-            'type': 'value_error.literal',
-            'ctx': {'allowed_choices': ('a',)},
+            'msg': 'unexpected constant value; permitted values: [\'a\']',
+            'type': 'value_error.const',
+            'ctx': {'allowed': ['a']},
         }
     ]
 
@@ -1692,8 +1692,8 @@ def test_literal_multiple():
     assert exc_info.value.errors() == [
         {
             'loc': ('a_or_b',),
-            'msg': 'value was not in allowed choices: (\'a\', \'b\')',
-            'type': 'value_error.literal',
-            'ctx': {'allowed_choices': ('a', 'b')},
+            'msg': 'unexpected constant value; permitted values: [\'a\', \'b\']',
+            'type': 'value_error.const',
+            'ctx': {'allowed': ['a', 'b']},
         }
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Properly handle attributes annotated with `typing_extensions.Literal`

-----

If you like this, let me know and I'll add documentation and finish the other bullets in the checklist. I'd also be happy to try implementing a workaround to eliminate the `typing_extensions` dependency (given some guidance about the desired outcome). I could also look into how to better integrate with the schema.

If you _don't_ like this (e.g., because you think my implementation is awkward, or because you think this feature is just premature while `Literal` remains in `typing_extensions` rather than `typing`), no worries -- I'll just close the pull request and maybe come back to it at a later date. But the implementation seemed simple enough that I felt like it was worth sharing.

## Related issue number

#561 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
