### PR TITLE
Add support for InitVar

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 v0.29 (unreleased)
-.................
+..................
 * support dataclasses.InitVar, #592 by @pfrederiks
 
 v0.28 (2019-06-06)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 History
 -------
+v0.29 (unreleased)
+.................
+* support dataclasses.InitVar, #592 by @pfrederiks
 
 v0.28 (2019-06-06)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,7 @@
 
 History
 -------
+
 v0.29 (unreleased)
 ..................
 * support dataclasses.InitVar, #592 by @pfrederiks

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
             pass
 
 
-def _pydantic_post_init(self: 'DataclassType', *initvars) -> None:
+def _pydantic_post_init(self: 'DataclassType', *initvars: Any) -> None:
     if self.__post_init_original__:
         self.__post_init_original__(*initvars)
     d = validate_model(self.__pydantic_model__, self.__dict__, cls=self.__class__)[0]

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -25,9 +25,9 @@ if TYPE_CHECKING:  # pragma: no cover
             pass
 
 
-def _pydantic_post_init(self: 'DataclassType') -> None:
+def _pydantic_post_init(self: 'DataclassType', *initvars) -> None:
     if self.__post_init_original__:
-        self.__post_init_original__()
+        self.__post_init_original__(*initvars)
     d = validate_model(self.__pydantic_model__, self.__dict__, cls=self.__class__)[0]
     object.__setattr__(self, '__dict__', d)
     object.__setattr__(self, '__initialised__', True)
@@ -81,6 +81,7 @@ def _process_class(
     fields: Dict[str, Any] = {
         name: (field.type, field.default if field.default != dataclasses.MISSING else Required)
         for name, field in cls.__dataclass_fields__.items()
+        if field.type is not dataclasses.InitVar
     }
     cls.__post_init_original__ = post_init_original
     cls.__post_init_post_parse__ = post_init_post_parse

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -79,9 +79,8 @@ def _process_class(
     cls = dataclasses._process_class(_cls, init, repr, eq, order, unsafe_hash, frozen)  # type: ignore
 
     fields: Dict[str, Any] = {
-        name: (field.type, field.default if field.default != dataclasses.MISSING else Required)
-        for name, field in cls.__dataclass_fields__.items()
-        if field.type is not dataclasses.InitVar
+        field.name: (field.type, field.default if field.default != dataclasses.MISSING else Required)
+        for field in dataclasses.fields(cls)
     }
     cls.__post_init_original__ = post_init_original
     cls.__post_init_post_parse__ = post_init_post_parse

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -380,3 +380,28 @@ def test_nested_schema():
             }
         },
     }
+
+
+def test_initvar():
+    from math import pi
+
+    InitVar = dataclasses.InitVar
+
+    @pydantic.dataclasses.dataclass
+    class RadiansWithInitVar:
+        rad: float = dataclasses.field(init=False)
+        deg: InitVar
+
+        def __post_init__(self, deg):
+            if deg:
+                self.rad = float(deg) / 180 * pi
+
+        @pydantic.validator("rad")
+        def validate_radians(cls, rad):
+            if rad > 2 * pi:
+                raise ValueError("radian too large")
+            return rad
+
+    assert RadiansWithInitVar(90).rad == 0.5 * pi
+    with pytest.raises(ValueError):
+        RadiansWithInitVar(9000)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,5 +1,6 @@
 import dataclasses
 from datetime import datetime
+from typing import ClassVar
 
 import pytest
 
@@ -411,3 +412,13 @@ def test_derived_field_from_initvar():
     assert derived.plusone == 2
     with pytest.raises(TypeError):
         DerivedWithInitVar("Not A Number")
+
+
+def test_classvar():
+    @pydantic.dataclasses.dataclass
+    class TestClassVar:
+        klassvar: ClassVar = "I'm a Class variable"
+        x: int
+
+    tcv = TestClassVar(2)
+    assert tcv.klassvar == "I'm a Class variable"

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -383,25 +383,31 @@ def test_nested_schema():
 
 
 def test_initvar():
-    from math import pi
-
     InitVar = dataclasses.InitVar
 
     @pydantic.dataclasses.dataclass
-    class RadiansWithInitVar:
-        rad: float = dataclasses.field(init=False)
-        deg: InitVar
+    class TestInitVar:
+        x: int
+        y: InitVar
 
-        def __post_init__(self, deg):
-            if deg:
-                self.rad = float(deg) / 180 * pi
+    tiv = TestInitVar(1, 2)
+    assert tiv.x == 1
+    with pytest.raises(AttributeError):
+        tiv.y
 
-        @pydantic.validator("rad")
-        def validate_radians(cls, rad):
-            if rad > 2 * pi:
-                raise ValueError("radian too large")
-            return rad
 
-    assert RadiansWithInitVar(90).rad == 0.5 * pi
-    with pytest.raises(ValueError):
-        RadiansWithInitVar(9000)
+def test_derived_field_from_initvar():
+    InitVar = dataclasses.InitVar
+
+    @pydantic.dataclasses.dataclass
+    class DerivedWithInitVar:
+        plusone: int = dataclasses.field(init=False)
+        number: InitVar[int]
+
+        def __post_init__(self, number):
+            self.plusone = number + 1
+
+    derived = DerivedWithInitVar(1)
+    assert derived.plusone == 2
+    with pytest.raises(TypeError):
+        DerivedWithInitVar("Not A Number")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

dataclasses.InitVar were not handled correctly. This change does the following:

Pass fields typed as InitVar as argument to the original `__post_init__` so that they can be processed like in the python 3.7 dataclasses library.

Exclude InitVar fields from the pydantic model as they are not part of the dataclass object.

## Related issue number

#592

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
