### PR TITLE
JSON extra uses orjson instead of ujson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     python: 3.6
     name: 'Without Deps 3.6'
     script:
-    - pip uninstall -y ujson email-validator typing-extensions
+    - pip uninstall -y orjson email-validator typing-extensions
     - make test
     env:
     - 'DEPS=no'
@@ -66,7 +66,7 @@ jobs:
     python: 3.7
     name: 'Without Deps 3.7'
     script:
-    - pip uninstall -y ujson email-validator cython typing-extensions
+    - pip uninstall -y orjson email-validator cython typing-extensions
     - make test
     env:
     - 'DEPS=no'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ v0.30 (unreleased)
 * clarify, that self-referencing models require python 3.7+, #616 by @vlcinsky
 * fix truncate for types, #611 by @dmontagu
 * fix schema generation with multiple/circular references to the same model, #621 by @tiangolo and @wongpat
+* **breaking change** `pip install pydantic[ujson]` is changed to `pip install pydantic[fast-json]`, uses `orjson`
+  instead of `ujson` for JSON parsing, #599 by @ijl
 
 v0.29 (2019-06-19)
 ..................

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,15 +91,15 @@ To test if *pydantic* is compiled run::
     import pydantic
     print('compiled:', pydantic.compiled)
 
-If you want *pydantic* to parse json faster you can add `ujson <https://pypi.python.org/pypi/ujson>`_
+If you want *pydantic* to parse JSON faster you can add `orjson <https://pypi.org/project/orjson/>`_
 as an optional dependency. Similarly *pydantic's* email validation relies on
 `email-validator <https://github.com/JoshData/python-email-validator>`_ ::
 
-    pip install pydantic[ujson]
+    pip install pydantic[fast-json]
     # or
     pip install pydantic[email]
     # or just
-    pip install pydantic[ujson,email]
+    pip install pydantic[fast-json,email]
 
 Of course you can also install these requirements manually with ``pip install ...``.
 

--- a/pydantic/parse.py
+++ b/pydantic/parse.py
@@ -6,9 +6,9 @@ from typing import Any, Union
 from .types import StrBytes
 
 try:
-    import ujson as json
+    from orjson import loads as json_loads
 except ImportError:
-    import json  # type: ignore
+    from json import loads as json_loads  # type: ignore
 
 
 class Protocol(str, Enum):
@@ -32,7 +32,7 @@ def load_str_bytes(
     if proto == Protocol.json:
         if isinstance(b, bytes):
             b = b.decode(encoding)
-        return json.loads(b)
+        return json_loads(b)
     elif proto == Protocol.pickle:
         if not allow_pickle:
             raise RuntimeError('Trying to decode with pickle with allow_pickle=False')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -r docs/requirements.txt
 -r tests/requirements.txt
 
-ujson==1.35
+orjson>=2.0.6,<3;platform_python_implementation=="CPython" and platform_machine=="x86_64" and python_version<"3.8"
 email-validator==1.0.4
-dataclasses==0.6; python_version < '3.7'
+dataclasses==0.6;python_version < '3.7'
 typing-extensions==3.7.2

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,8 @@ setup(
         'dataclasses>=0.6;python_version<"3.7"'
     ],
     extras_require={
-        'ujson': ['ujson>=1.35'],
         'email': ['email-validator>=1.0.3'],
+        'fast-json': ['orjson>=2.0.6,<3;platform_python_implementation=="CPython" and platform_machine=="x86_64" and python_version<"3.8"'],
         'typing_extensions': ['typing-extensions>=3.7.2']
     },
     ext_modules=ext_modules,


### PR DESCRIPTION
This is the minimum change to replace ujson. There are
additional calls to json.loads that may be modified.

The extra is renamed 'fast-json' to match 'email' and avoid further
changes.

#589