### PR TITLE
Fix #609 (default arguments for GenericModel)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.30 (unreleased)
 ..................
 * enforce single quotes in code, #612 by @samuelcolvin
 * fix infinite recursion with dataclass inheritance and ``__post_init__``, #606 by @Hanaasagi
+* fix default values for ``GenericModel``, #610 by @dmontagu
 
 v0.29 (2019-06-19)
 ..................

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -43,7 +43,7 @@ class GenericModel(BaseModel):
         model_name = concrete_name(cls, params)
         validators = gather_validators(cls)
         fields: Dict[str, Tuple[Type[Any], Any]] = {
-            k: (v, getattr(cls, k, ...)) for k, v in concrete_type_hints.items()
+            k: (v, cls.__fields__[k].default) for k, v in concrete_type_hints.items() if k in cls.__fields__
         }
         created_model = create_model(
             model_name=model_name,

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,6 +1,6 @@
 import sys
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, ClassVar, Dict, Generic, List, Optional, TypeVar, Union
 
 import pytest
 
@@ -66,6 +66,31 @@ def test_config_is_inherited():
         instance.data = 2
 
     assert str(exc_info.value) == '"Model[int]" is immutable and does not support item assignment'
+
+
+@skip_36
+def test_default_arguments():
+    T = TypeVar('T')
+
+    class Result(GenericModel, Generic[T]):
+        data: T
+        other: bool = True
+    result = Result[int](data=1)
+    assert result.other is True
+
+
+@skip_36
+def test_classvar():
+    T = TypeVar('T')
+
+    class Result(GenericModel, Generic[T]):
+        data: T
+        other: ClassVar[int] = 1
+
+    assert Result.other == 1
+    assert Result[int].other == 1
+    assert Result[int](data=1).other == 1
+    assert "other" not in Result.__fields__
 
 
 @skip_36

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -48,7 +48,7 @@ def test_value_validation():
                 raise ValueError('value is zero')
 
     with pytest.raises(ValidationError) as exc_info:
-        Response[Dict[int, int]](data={1: "a"})
+        Response[Dict[int, int]](data={1: 'a'})
     assert exc_info.value.errors() == [
         {'loc': ('data', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
@@ -94,7 +94,7 @@ def test_config_is_inherited():
 
 
 @skip_36
-def test_default_arguments():
+def test_default_argument():
     T = TypeVar('T')
 
     class Result(GenericModel, Generic[T]):
@@ -103,6 +103,23 @@ def test_default_arguments():
 
     result = Result[int](data=1)
     assert result.other is True
+
+
+@skip_36
+def test_default_argument_for_typevar():
+    T = TypeVar('T')
+
+    class Result(GenericModel, Generic[T]):
+        data: T = 4
+
+    result = Result[int]()
+    assert result.data == 4
+
+    result = Result[float]()
+    assert result.data == 4
+
+    result = Result[int](data=1)
+    assert result.data == 1
 
 
 @skip_36
@@ -116,7 +133,7 @@ def test_classvar():
     assert Result.other == 1
     assert Result[int].other == 1
     assert Result[int](data=1).other == 1
-    assert "other" not in Result.__fields__
+    assert 'other' not in Result.__fields__
 
 
 @skip_36
@@ -127,8 +144,8 @@ def test_non_annotated_field():
         data: T
         other = True
 
-    assert "other" in Result.__fields__
-    assert "other" in Result[int].__fields__
+    assert 'other' in Result.__fields__
+    assert 'other' in Result[int].__fields__
 
     result = Result[int](data=1)
     assert result.other is True

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -40,7 +40,7 @@ def test_value_validation():
     class Response(GenericModel, Generic[T]):
         data: T
 
-        @validator("data")
+        @validator('data')
         def validate_value_nonzero(cls, v):
             if isinstance(v, dict):
                 return v  # ensure v is actually a value of the dict, not the dict itself

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -120,6 +120,21 @@ def test_classvar():
 
 
 @skip_36
+def test_non_annotated_field():
+    T = TypeVar('T')
+
+    class Result(GenericModel, Generic[T]):
+        data: T
+        other = True
+
+    assert "other" in Result.__fields__
+    assert "other" in Result[int].__fields__
+
+    result = Result[int](data=1)
+    assert result.other is True
+
+
+@skip_36
 def test_must_inherit_from_generic():
     with pytest.raises(TypeError) as exc_info:
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -45,7 +45,7 @@ def test_value_validation():
             if isinstance(v, dict):
                 return v  # ensure v is actually a value of the dict, not the dict itself
             if v == 0:
-                raise ValueError("value is zero")
+                raise ValueError('value is zero')
 
     with pytest.raises(ValidationError) as exc_info:
         Response[Dict[int, int]](data={1: "a"})


### PR DESCRIPTION
Fix #609 (default arguments for GenericModel)

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated