### PR TITLE
Fix #608 (repr on model with class)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.30 (unreleased)
 ..................
 * enforce single quotes in code, #612 by @samuelcolvin
 * fix infinite recursion with dataclass inheritance and ``__post_init__``, #606 by @Hanaasagi
+* fix truncate for types, #611 by @dmontagu
 
 v0.29 (2019-06-19)
 ..................

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -155,7 +155,10 @@ def truncate(v: Union[str], *, max_len: int = 80) -> str:
     if isinstance(v, str) and len(v) > (max_len - 2):
         # -3 so quote + string + … + quote has correct length
         return (v[: (max_len - 3)] + '…').__repr__()
-    v = type(v).__repr__(v)
+    try:
+        v = v.__repr__()
+    except TypeError:
+        v = type(v).__repr__(v)  # in case v is a type
     if len(v) > max_len:
         v = v[: max_len - 1] + '…'
     return v

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -155,7 +155,7 @@ def truncate(v: Union[str], *, max_len: int = 80) -> str:
     if isinstance(v, str) and len(v) > (max_len - 2):
         # -3 so quote + string + … + quote has correct length
         return (v[: (max_len - 3)] + '…').__repr__()
-    v = v.__repr__()
+    v = type(v).__repr__(v)
     if len(v) > max_len:
         v = v[: max_len - 1] + '…'
     return v

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,4 +149,4 @@ def test_lenient_issubclass_is_lenient():
 
 
 def test_truncate_type():
-    assert truncate(object) == '<class \'object\'>'
+    assert truncate(object) == "<class 'object'>"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import pytest
 
-from pydantic.utils import display_as_type, import_string, lenient_issubclass, make_dsn, validate_email
+from pydantic.utils import display_as_type, import_string, lenient_issubclass, make_dsn, truncate, validate_email
 
 try:
     import email_validator
@@ -146,3 +146,7 @@ def test_lenient_issubclass():
 
 def test_lenient_issubclass_is_lenient():
     assert lenient_issubclass('a', 'a') is False
+
+
+def test_truncate_type():
+    assert truncate(object) == '<class \'object\'>'


### PR DESCRIPTION
## Change Summary

Handle the case where `pydantic.utils.truncate` is called on a type.

## Related issue number

fix #608

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
