### PR TITLE
doc: self-referencing got note about rq for python 3.7+

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.30 (unreleased)
 ..................
 * enforce single quotes in code, #612 by @samuelcolvin
 * fix infinite recursion with dataclass inheritance and ``__post_init__``, #606 by @Hanaasagi
+* clarify, that self-referencing models require python 3.7+
 
 v0.29 (2019-06-19)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ v0.30 (unreleased)
 ..................
 * enforce single quotes in code, #612 by @samuelcolvin
 * fix infinite recursion with dataclass inheritance and ``__post_init__``, #606 by @Hanaasagi
-* clarify, that self-referencing models require python 3.7+
+* clarify, that self-referencing models require python 3.7+, #616 by @vlcinsky
 
 v0.29 (2019-06-19)
 ..................

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -277,7 +277,7 @@ The ellipsis ``...`` just means "Required" same as annotation only declarations 
 Self-referencing Models
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Data structures with self-referencing models are also supported, provided the function
+Since ``python 3.7``, data structures with self-referencing models are also supported, provided the function
 ``update_forward_refs()`` is called once the model is created (you will be reminded
 with a friendly error message if you don't).
 


### PR DESCRIPTION
## Change Summary
Doc updated to explicitly state, self-referencing models require python 3.7+

## Related issue number
- issue #616
## Checklist

* [ ] (not applicable) Unit tests for the changes exist
* [ ] (not applicable) Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
