### PR TITLE
Add alias_generator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ v0.30 (unreleased)
 * fix default values for ``GenericModel``, #610 by @dmontagu
 * clarify, that self-referencing models require python 3.7+, #616 by @vlcinsky
 * fix truncate for types, #611 by @dmontagu
-* add alias_provider support #622 by @MrMrRobat
+* add ``alias_generator`` support, #622 by @MrMrRobat
 
 v0.29 (2019-06-19)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ v0.30 (unreleased)
 * fix default values for ``GenericModel``, #610 by @dmontagu
 * clarify, that self-referencing models require python 3.7+, #616 by @vlcinsky
 * fix truncate for types, #611 by @dmontagu
+* add alias_provider support #622 by @MrMrRobat
 
 v0.29 (2019-06-19)
 ..................

--- a/docs/examples/alias_generator_config.py
+++ b/docs/examples/alias_generator_config.py
@@ -1,9 +1,7 @@
 from pydantic import BaseModel
 
-
 def to_camel(string: str) -> str:
     return ''.join(word.capitalize() for word in string.split('_'))
-
 
 class Voice(BaseModel):
     name: str
@@ -11,8 +9,7 @@ class Voice(BaseModel):
     language_code: str
 
     class Config:
-        alias_provider = to_camel
-
+        alias_generator = to_camel
 
 voice = Voice(Name='Filiz', Gender='Female', LanguageCode='tr-TR')
 print(voice.language_code)

--- a/docs/examples/alias_provider_config.py
+++ b/docs/examples/alias_provider_config.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+
+def to_camel(string: str) -> str:
+    return ''.join(word.capitalize() for word in string.split('_'))
+
+
+class Voice(BaseModel):
+    name: str
+    gender: str
+    language_code: str
+
+    class Config:
+        alias_provider = to_camel
+
+
+voice = Voice(Name='Filiz', Gender='Female', LanguageCode='tr-TR')
+print(voice.language_code)
+print(voice.dict(by_alias=True))
+
+"""
+tr-TR
+{'Name': 'Filiz', 'Gender': 'Female', 'LanguageCode': 'tr-TR'}
+"""

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -750,7 +750,7 @@ Version for models based on ``@dataclass`` decorator:
 Alias Generator
 ~~~~~~~~~~~~~~~
 If data source field names not match your code style (e. g. CamelCase fields),
-you can automatically generate aliases for them using ``alias_generator``:
+you can automatically generate aliases using ``alias_generator``:
 
 .. literalinclude:: examples/alias_generator_config.py
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -466,16 +466,6 @@ Outputs:
 .. literalinclude:: examples/schema3.json
 
 
-Alias Provider
-..............
-If data source field names not match your code style (e. g. CamelCase fields),
-you can automatically generate aliases for them using ``alias_provider``:
-
-.. literalinclude:: examples/alias_provider_config.py
-
-(This script is complete, it should run "as is")
-
-
 Error Handling
 ..............
 
@@ -732,7 +722,7 @@ Options:
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`
-:alias_provider: callable that takes field name and returns alias for it
+:alias_generator: callable that takes field name and returns alias for it
 
 .. warning::
 
@@ -755,6 +745,17 @@ Version for models based on ``@dataclass`` decorator:
 (This script is complete, it should run "as is")
 
 .. _settings:
+
+
+Alias Generator
+...............
+If data source field names not match your code style (e. g. CamelCase fields),
+you can automatically generate aliases for them using ``alias_generator``:
+
+.. literalinclude:: examples/alias_generator_config.py
+
+(This script is complete, it should run "as is")
+
 
 Settings
 ........

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -749,7 +749,7 @@ Version for models based on ``@dataclass`` decorator:
 
 Alias Generator
 ~~~~~~~~~~~~~~~
-If data source field names not match your code style (e. g. CamelCase fields),
+If data source field names do not match your code style (e. g. CamelCase fields),
 you can automatically generate aliases using ``alias_generator``:
 
 .. literalinclude:: examples/alias_generator_config.py

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -748,7 +748,7 @@ Version for models based on ``@dataclass`` decorator:
 
 
 Alias Generator
-...............
+~~~~~~~~~~~~~~~
 If data source field names not match your code style (e. g. CamelCase fields),
 you can automatically generate aliases for them using ``alias_generator``:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -466,6 +466,16 @@ Outputs:
 .. literalinclude:: examples/schema3.json
 
 
+Alias Provider
+..............
+If data source field names not match your code style (e. g. CamelCase fields),
+you can automatically generate aliases for them using ``alias_provider``:
+
+.. literalinclude:: examples/alias_provider_config.py
+
+(This script is complete, it should run "as is")
+
+
 Error Handling
 ..............
 
@@ -722,6 +732,7 @@ Options:
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`
+:alias_provider: callable that takes field name and returns alias for it
 
 .. warning::
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -101,7 +101,7 @@ class BaseConfig:
         field_config = cls.fields.get(name) or {}
         if isinstance(field_config, str):
             field_config = {'alias': field_config}
-        elif cls.alias_generator:
+        elif not field_config and cls.alias_generator:
             alias = cls.alias_generator(name)
             if not isinstance(alias, str):
                 raise TypeError(f'Config.alias_generator must return str, not {type(alias)}')

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -94,12 +94,18 @@ class BaseConfig:
     arbitrary_types_allowed = False
     json_encoders: Dict[AnyType, AnyCallable] = {}
     orm_mode: bool = False
+    alias_provider: Optional[Callable[[str], str]] = None
 
     @classmethod
     def get_field_schema(cls, name: str) -> Dict[str, str]:
         field_config = cls.fields.get(name) or {}
         if isinstance(field_config, str):
             field_config = {'alias': field_config}
+        elif cls.alias_provider:
+            alias = cls.alias_provider(name)
+            if not isinstance(alias, str):
+                raise TypeError(f'Config.alias_provider must return str, not {type(alias)}')
+            field_config = {'alias': alias}
         return field_config
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -94,17 +94,17 @@ class BaseConfig:
     arbitrary_types_allowed = False
     json_encoders: Dict[AnyType, AnyCallable] = {}
     orm_mode: bool = False
-    alias_provider: Optional[Callable[[str], str]] = None
+    alias_generator: Optional[Callable[[str], str]] = None
 
     @classmethod
     def get_field_schema(cls, name: str) -> Dict[str, str]:
         field_config = cls.fields.get(name) or {}
         if isinstance(field_config, str):
             field_config = {'alias': field_config}
-        elif cls.alias_provider:
-            alias = cls.alias_provider(name)
+        elif cls.alias_generator:
+            alias = cls.alias_generator(name)
             if not isinstance(alias, str):
-                raise TypeError(f'Config.alias_provider must return str, not {type(alias)}')
+                raise TypeError(f'Config.alias_generator must return str, not {type(alias)}')
             field_config = {'alias': alias}
         return field_config
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -651,7 +651,7 @@ def test_dict_with_extra_keys():
     assert m.dict(by_alias=True) == {'alias_a': None, 'extra_key': 'extra'}
 
 
-def test_alias_provider():
+def test_alias_generator():
     def to_camel(string: str):
         return ''.join(x.capitalize() for x in string.split('_'))
 
@@ -660,7 +660,7 @@ def test_alias_provider():
         foo_bar: str
 
         class Config:
-            alias_provider = to_camel
+            alias_generator = to_camel
 
     data = {'A': ['foo', 'bar'], 'FooBar': 'foobar'}
     v = MyModel(**data)
@@ -668,12 +668,17 @@ def test_alias_provider():
     assert v.foo_bar == 'foobar'
     assert v.dict(by_alias=True) == data
 
+
+def test_alias_generator_wrong_type_error():
+    def return_bytes(string):
+        return b'not a string'
+
     with pytest.raises(TypeError) as e:
 
         class MyModel(BaseModel):
             bar: Any
 
             class Config:
-                alias_provider = str.encode
+                alias_generator = return_bytes
 
-    assert str(e.value) == "Config.alias_provider must return str, not <class 'bytes'>"
+    assert str(e.value) == "Config.alias_generator must return str, not <class 'bytes'>"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -649,3 +649,31 @@ def test_dict_with_extra_keys():
     m = MyModel(extra_key='extra')
     assert m.dict() == {'a': None, 'extra_key': 'extra'}
     assert m.dict(by_alias=True) == {'alias_a': None, 'extra_key': 'extra'}
+
+
+def test_alias_provider():
+    def to_camel(string: str):
+        return ''.join(x.capitalize() for x in string.split('_'))
+
+    class MyModel(BaseModel):
+        a: List[str] = None
+        foo_bar: str
+
+        class Config:
+            alias_provider = to_camel
+
+    data = {'A': ['foo', 'bar'], 'FooBar': 'foobar'}
+    v = MyModel(**data)
+    assert v.a == ['foo', 'bar']
+    assert v.foo_bar == 'foobar'
+    assert v.dict(by_alias=True) == data
+
+    with pytest.raises(TypeError) as e:
+
+        class MyModel(BaseModel):
+            bar: Any
+
+            class Config:
+                alias_provider = str.encode
+
+    assert str(e.value) == "Config.alias_provider must return str, not <class 'bytes'>"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -669,6 +669,25 @@ def test_alias_generator():
     assert v.dict(by_alias=True) == data
 
 
+def test_alias_generator_with_field_schema():
+    def to_upper_case(string: str):
+        return string.upper()
+
+    class MyModel(BaseModel):
+        my_shiny_field: Any  # Alias from Config.fields will be used
+        foo_bar: str  # Alias from Config.fields will be used
+        baz_bar: str  # Alias will be generated
+        another_field: str  # Alias will be generated
+
+        class Config:
+            alias_generator = to_upper_case
+            fields = {'my_shiny_field': 'MY_FIELD', 'foo_bar': {'alias': 'FOO'}}
+
+    data = {'MY_FIELD': ['a'], 'FOO': 'bar', 'BAZ_BAR': 'ok', 'ANOTHER_FIELD': '...'}
+    m = MyModel(**data)
+    assert m.dict(by_alias=True) == data
+
+
 def test_alias_generator_wrong_type_error():
     def return_bytes(string):
         return b'not a string'


### PR DESCRIPTION
## Change Summary
Add `Config.alias_generator` that provides ability to convert name to alias for each field of model. See docs example:

```python

from pydantic import BaseModel

def to_camel(string: str) -> str:
     return ''.join(word.capitalize() for word in string.split('_'))
 
class Voice(BaseModel):
    name: str
    gender: str
    language_code: str
    
    class Config:
         alias_generator = to_camel

 voice = Voice(Name='Filiz', Gender='Female', LanguageCode='tr-TR')
 print(voice.language_code)
 print(voice.dict(by_alias=True))

  """
 tr-TR
 {'Name': 'Filiz', 'Gender': 'Female', 'LanguageCode': 'tr-TR'}
 """
```
## Related issue number
None

## Checklist
* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * add alias_provider support #622 by @MrMrRobat
