### PR TITLE
Fix unparameterized generic type schema generation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ v0.30 (unreleased)
 * fix default values for ``GenericModel``, #610 by @dmontagu
 * clarify, that self-referencing models require python 3.7+, #616 by @vlcinsky
 * fix truncate for types, #611 by @dmontagu
+* fix unparameterized generic type schema generation, #625 by @dmontagu
 
 v0.29 (2019-06-19)
 ..................

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, cast
 from uuid import UUID
 
 import pydantic
@@ -720,7 +720,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
             ref_prefix=ref_prefix,
             known_models=known_models,
         )
-    if field.type_ is Any:
+    if field.type_ is Any or type(field.type_) == TypeVar:
         return {}, definitions  # no restrictions
     if is_callable_type(field.type_):
         raise SkipField(f'Callable {field.name} was excluded from schema since JSON schema has no equivalent type.')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1310,11 +1310,22 @@ def test_field_with_validator():
 
 
 def test_unparameterized_schema_generation():
-    class Foo(BaseModel):
+    class FooList(BaseModel):
+        d: List
+
+    assert model_schema(FooList) == {
+        'title': 'FooList',
+        'type': 'object',
+        'properties': {'d': {'items': {}, 'title': 'D', 'type': 'array'}},
+        'required': ['d'],
+    }
+
+    class FooDict(BaseModel):
         d: Dict
 
-    assert model_schema(Foo) == {
-        'title': 'Foo',
+    model_schema(Foo)
+    assert model_schema(FooDict) == {
+        'title': 'FooDict',
         'type': 'object',
         'properties': {'d': {'title': 'D', 'type': 'object'}},
         'required': ['d'],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1313,6 +1313,9 @@ def test_unparameterized_schema_generation():
     class FooList(BaseModel):
         d: List
 
+    class BarList(BaseModel):
+        d: list
+
     assert model_schema(FooList) == {
         'title': 'FooList',
         'type': 'object',
@@ -1320,8 +1323,16 @@ def test_unparameterized_schema_generation():
         'required': ['d'],
     }
 
+    foo_list_schema = model_schema(FooList)
+    bar_list_schema = model_schema(BarList)
+    bar_list_schema['title'] = 'FooList'  # to check for equality
+    assert foo_list_schema == bar_list_schema
+
     class FooDict(BaseModel):
         d: Dict
+
+    class BarDict(BaseModel):
+        d: dict
 
     model_schema(Foo)
     assert model_schema(FooDict) == {
@@ -1330,3 +1341,8 @@ def test_unparameterized_schema_generation():
         'properties': {'d': {'title': 'D', 'type': 'object'}},
         'required': ['d'],
     }
+
+    foo_dict_schema = model_schema(FooDict)
+    bar_dict_schema = model_schema(BarDict)
+    bar_dict_schema['title'] = 'FooDict'  # to check for equality
+    assert foo_dict_schema == bar_dict_schema

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,7 +11,13 @@ from uuid import UUID
 import pytest
 
 from pydantic import BaseModel, Schema, ValidationError, validator
-from pydantic.schema import get_flat_models_from_model, get_flat_models_from_models, get_model_name_map, schema
+from pydantic.schema import (
+    get_flat_models_from_model,
+    get_flat_models_from_models,
+    get_model_name_map,
+    model_schema,
+    schema,
+)
 from pydantic.types import (
     DSN,
     UUID1,
@@ -1300,4 +1306,16 @@ def test_field_with_validator():
         'title': 'Model',
         'type': 'object',
         'properties': {'something': {'type': 'integer', 'title': 'Something'}},
+    }
+
+
+def test_unparameterized_schema_generation():
+    class Foo(BaseModel):
+        d: Dict
+
+    assert model_schema(Foo) == {
+        'title': 'Foo',
+        'type': 'object',
+        'properties': {'d': {'title': 'D', 'type': 'object'}},
+        'required': ['d'],
     }


### PR DESCRIPTION
## Change Summary

Fixes #623 as described by @samuelcolvin (unparameterized generic types will not have restrictions on the parameterized types).

## Related issue number

#623

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
