### PR TITLE
support keyword argument unpacking on BaseModel

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ v0.30 (unreleased)
 * fix truncate for types, #611 by @dmontagu
 * fix unparameterized generic type schema generation, #625 by @dmontagu
 * fix schema generation with multiple/circular references to the same model, #621 by @tiangolo and @wongpat
+* support keyword argument unpacking on BaseModel, PR #634 by @duxiaoyao
 
 v0.29 (2019-06-19)
 ..................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    KeysView,
     List,
     Mapping,
     Optional,
@@ -512,6 +513,12 @@ class BaseModel(metaclass=MetaModel):
             keys -= exclude
 
         return keys
+
+    def keys(self) -> KeysView[str]:
+        return self.__fields__.keys()
+
+    def __getitem__(self, name: str) -> Any:
+        return getattr(self, name)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -649,3 +649,8 @@ def test_dict_with_extra_keys():
     m = MyModel(extra_key='extra')
     assert m.dict() == {'a': None, 'extra_key': 'extra'}
     assert m.dict(by_alias=True) == {'alias_a': None, 'extra_key': 'extra'}
+
+
+def test_keyword_argument_unpacking():
+    m = UltraSimpleModel(a=10.2)
+    assert {**m} == {'a': 10.2, 'b': 10}


### PR DESCRIPTION
## Change Summary
Add keyword argument unpacking support to BaseModel

Psycopg 2 is the most popular PostgreSQL database adapter for Python. It supports named arguments using %(name)s placeholders in the query and specifying the values into a mapping. For example:
```
cursor.execute("INSERT INTO customer (name, score) VALUES (%(name)s, %(score)s",
              {'name': 'Jack', 'score': 100})
```
Say customer is an instance of class  Customer which inherits from BaseModel and holds the data to be inserted, we would like to do this:
```
cursor.execute("INSERT INTO customer (name, score) VALUES (%(name)s, %(score)s",
              **customer)
```
Above is why we want BaseModel supports keyword argument unpacking.

## Related issue number
N/A

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] ~~Documentation reflects the changes where applicable~~
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
