### PR TITLE
Re-enable nested model init calls while still allowing self

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+v0.31 (2019-??-??)
+..................
+* nested classes which inherit and change `__init__` are now correctly processed while still allowing `self` as a
+  parameter, #644 by @lnaden and @dgasmith
+
 v0.30 (2019-07-07)
 ..................
 * enforce single quotes in code, #612 by @samuelcolvin

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,9 +3,9 @@
 History
 -------
 
-v0.31 (2019-??-??)
+v0.31 (unreleased)
 ..................
-* nested classes which inherit and change `__init__` are now correctly processed while still allowing `self` as a
+* nested classes which inherit and change ``__init__`` are now correctly processed while still allowing ``self`` as a
   parameter, #644 by @lnaden and @dgasmith
 
 v0.30 (2019-07-07)

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -20,9 +20,9 @@ class BaseSettings(BaseModel):
     Heroku and any 12 factor app design.
     """
 
-    def __init__(pydantic_base_settings_init, **values: Any) -> None:
+    def __init__(__pydantic_self__, **values: Any) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
-        super().__init__(**pydantic_base_settings_init._build_values(values))
+        super().__init__(**__pydantic_self__._build_values(values))
 
     def _build_values(self, init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {**self._build_environ(), **init_kwargs}

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -20,8 +20,9 @@ class BaseSettings(BaseModel):
     Heroku and any 12 factor app design.
     """
 
-    def __init__(self, **values: Any) -> None:
-        super().__init__(**self._build_values(values))
+    def __init__(pydantic_base_settings_init, **values: Any) -> None:
+        # Uses something other than `self` the first arg to allow "self" as a settable attribute
+        super().__init__(**pydantic_base_settings_init._build_values(values))
 
     def _build_values(self, init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {**self._build_environ(), **init_kwargs}

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -263,14 +263,14 @@ class BaseModel(metaclass=MetaModel):
     Config = BaseConfig
     __slots__ = ('__values__', '__fields_set__')
 
-    def __init__(pydantic_base_model_init, **data: Any) -> None:
+    def __init__(__pydantic_self__, **data: Any) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
         if TYPE_CHECKING:  # pragma: no cover
-            pydantic_base_model_init.__values__: Dict[str, Any] = {}
-            pydantic_base_model_init.__fields_set__: 'SetStr' = set()
-        values, fields_set, _ = validate_model(pydantic_base_model_init, data)
-        object.__setattr__(pydantic_base_model_init, '__values__', values)
-        object.__setattr__(pydantic_base_model_init, '__fields_set__', fields_set)
+            __pydantic_self__.__values__: Dict[str, Any] = {}
+            __pydantic_self__.__fields_set__: 'SetStr' = set()
+        values, fields_set, _ = validate_model(__pydantic_self__, data)
+        object.__setattr__(__pydantic_self__, '__values__', values)
+        object.__setattr__(__pydantic_self__, '__fields_set__', fields_set)
 
     @no_type_check
     def __getattr__(self, name):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import (
     BaseConfig,
     BaseModel,
+    BaseSettings,
     Extra,
     NoneStrBytes,
     StrBytes,
@@ -897,12 +898,35 @@ def test_self():
     }
 
 
-def test_self_recursive():
-    class SubModel(BaseModel):
+@pytest.mark.parametrize('model', [BaseModel, BaseSettings])
+def test_self_recursive(model):
+    class SubModel(model):
         self: int
 
-    class Model(BaseModel):
+    class Model(model):
         sm: SubModel
 
     m = Model.parse_obj({'sm': {'self': '123'}})
     assert m.dict() == {'sm': {'self': 123}}
+
+
+@pytest.mark.parametrize('model', [BaseModel, BaseSettings])
+def test_nested_init(model):
+    class NestedModel(model):
+        self: str
+        modified_number: int = 1
+
+        def __init__(someinit, **kwargs):
+            super().__init__(**kwargs)
+            someinit.modified_number += 1
+
+    class TopModel(model):
+        self: str
+        nest: NestedModel
+
+    m = TopModel.parse_obj(dict(self="Top Model",
+                                nest=dict(self="Nested Model",
+                                          modified_number=0)))
+    assert m.self == "Top Model"
+    assert m.nest.self == "Nested Model"
+    assert m.nest.modified_number == 1

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -924,9 +924,7 @@ def test_nested_init(model):
         self: str
         nest: NestedModel
 
-    m = TopModel.parse_obj(dict(self='Top Model',
-                                nest=dict(self='Nested Model',
-                                          modified_number=0)))
+    m = TopModel.parse_obj(dict(self='Top Model', nest=dict(self='Nested Model', modified_number=0)))
     assert m.self == 'Top Model'
     assert m.nest.self == 'Nested Model'
     assert m.nest.modified_number == 1

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -924,9 +924,9 @@ def test_nested_init(model):
         self: str
         nest: NestedModel
 
-    m = TopModel.parse_obj(dict(self="Top Model",
-                                nest=dict(self="Nested Model",
+    m = TopModel.parse_obj(dict(self='Top Model',
+                                nest=dict(self='Nested Model',
                                           modified_number=0)))
-    assert m.self == "Top Model"
-    assert m.nest.self == "Nested Model"
+    assert m.self == 'Top Model'
+    assert m.nest.self == 'Nested Model'
     assert m.nest.modified_number == 1


### PR DESCRIPTION
## Change Summary

This commit enables nested model `__init__` statements to be executed
while still allowing `self` as an argument.

Effectively reverses the changes from #632 while still enabling the
feature it implemented. In theory, there will still be a collision if
someone ever tried to use `pydantic_base_model/settings_init` as an arg,
but I don't know how to engineer a case where a collision would *never*
happen, I'm not sure there is one.

This commit also added a test for both `BaseModel` and `BaseSettings` for
both the `self`-as-a-parameter and the nested `__init__` features since
`BaseSettings` now has the same issue as `BaseModel` since it invoked
an `__init__` with self.

I have added a comment under the `__init__` for both `BaseModel` and
`BaseSetting` since not having `self` as the first arg is such a
rarity within Python that it will likely confuse future developers who
encounter it.

The actual name of the variable referencing the class itself can be
up for debate.

cc and credit @dgasmith for solution idea

## Related issue number

#632 and #629

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
