### PR TITLE
Make schema work for Literal and NewType

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,11 +3,14 @@
 History
 -------
 
+v0.31 (unreleased)
+..................
+* fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
+
 v0.30.1 (2019-07-15)
 ....................
 * fix so nested classes which inherit and change ``__init__`` are correctly processed while still allowing ``self`` as a
   parameter, #644 by @lnaden and @dgasmith
-* fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
 
 v0.30 (2019-07-07)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.30.1 (2019-07-15)
 ....................
 * fix so nested classes which inherit and change ``__init__`` are correctly processed while still allowing ``self`` as a
   parameter, #644 by @lnaden and @dgasmith
+* fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
 
 v0.30 (2019-07-07)
 ..................

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -29,6 +29,7 @@ from .utils import (
     Callable,
     ForwardRef,
     display_as_type,
+    is_literal_type,
     lenient_issubclass,
     literal_values,
     sequence_like,
@@ -195,16 +196,16 @@ class Field:
         if self.type_ is Pattern:
             # python 3.7 only, Pattern is a typing object but without sub fields
             return
+        if is_literal_type(self.type_):
+            types_ = sorted(set(type(value) for value in literal_values(self.type_)), key=str)
+            if len(types_) > 1:
+                self.sub_fields = [self._create_sub_type(t, f'{self.name}_{display_as_type(t)}') for t in types_]
+            return
         origin = getattr(self.type_, '__origin__', None)
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.
             return
         if origin is Callable:
-            return
-        if Literal is not None and origin is Literal:
-            types_ = list(set(type(arg) for arg in literal_values(self.type_)))
-            if len(types_) > 1:
-                self.sub_fields = [self._create_sub_type(t, f'{self.name}_{display_as_type(t)}') for t in types_]
             return
         if origin is Union:
             types_ = []

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -193,6 +193,9 @@ class Field:
         if origin is Callable:
             return
         if Literal is not None and origin is Literal:
+            types_ = list(set(type(arg) for arg in self.type_.__args__))  # type: ignore
+            if len(types_) > 1:
+                self.sub_fields = [self._create_sub_type(t, f'{self.name}_{display_as_type(t)}') for t in types_]
             return
         if origin is Union:
             types_ = []

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -197,8 +197,9 @@ class Field:
             # python 3.7 only, Pattern is a typing object but without sub fields
             return
         if is_literal_type(self.type_):
-            if len(literal_values(self.type_)) > 1:
-                self.type_ = Union[tuple(Literal[value] for value in literal_values(self.type_))]
+            values = literal_values(self.type_)
+            if len(values) > 1:
+                self.type_ = Union[tuple(Literal[value] for value in values)]
             else:
                 return
         origin = getattr(self.type_, '__origin__', None)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -197,10 +197,10 @@ class Field:
             # python 3.7 only, Pattern is a typing object but without sub fields
             return
         if is_literal_type(self.type_):
-            types_ = sorted(set(type(value) for value in literal_values(self.type_)), key=str)
-            if len(types_) > 1:
-                self.sub_fields = [self._create_sub_type(t, f'{self.name}_{display_as_type(t)}') for t in types_]
-            return
+            if len(literal_values(self.type_)) > 1:
+                self.type_ = Union[tuple(Literal[value] for value in literal_values(self.type_))]
+            else:
+                return
         origin = getattr(self.type_, '__origin__', None)
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -23,7 +23,16 @@ from . import errors as errors_
 from .class_validators import Validator, make_generic_validator
 from .error_wrappers import ErrorWrapper
 from .types import Json, JsonWrapper
-from .utils import AnyCallable, AnyType, Callable, ForwardRef, display_as_type, lenient_issubclass, sequence_like
+from .utils import (
+    AnyCallable,
+    AnyType,
+    Callable,
+    ForwardRef,
+    display_as_type,
+    lenient_issubclass,
+    literal_values,
+    sequence_like,
+)
 from .validators import NoneType, constant_validator, dict_validator, find_validators
 
 try:
@@ -193,7 +202,7 @@ class Field:
         if origin is Callable:
             return
         if Literal is not None and origin is Literal:
-            types_ = list(set(type(arg) for arg in self.type_.__args__))  # type: ignore
+            types_ = list(set(type(arg) for arg in literal_values(self.type_)))
             if len(types_) > 1:
                 self.sub_fields = [self._create_sub_type(t, f'{self.name}_{display_as_type(t)}') for t in types_]
             return

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -52,6 +52,7 @@ from .utils import (
     is_literal_type,
     is_new_type,
     lenient_issubclass,
+    literal_values,
     new_type_supertype,
 )
 
@@ -753,7 +754,8 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     if is_new_type(field_type):
         field_type = new_type_supertype(field_type)
     if is_literal_type(field_type):
-        field_type = Union[tuple(type(arg) for arg in field_type.__args__)]  # type: ignore
+        # If there were distinct literal value types, field.sub_fields would not be falsy
+        field_type = type(literal_values(field_type)[0])
     if issubclass(field_type, Enum):
         f_schema.update({'enum': [item.value for item in field_type]})
         # Don't return immediately, to allow adding specific types

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -46,7 +46,14 @@ from .types import (
     conlist,
     constr,
 )
-from .utils import clean_docstring, is_callable_type, lenient_issubclass
+from .utils import (
+    clean_docstring,
+    is_callable_type,
+    is_literal_type,
+    is_new_type,
+    lenient_issubclass,
+    new_type_supertype,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import dataclasses  # noqa: F401
@@ -742,27 +749,31 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     f_schema: Dict[str, Any] = {}
     if field.schema is not None and field.schema.const:
         f_schema['const'] = field.default
-    if issubclass(field.type_, Enum):
-        f_schema.update({'enum': [item.value for item in field.type_]})
+    field_type = field.type_
+    if is_new_type(field_type):
+        field_type = new_type_supertype(field_type)
+    if is_literal_type(field_type):
+        field_type = Union[tuple(type(arg) for arg in field_type.__args__)]  # type: ignore
+    if issubclass(field_type, Enum):
+        f_schema.update({'enum': [item.value for item in field_type]})
         # Don't return immediately, to allow adding specific types
     for field_name, schema_name in validation_attribute_to_schema_keyword.items():
-        field_value = getattr(field.type_, field_name, None)
+        field_value = getattr(field_type, field_name, None)
         if field_value is not None:
             if field_name == 'regex':
                 field_value = field_value.pattern
             f_schema[schema_name] = field_value
     for type_, t_schema in field_class_to_schema_enum_enabled:
-        if issubclass(field.type_, type_):
+        if issubclass(field_type, type_):
             f_schema.update(t_schema)
             break
     # Return schema, with or without enum definitions
     if f_schema:
         return f_schema, definitions, nested_models
     for type_, t_schema in field_class_to_schema_enum_disabled:
-        if issubclass(field.type_, type_):
+        if issubclass(field_type, type_):
             return t_schema, definitions, nested_models
     # Handle dataclass-based models
-    field_type = field.type_
     if lenient_issubclass(getattr(field_type, '__pydantic_model__', None), pydantic.BaseModel):
         field_type = field_type.__pydantic_model__  # type: ignore
     if issubclass(field_type, pydantic.BaseModel):

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -754,8 +754,10 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     if is_new_type(field_type):
         field_type = new_type_supertype(field_type)
     if is_literal_type(field_type):
-        # If there were distinct literal value types, field.sub_fields would not be falsy
-        field_type = type(literal_values(field_type)[0])
+        # If there were multiple literal values, field.sub_fields would not be falsy
+        literal_value = literal_values(field_type)[0]
+        field_type = type(literal_value)
+        f_schema['const'] = literal_value
     if issubclass(field_type, Enum):
         f_schema.update({'enum': [item.value for item in field_type]})
         # Don't return immediately, to allow adding specific types

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -13,6 +13,7 @@ from typing import (  # type: ignore
     Dict,
     Generator,
     List,
+    NewType,
     Optional,
     Pattern,
     Set,
@@ -311,8 +312,11 @@ else:
         return type_.__values__
 
 
+test_type = NewType('test_type', str)
+
+
 def is_new_type(type_: AnyType) -> bool:
-    return isinstance(type_, type(lambda: None)) and hasattr(type_, '__supertype__')
+    return isinstance(type_, type(test_type)) and hasattr(type_, '__supertype__')
 
 
 def new_type_supertype(type_: AnyType) -> AnyType:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -298,18 +298,24 @@ if sys.version_info >= (3, 7):
     def is_literal_type(type_: AnyType) -> bool:
         return Literal is not None and getattr(type_, '__origin__', None) is Literal
 
+    def literal_values(type_: AnyType) -> Tuple[Any, ...]:
+        return type_.__args__
+
 
 else:
 
     def is_literal_type(type_: AnyType) -> bool:
         return Literal is not None and hasattr(type_, '__values__') and type_ == Literal[type_.__values__]
 
+    def literal_values(type_: AnyType) -> Tuple[Any, ...]:
+        return type_.__values__
 
-def is_new_type(type_: Any) -> bool:
+
+def is_new_type(type_: AnyType) -> bool:
     return isinstance(type_, type(lambda: None)) and hasattr(type_, '__supertype__')
 
 
-def new_type_supertype(type_: Any) -> AnyType:
+def new_type_supertype(type_: AnyType) -> AnyType:
     while hasattr(type_, '__supertype__'):
         type_ = type_.__supertype__
     return type_

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -305,6 +305,16 @@ else:
         return Literal is not None and hasattr(type_, '__values__') and type_ == Literal[type_.__values__]
 
 
+def is_new_type(type_: Any) -> bool:
+    return isinstance(type_, type(lambda: None)) and hasattr(type_, '__supertype__')
+
+
+def new_type_supertype(type_: Any) -> AnyType:
+    while hasattr(type_, '__supertype__'):
+        type_ = type_.__supertype__
+    return type_
+
+
 def _check_classvar(v: AnyType) -> bool:
     return type(v) == type(ClassVar) and (sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -71,6 +71,11 @@ try:
 except ImportError:
     email_validator = None
 
+try:
+    import typing_extensions
+except ImportError:
+    typing_extensions = None
+
 
 def test_key():
     class ApplePie(BaseModel):
@@ -1436,6 +1441,7 @@ def test_new_type_schema():
     }
 
 
+@pytest.mark.skipif(not typing_extensions, reason='typing_extensions not installed')
 def test_literal_schema():
     class Model(BaseModel):
         a: Literal[1]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, NewType, Optional, Set, Tuple, Union
 from uuid import UUID
 
 import pytest
@@ -64,6 +64,7 @@ from pydantic.types import (
     constr,
     urlstr,
 )
+from pydantic.utils import Literal
 
 try:
     import email_validator
@@ -1410,4 +1411,44 @@ def test_root_nested_model():
                 'required': ['a'],
             }
         },
+    }
+
+
+def test_new_type_schema():
+    a_type = NewType('a_type', int)
+    b_type = NewType('b_type', a_type)
+    c_type = NewType('c_type', str)
+
+    class Model(BaseModel):
+        a: a_type
+        b: b_type
+        c: c_type
+
+    assert Model.schema() == {
+        'properties': {
+            'a': {'title': 'A', 'type': 'integer'},
+            'b': {'title': 'B', 'type': 'integer'},
+            'c': {'title': 'C', 'type': 'string'},
+        },
+        'required': ['a', 'b', 'c'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
+def test_literal_schema():
+    class Model(BaseModel):
+        a: Literal[1]
+        b: Literal['a']
+        c: Literal['a', 1]
+
+    assert Model.schema() == {
+        'properties': {
+            'a': {'title': 'A', 'type': 'integer'},
+            'b': {'title': 'B', 'type': 'string'},
+            'c': {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'title': 'C'},
+        },
+        'required': ['a', 'b', 'c'],
+        'title': 'Model',
+        'type': 'object',
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1450,9 +1450,9 @@ def test_literal_schema():
 
     assert Model.schema() == {
         'properties': {
-            'a': {'title': 'A', 'type': 'integer'},
-            'b': {'title': 'B', 'type': 'string'},
-            'c': {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'title': 'C'},
+            'a': {'title': 'A', 'type': 'integer', 'const': 1},
+            'b': {'title': 'B', 'type': 'string', 'const': 'a'},
+            'c': {'anyOf': [{'type': 'string', 'const': 'a'}, {'type': 'integer', 'const': 1}], 'title': 'C'},
         },
         'required': ['a', 'b', 'c'],
         'title': 'Model',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1698,8 +1698,14 @@ def test_literal_multiple():
     assert exc_info.value.errors() == [
         {
             'loc': ('a_or_b',),
-            'msg': "unexpected value; permitted: 'a', 'b'",
+            'msg': "unexpected value; permitted: 'a'",
             'type': 'value_error.const',
-            'ctx': {'given': 'c', 'permitted': ('a', 'b')},
-        }
+            'ctx': {'given': 'c', 'permitted': ('a',)},
+        },
+        {
+            'loc': ('a_or_b',),
+            'msg': "unexpected value; permitted: 'b'",
+            'type': 'value_error.const',
+            'ctx': {'given': 'c', 'permitted': ('b',)},
+        },
     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,19 @@
 import os
 from enum import Enum
-from typing import Union
+from typing import NewType, Union
 
 import pytest
 
-from pydantic.utils import display_as_type, import_string, lenient_issubclass, make_dsn, truncate, validate_email
+from pydantic.utils import (
+    display_as_type,
+    import_string,
+    is_new_type,
+    lenient_issubclass,
+    make_dsn,
+    new_type_supertype,
+    truncate,
+    validate_email,
+)
 
 try:
     import email_validator
@@ -150,3 +159,18 @@ def test_lenient_issubclass_is_lenient():
 
 def test_truncate_type():
     assert truncate(object) == "<class 'object'>"
+
+
+def test_is_new_type():
+    new_type = NewType('new_type', str)
+    new_new_type = NewType('new_new_type', new_type)
+    assert is_new_type(new_type)
+    assert is_new_type(new_new_type)
+    assert not is_new_type(str)
+
+
+def test_new_type_supertype():
+    new_type = NewType('new_type', str)
+    new_new_type = NewType('new_new_type', new_type)
+    assert new_type_supertype(new_type) == str
+    assert new_type_supertype(new_new_type) == str


### PR DESCRIPTION
## Change Summary

`BaseModel.schema()` produces reasonable output for both `Literal` and `NewType` (both of which previously generated errors).

## Related issue number

#646 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
