### PR TITLE
Support assert statements inside validators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ mypy:
 
 .PHONY: test
 test:
-	@python tests/try_assert.py
 	pytest --cov=pydantic
+	@python tests/try_assert.py
 
 .PHONY: external-mypy
 external-mypy:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ mypy:
 
 .PHONY: test
 test:
+	@python tests/try_assert.py
 	pytest --cov=pydantic
 
 .PHONY: external-mypy

--- a/changes/653-abdusco.rst
+++ b/changes/653-abdusco.rst
@@ -1,0 +1,1 @@
+add support for ``assert`` statements inside validators

--- a/docs/examples/validators_simple.py
+++ b/docs/examples/validators_simple.py
@@ -22,6 +22,7 @@ class UserModel(BaseModel):
     @validator('username')
     def username_alphanumeric(cls, v):
         assert v.isalpha(), 'must be alphanumeric'
+        return v
 
 
 print(UserModel(name='samuel colvin', password1='zxcvbn', password2='zxcvbn'))

--- a/docs/examples/validators_simple.py
+++ b/docs/examples/validators_simple.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ValidationError, validator
 
 class UserModel(BaseModel):
     name: str
-    username: int
+    username: str
     password1: str
     password2: str
 

--- a/docs/examples/validators_simple.py
+++ b/docs/examples/validators_simple.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, ValidationError, validator
 
 class UserModel(BaseModel):
     name: str
+    username: int
     password1: str
     password2: str
 
@@ -17,6 +18,10 @@ class UserModel(BaseModel):
         if 'password1' in values and v != values['password1']:
             raise ValueError('passwords do not match')
         return v
+
+    @validator('username')
+    def username_alphanumeric(cls, v):
+        assert v.isalpha(), 'must be alphanumeric'
 
 
 print(UserModel(name='samuel colvin', password1='zxcvbn', password2='zxcvbn'))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,7 +194,7 @@ A few things to note on validators:
 * their signature can be ``(cls, value)`` or ``(cls, value, values, config, field)``. As of **v0.20**, any subset of
   ``values``, ``config`` and ``field`` is also permitted, eg. ``(cls, value, field)``, however due to the way
   validators are inspected, the variadic key word argument ("``**kwargs``") **must** be called ``kwargs``.
-* validator should either return the new value or raise a ``ValueError`` or ``TypeError``
+* validator should either return the new value or raise a ``ValueError``, ``TypeError``, or ``AssertionError`` (``assert`` statement can be used too)
 * where validators rely on other values, you should be aware that:
 
   - Validation is done in the order fields are defined, eg. here ``password2`` has access to ``password1``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,7 +194,9 @@ A few things to note on validators:
 * their signature can be ``(cls, value)`` or ``(cls, value, values, config, field)``. As of **v0.20**, any subset of
   ``values``, ``config`` and ``field`` is also permitted, eg. ``(cls, value, field)``, however due to the way
   validators are inspected, the variadic key word argument ("``**kwargs``") **must** be called ``kwargs``.
-* validator should either return the new value or raise a ``ValueError``, ``TypeError``, or ``AssertionError`` (``assert`` statement can be used too)
+* validator should either return the new value or raise a ``ValueError``, ``TypeError``, or ``AssertionError`` (``assert`` statement can be used too).
+  If you're using ``assert`` statements, you should keep in mind that running Python with ``-O`` `optimization flag <https://docs.python.org/3/using/cmdline.html#cmdoption-o>`_
+  disables ``assert`` statements, and **validators will stop working**.
 * where validators rely on other values, you should be aware that:
 
   - Validation is done in the order fields are defined, eg. here ``password2`` has access to ``password1``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -197,7 +197,9 @@ A few things to note on validators:
 * validators should either return the new value or raise a ``ValueError``, ``TypeError``, or ``AssertionError``
   (``assert`` statements may be used).
 
-  * If you make use of ``assert`` statements, keep in mind that running
+.. warning::
+
+    If you make use of ``assert`` statements, keep in mind that running
     Python with the ``-O`` `optimization flag <https://docs.python.org/3/using/cmdline.html#cmdoption-o>`_
     disables ``assert`` statements, and **validators will stop working**.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,9 +194,13 @@ A few things to note on validators:
 * their signature can be ``(cls, value)`` or ``(cls, value, values, config, field)``. As of **v0.20**, any subset of
   ``values``, ``config`` and ``field`` is also permitted, eg. ``(cls, value, field)``, however due to the way
   validators are inspected, the variadic key word argument ("``**kwargs``") **must** be called ``kwargs``.
-* validator should either return the new value or raise a ``ValueError``, ``TypeError``, or ``AssertionError`` (``assert`` statement can be used too).
-  If you're using ``assert`` statements, you should keep in mind that running Python with ``-O`` `optimization flag <https://docs.python.org/3/using/cmdline.html#cmdoption-o>`_
-  disables ``assert`` statements, and **validators will stop working**.
+* validators should either return the new value or raise a ``ValueError``, ``TypeError``, or ``AssertionError``
+  (``assert`` statements may be used).
+
+  * If you make use of ``assert`` statements, keep in mind that running
+    Python with the ``-O`` `optimization flag <https://docs.python.org/3/using/cmdline.html#cmdoption-o>`_
+    disables ``assert`` statements, and **validators will stop working**.
+
 * where validators rely on other values, you should be aware that:
 
   - Validation is done in the order fields are defined, eg. here ``password2`` has access to ``password1``

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -109,21 +109,15 @@ def flatten_errors(
 
 @lru_cache()
 def get_exc_type(cls: Type[Exception]) -> str:
-    type_names = {
-        TypeError: 'type_error',
-        ValueError: 'value_error',
-        AssertionError: 'assertion_error'
-    }
+    if issubclass(cls, AssertionError):
+        return 'assertion_error'
 
-    try:
-        # use bare name
-        return type_names[cls]
-    except KeyError:
-        pass
+    base_name = 'type_error' if issubclass(cls, TypeError) else 'value_error'
+    if cls in (TypeError, ValueError):
+        # just TypeError or ValueError, no extra code
+        return base_name
 
-    # if it's not one of the errors above, we just take the lowercase of the exception name
+    # if it's not a TypeError or ValueError, we just take the lowercase of the exception name
     # no chaining or snake case logic, use "code" for more complex error types.
-    for base_class, base_name in type_names.items():
-        if issubclass(cls, base_class):
-            code = getattr(cls, 'code', None) or cls.__name__.replace('Error', '').lower()
-            return base_name + '.' + code
+    code = getattr(cls, 'code', None) or cls.__name__.replace('Error', '').lower()
+    return base_name + '.' + code

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -109,13 +109,21 @@ def flatten_errors(
 
 @lru_cache()
 def get_exc_type(cls: Type[Exception]) -> str:
+    type_names = {
+        TypeError: 'type_error',
+        ValueError: 'value_error',
+        AssertionError: 'assertion_error'
+    }
 
-    base_name = 'type_error' if issubclass(cls, TypeError) else 'value_error'
-    if cls in (TypeError, ValueError):
-        # just TypeError or ValueError, no extra code
-        return base_name
+    try:
+        # use bare name
+        return type_names[cls]
+    except KeyError:
+        pass
 
-    # if it's not a TypeError or ValueError, we just take the lowercase of the exception name
+    # if it's not one of the errors above, we just take the lowercase of the exception name
     # no chaining or snake case logic, use "code" for more complex error types.
-    code = getattr(cls, 'code', None) or cls.__name__.replace('Error', '').lower()
-    return base_name + '.' + code
+    for base_class, base_name in type_names.items():
+        if issubclass(cls, base_class):
+            code = getattr(cls, 'code', None) or cls.__name__.replace('Error', '').lower()
+            return base_name + '.' + code

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -448,7 +448,7 @@ class Field:
         for validator in validators:
             try:
                 v = validator(cls, v, values, self, self.model_config)
-            except (ValueError, TypeError) as exc:
+            except (ValueError, TypeError, AssertionError) as exc:
                 return v, ErrorWrapper(exc, loc=loc, config=self.model_config)
         return v, None
 

--- a/tests/test_error_wrappers.py
+++ b/tests/test_error_wrappers.py
@@ -207,6 +207,7 @@ def test_errors_unknown_error_object():
     (
         (TypeError(), 'type_error'),
         (ValueError(), 'value_error'),
+        (AssertionError(), 'assertion_error'),
         (errors.DecimalIsNotFiniteError(), 'value_error.decimal.not_finite'),
     ),
 )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -649,5 +649,7 @@ def test_assert_raises_validation_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'invalid a\nassert False', 'type': 'assertion_error'}]
+    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': f'invalid a\nassert False', 'type': 'assertion_error'}]
+    injected_by_pytest = '\nassert False'
+    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}]
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -645,11 +645,14 @@ def test_assert_raises_validation_error():
 
         @validator('a')
         def check_a(cls, v):
-            assert False, 'invalid a'
+            assert v == 'a', 'invalid a'
+            return v
+
+    Model(a='a')
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    injected_by_pytest = '\nassert False'
+    injected_by_pytest = "\nassert 'snap' == 'a'\n  - snap\n  + a"
     assert exc_info.value.errors() == [
         {'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}
     ]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -649,7 +649,7 @@ def test_assert_raises_validation_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': f'invalid a\nassert False', 'type': 'assertion_error'}]
     injected_by_pytest = '\nassert False'
-    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}]
-
+    assert exc_info.value.errors() == [
+        {'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}
+    ]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -649,4 +649,5 @@ def test_assert_raises_validation_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert 'invalid a' in str(exc_info.value)
+    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'invalid a\nassert False', 'type': 'assertion_error'}]
+

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -637,3 +637,16 @@ def test_make_generic_validator_self():
     with pytest.raises(ConfigError) as exc_info:
         make_generic_validator(test_validator)
     assert ': (self, v), "self" not permitted as first argument, should be: (cls, value' in str(exc_info.value)
+
+
+def test_assert_raises_validation_error():
+    class Model(BaseModel):
+        a: str
+
+        @validator('a')
+        def check_a(cls, v):
+            assert False, 'invalid a'
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='snap')
+    assert 'invalid a' in str(exc_info.value)

--- a/tests/try_assert.py
+++ b/tests/try_assert.py
@@ -23,9 +23,9 @@ def test_assert_raises_validation_error():
     except ValidationError as exc:
         actual_errors = exc.errors()
         if actual_errors != expected_errors:
-            raise RuntimeError(f"{test_name}:\nActual errors: {actual_errors}\nExpected errors: {expected_errors}")
+            raise RuntimeError(f'{test_name}:\nActual errors: {actual_errors}\nExpected errors: {expected_errors}')
     else:
-        raise RuntimeError(f"{test_name}: ValidationError was not raised")
+        raise RuntimeError(f'{test_name}: ValidationError was not raised')
 
 
 if __name__ == '__main__':

--- a/tests/try_assert.py
+++ b/tests/try_assert.py
@@ -1,0 +1,43 @@
+"""
+This test is executed separately due to pytest's assertion-rewriting
+"""
+import sys
+from typing import List
+
+from pydantic import BaseModel, ValidationError, validator
+
+
+def test_assert_raises_validation_error():
+    test_name = test_assert_raises_validation_error.__name__
+
+    class Model(BaseModel):
+        a: str
+
+        @validator('a')
+        def check_a(cls, v):
+            assert v == 'a', 'invalid a'
+            return v
+
+    Model(a='a')
+    expected_errors = [{'loc': ('a',), 'msg': f'invalid a', 'type': 'assertion_error'}]
+
+    try:
+        Model(a='snap')
+    except ValidationError as exc:
+        actual_errors = exc.errors()
+        if actual_errors != expected_errors:
+            description = [f'Actual errors: {actual_errors}', f'Expected errors: {expected_errors}']
+            fail_test(test_name, description)
+    else:
+        fail_test(test_name, ['ValidationError was not raised'])
+
+
+def fail_test(test_name: str, description: List[str]):
+    print(f'{__file__}: failure in {test_name}')
+    print('\n'.join(['    ' + line for line in description]))
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    test_assert_raises_validation_error()
+    print('Non-pytest assert tests passed')

--- a/tests/try_assert.py
+++ b/tests/try_assert.py
@@ -1,9 +1,6 @@
 """
 This test is executed separately due to pytest's assertion-rewriting
 """
-import sys
-from typing import List
-
 from pydantic import BaseModel, ValidationError, validator
 
 
@@ -26,16 +23,9 @@ def test_assert_raises_validation_error():
     except ValidationError as exc:
         actual_errors = exc.errors()
         if actual_errors != expected_errors:
-            description = [f'Actual errors: {actual_errors}', f'Expected errors: {expected_errors}']
-            fail_test(test_name, description)
+            raise RuntimeError(f"{test_name}:\nActual errors: {actual_errors}\nExpected errors: {expected_errors}")
     else:
-        fail_test(test_name, ['ValidationError was not raised'])
-
-
-def fail_test(test_name: str, description: List[str]):
-    print(f'{__file__}: failure in {test_name}')
-    print('\n'.join(['    ' + line for line in description]))
-    sys.exit(1)
+        raise RuntimeError(f"{test_name}: ValidationError was not raised")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Change Summary

This PR adds support for `assert` statements inside validators (related: https://github.com/samuelcolvin/pydantic/issues/654). This means we can use:
```python
class CreateJob(BaseModel):
    name: str
    interval: int

    @validator('interval')
    def parse_interval(cls, v: int):
        assert v > 60, 'Interval must be longer than 60 seconds'
        return timedelta(seconds=v)
```
to raise validation errors.

I've updated docs, but haven't been able to build it on Windows. I'm getting this error:
```
(venv) D:\Development\oss\pydantic>make docs
make -C docs html
make[1]: Entering directory 'D:/Development/oss/pydantic/docs'
rm -rf _build
./schema_mapping.py
env: 'python3': Permission denied
make[1]: *** [Makefile:17: html] Error 126
make[1]: Leaving directory 'D:/Development/oss/pydantic/docs'
make: *** [Makefile:97: docs] Error 2
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
