### PR TITLE
Use inspect.getdoc to get model description

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 v0.31 (unreleased)
 ..................
+* use ``inspect.cleandoc`` internally to get model description, #657 by @tiangolo
 * nested classes which inherit and change ``__init__`` are now correctly processed while still allowing ``self`` as a
   parameter, #644 by @lnaden and @dgasmith
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 import warnings
 from datetime import date, datetime, time, timedelta
@@ -46,7 +47,7 @@ from .types import (
     conlist,
     constr,
 )
-from .utils import clean_docstring, is_callable_type, lenient_issubclass
+from .utils import is_callable_type, lenient_issubclass
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import dataclasses  # noqa: F401
@@ -546,8 +547,9 @@ def model_process_schema(
     ref_prefix = ref_prefix or default_prefix
     known_models = known_models or set()
     s = {'title': model.__config__.title or model.__name__}
-    if model.__doc__:
-        s['description'] = clean_docstring(model.__doc__)
+    doc = inspect.getdoc(model)
+    if doc:
+        s['description'] = doc
     known_models.add(model)
     m_schema, m_definitions, nested_models = model_type_schema(
         model, by_alias=by_alias, model_name_map=model_name_map, ref_prefix=ref_prefix, known_models=known_models

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from enum import Enum
 from functools import lru_cache
 from importlib import import_module
-from textwrap import dedent
 from typing import (  # type: ignore
     TYPE_CHECKING,
     Any,
@@ -197,10 +196,6 @@ def change_exception(raise_exc: ExcType, *except_types: ExcType) -> Generator[No
         yield
     except except_types as e:
         raise raise_exc from e
-
-
-def clean_docstring(d: str) -> str:
-    return dedent(d).strip(' \r\n\t')
 
 
 def sequence_like(v: AnyType) -> bool:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Use `inspect.getdoc` to get model description instead of the custom function `clean_docstring`.

It also allows models to inherit a description, the same way classes inherit a docstring.

Ref: https://docs.python.org/3/library/inspect.html#inspect.getdoc

<!-- Please give a short summary of the changes. -->

## Related issue number

Minor change without issue.

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
