### PR TITLE
Fix alias_generator and field config conflict

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.31 (unreleased)
 ..................
 * nested classes which inherit and change ``__init__`` are now correctly processed while still allowing ``self`` as a
   parameter, #644 by @lnaden and @dgasmith
+* fix ``alias_generator`` and field config conflict, #645 by @gmetzker and #658 by @MrMrRobat
 
 v0.30 (2019-07-07)
 ..................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,13 @@ History
 
 v0.31 (unreleased)
 ..................
-* nested classes which inherit and change ``__init__`` are now correctly processed while still allowing ``self`` as a
-  parameter, #644 by @lnaden and @dgasmith
+* fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
 * fix ``alias_generator`` and field config conflict, #645 by @gmetzker and #658 by @MrMrRobat
+
+v0.30.1 (2019-07-15)
+....................
+* fix so nested classes which inherit and change ``__init__`` are correctly processed while still allowing ``self`` as a
+  parameter, #644 by @lnaden and @dgasmith
 
 v0.30 (2019-07-07)
 ..................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -100,11 +100,11 @@ class BaseConfig:
         field_config = cls.fields.get(name) or {}
         if isinstance(field_config, str):
             field_config = {'alias': field_config}
-        elif not field_config and cls.alias_generator:
+        elif cls.alias_generator and 'alias' not in field_config:
             alias = cls.alias_generator(name)
             if not isinstance(alias, str):
                 raise TypeError(f'Config.alias_generator must return str, not {type(alias)}')
-            field_config = {'alias': alias}
+            field_config['alias'] = alias
         return field_config
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -681,7 +681,7 @@ def test_alias_generator_with_field_schema():
 
         class Config:
             alias_generator = to_upper_case
-            fields = {'my_shiny_field': 'MY_FIELD', 'foo_bar': {'alias': 'FOO'}}
+            fields = {'my_shiny_field': 'MY_FIELD', 'foo_bar': {'alias': 'FOO'}, 'another_field': {'not_alias': 'a'}}
 
     data = {'MY_FIELD': ['a'], 'FOO': 'bar', 'BAZ_BAR': 'ok', 'ANOTHER_FIELD': '...'}
     m = MyModel(**data)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary
`alias_generator`  will work if field has extra values in schema, but no `'alias'` specified

<!-- Please give a short summary of the changes. -->

## Related issue number

#645

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
