### PR TITLE
Bugfix for generic types with parameterized generic fields

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.31 (unreleased)
 * better support for floating point `multiple_of` values, #652 by @justindujardin
 * fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
 * add documentation for Literal type, #651 by @dmontagu
+* fix bug in ``GenericModel`` for models with concrete parameterized fields, #672 by @dmontagu
 
 v0.30.1 (2019-07-15)
 ....................

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -68,12 +68,9 @@ def concrete_name(cls: Type[Any], params: Tuple[Type[Any], ...]) -> str:
 
 
 def resolve_type_hint(type_: Any, typevars_map: Dict[Any, Any]) -> Type[Any]:
-    if hasattr(type_, '__origin__'):
-        new_args = tuple(resolve_type_hint(x, typevars_map) for x in type_.__args__)
-        if type_.__origin__ is Union:
-            return type_.__origin__[new_args]
-        new_args = tuple([typevars_map[x] for x in type_.__parameters__])
-        return type_[new_args]
+    if hasattr(type_, '__origin__') and getattr(type_, '__parameters__', None):
+        concrete_type_args = tuple([typevars_map[x] for x in type_.__parameters__])
+        return type_[concrete_type_args]
     return typevars_map.get(type_, type_)
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -342,6 +342,7 @@ def test_generic():
     ]
 
 
+@skip_36
 def test_alongside_concrete_generics():
     from pydantic.generics import GenericModel
 
@@ -356,6 +357,7 @@ def test_alongside_concrete_generics():
     assert model.metadata == {}
 
 
+@skip_36
 def test_complex_nesting():
     from pydantic.generics import GenericModel
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -340,3 +340,30 @@ def test_generic():
         {'loc': ('error',), 'msg': 'Must not provide both data and error', 'type': 'value_error'},
         {'loc': ('error',), 'msg': 'value is not none', 'type': 'type_error.none.allowed'},
     ]
+
+
+def test_alongside_concrete_generics():
+    from pydantic.generics import GenericModel
+
+    T = TypeVar('T')
+
+    class MyModel(GenericModel, Generic[T]):
+        item: T
+        metadata: Dict[str, Any]
+
+    model = MyModel[int](item=1, metadata={})
+    assert model.item == 1
+    assert model.metadata == {}
+
+
+def test_complex_nesting():
+    from pydantic.generics import GenericModel
+
+    T = TypeVar('T')
+
+    class MyModel(GenericModel, Generic[T]):
+        item: List[Dict[Union[int, T], str]]
+
+    item = [{1: 'a', 'a': 'a'}]
+    model = MyModel[str](item=item)
+    assert model.item == item


### PR DESCRIPTION
## Change Summary

Fixes a bug where a generic parameter exists alongside a fully-parameterized generic parameter in the model.

## Related issue number

Fixes a bug discovered while answering https://github.com/samuelcolvin/pydantic/issues/668

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
