### PR TITLE
Update error message for enum validator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.31 (unreleased)
 * better support for floating point `multiple_of` values, #652 by @justindujardin
 * fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
 * add documentation for Literal type, #651 by @dmontagu
+* more detailed message for ``EnumError``, #673 by @dmontagu
 
 v0.30.1 (2019-07-15)
 ....................

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -86,7 +86,9 @@ class UrlRegexError(PydanticValueError):
 
 
 class EnumError(PydanticTypeError):
-    msg_template = 'value is not a valid enumeration member'
+    def __str__(self) -> str:
+        permitted = ', '.join(repr(v.value) for v in self.ctx['enum_type'])  # type: ignore
+        return f'value is not a valid enumeration member; permitted: {permitted}'
 
 
 class IntegerError(PydanticTypeError):

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -219,9 +219,10 @@ def set_validator(v: Any) -> Set[Any]:
 
 
 def enum_validator(v: Any, field: 'Field', config: 'BaseConfig') -> Enum:
-    with change_exception(errors.EnumError, ValueError):
+    try:
         enum_v = field.type_(v)
-
+    except ValueError:
+        raise errors.EnumError(enum_type=field.type_)
     return enum_v.value if config.use_enum_values else enum_v
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -473,7 +473,12 @@ def test_enum_fails():
     with pytest.raises(ValueError) as exc_info:
         CookingModel(tool=3)
     assert exc_info.value.errors() == [
-        {'loc': ('tool',), 'msg': 'value is not a valid enumeration member', 'type': 'type_error.enum'}
+        {
+            'loc': ('tool',),
+            'msg': 'value is not a valid enumeration member; permitted: 1, 2',
+            'type': 'type_error.enum',
+            'ctx': {'enum_type': ToolEnum},
+        }
     ]
 
 


### PR DESCRIPTION
## Change Summary

Modify the EnumError message to be a little clearer (in line with the WrongConstantError).

## Related issue number

#671

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
