### PR TITLE
Add Config.keep_untouched for custom descriptors support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.31 (unreleased)
 ..................
 * fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
+* add Config.keep_untouched for custom descriptors support, #679 by @MrMrRobat
 
 v0.30.1 (2019-07-15)
 ....................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ v0.31 (unreleased)
 * better support for floating point `multiple_of` values, #652 by @justindujardin
 * fix schema generation for ``NewType`` and ``Literal``, #649 by @dmontagu
 * add documentation for Literal type, #651 by @dmontagu
-* add Config.keep_untouched for custom descriptors support, #679 by @MrMrRobat
+* add ``Config.keep_untouched`` for custom descriptors support, #679 by @MrMrRobat
 
 v0.30.1 (2019-07-15)
 ....................

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -762,7 +762,8 @@ Options:
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`
 :alias_generator: callable that takes field name and returns alias for it
-:keep_untouched: custom types of model attributes (e. g. descriptors) that won't change during model creation
+:keep_untouched: tuple of types (e. g. descriptors) that won't change during model creation and won't be
+  included in the model schemas.
 
 .. warning::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -739,6 +739,7 @@ Options:
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`
 :alias_generator: callable that takes field name and returns alias for it
+:keep_untouched: custom types of model attributes (e. g. descriptors) that won't change during model creation
 
 .. warning::
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -94,6 +94,7 @@ class BaseConfig:
     json_encoders: Dict[AnyType, AnyCallable] = {}
     orm_mode: bool = False
     alias_generator: Optional[Callable[[str], str]] = None
+    keep_untouched: Tuple[type, ...] = ()
 
     @classmethod
     def get_field_schema(cls, name: str) -> Dict[str, str]:
@@ -214,10 +215,11 @@ class MetaModel(ABCMeta):
                         config=config,
                     )
 
+            type_blacklist = TYPE_BLACKLIST + config.keep_untouched
             for var_name, value in namespace.items():
                 if (
                     is_valid_field(var_name)
-                    and (annotations.get(var_name) == PyObject or not isinstance(value, TYPE_BLACKLIST))
+                    and (annotations.get(var_name) == PyObject or not isinstance(value, type_blacklist))
                     and var_name not in class_vars
                 ):
                     validate_field_name(bases, var_name)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -170,7 +170,7 @@ def validate_custom_root_type(fields: Dict[str, Field]) -> None:
         raise TypeError('custom root type cannot allow mapping')
 
 
-TYPE_BLACKLIST = FunctionType, property, type, classmethod, staticmethod
+UNTOUCHED_TYPES = FunctionType, property, type, classmethod, staticmethod
 
 
 class MetaModel(ABCMeta):
@@ -218,11 +218,11 @@ class MetaModel(ABCMeta):
                         config=config,
                     )
 
-            type_blacklist = TYPE_BLACKLIST + config.keep_untouched
+            untouched_types = UNTOUCHED_TYPES + config.keep_untouched
             for var_name, value in namespace.items():
                 if (
                     is_valid_field(var_name)
-                    and (annotations.get(var_name) == PyObject or not isinstance(value, type_blacklist))
+                    and (annotations.get(var_name) == PyObject or not isinstance(value, untouched_types))
                     and var_name not in class_vars
                 ):
                     validate_field_name(bases, var_name)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -472,7 +472,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if config.arbitrary_types_allowed:
         yield make_arbitrary_type_validator(type_)
     else:
-        raise RuntimeError(f'no validator found for {type_}')
+        raise RuntimeError(f'no validator found for {type_}\n see keep_untouched or arbitrary_types_allowed in Config')
 
 
 def _find_supertype(type_: AnyType) -> Optional[AnyType]:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -474,7 +474,9 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if config.arbitrary_types_allowed:
         yield make_arbitrary_type_validator(type_)
     else:
-        raise RuntimeError(f'no validator found for {type_} see `keep_untouched` or `arbitrary_types_allowed` in Config')
+        raise RuntimeError(
+            f'no validator found for {type_} see `keep_untouched` or `arbitrary_types_allowed` in Config'
+        )
 
 
 def _find_supertype(type_: AnyType) -> Optional[AnyType]:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -474,7 +474,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if config.arbitrary_types_allowed:
         yield make_arbitrary_type_validator(type_)
     else:
-        raise RuntimeError(f'no validator found for {type_}\n see keep_untouched or arbitrary_types_allowed in Config')
+        raise RuntimeError(f'no validator found for {type_} see `keep_untouched` or `arbitrary_types_allowed` in Config')
 
 
 def _find_supertype(type_: AnyType) -> Optional[AnyType]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -788,9 +788,11 @@ def test_custom_types_fail_without_keep_untouched():
             def class_name(cls) -> str:
                 return cls.__name__
 
+        Model.class_name
+
     assert str(e.value) == (
-        "no validator found for <class 'tests.test_main.test_untouched_types.<locals>._ClassPropertyDescriptor'>\n "
-        'see keep_untouched or arbitrary_types_allowed in Config'
+        "no validator found for <class 'tests.test_main.test_custom_types_fail_without_keep_untouched.<locals>."
+        "_ClassPropertyDescriptor'>\n see keep_untouched or arbitrary_types_allowed in Config"
     )
 
     class Model(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -768,6 +768,19 @@ def test_untouched_types():
     assert Model.class_name == 'Model'
     assert Model().class_name == 'Model'
 
+
+def test_custom_types_fail_without_keep_untouched():
+    from pydantic import BaseModel
+
+    class _ClassPropertyDescriptor:
+        def __init__(self, getter):
+            self.getter = getter
+
+        def __get__(self, instance, owner):
+            return self.getter(owner)
+
+    classproperty = _ClassPropertyDescriptor
+
     with pytest.raises(RuntimeError) as e:
 
         class Model(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -792,7 +792,7 @@ def test_custom_types_fail_without_keep_untouched():
 
     assert str(e.value) == (
         "no validator found for <class 'tests.test_main.test_custom_types_fail_without_keep_untouched.<locals>."
-        "_ClassPropertyDescriptor'>\n see keep_untouched or arbitrary_types_allowed in Config"
+        "_ClassPropertyDescriptor'> see `keep_untouched` or `arbitrary_types_allowed` in Config"
     )
 
     class Model(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary
This will allow to extend default `TYPE_BLACKLIST` during class creation. 

It's very helpful if we want use custom descriptors for our class (like [cached_property](https://github.com/pydanny/cached-property), etc) and don't want pydantic to break them.

```py
from pydantic import BaseModel

class _ClassPropertyDescriptor:
    __slots__ = ('getter', )

    def __init__(self, getter):
        self.getter = getter

    def __get__(self, instance, owner):
        return self.getter(owner)

classproperty = _ClassPropertyDescriptor

class Model(BaseModel):
    class Config:
        keep_untouched = (classproperty, )

    @classproperty
    def class_name(cls) -> str:
        return cls.__name__

print(Model.class_name)  # Model
print(Model().class_name)  # Model
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
