### PR TITLE
Add support for base-0 int strings

### DIFF
--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -109,6 +109,8 @@ def int_validator(v: Any) -> int:
         return v
 
     with change_exception(errors.IntegerError, TypeError, ValueError):
+        if isinstance(v, (str, bytes)):
+            return int(v, base=0)
         return int(v)
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -37,6 +37,9 @@ def test_int_validation():
     assert Model(a=True).a == 1
     assert Model(a=False).a == 0
     assert Model(a=4.5).a == 4
+    assert Model(a='0b100').a == 4
+    assert Model(a='100').a == 100
+    assert Model(a='0x100').a == 256
 
 
 def test_validate_whole():


### PR DESCRIPTION
## Change Summary

Enables parsing of hex int strings (e.g., `'0xFF'`) and binary int strings (e.g., `'0b101'`) to int values.

I'm not yet confident this is a feature worth adding, but figured I'd provide a reference implementation for discussion related to the issue linked below. I'll close the pull request if we decide not to support it.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/682

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
