### PR TITLE
Make .json() work for EnumError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.32 (unreleased)
+..................
+* fix json generation for EnumError, #697 by @dmontagu
+
 v0.31 (2019-07-24)
 ..................
 * better support for floating point `multiple_of` values, #652 by @justindujardin

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -87,7 +87,7 @@ class UrlRegexError(PydanticValueError):
 
 class EnumError(PydanticTypeError):
     def __str__(self) -> str:
-        permitted = ', '.join(repr(v.value) for v in self.ctx['enum_type'])  # type: ignore
+        permitted = ', '.join(repr(v.value) for v in self.ctx['enum_values'])  # type: ignore
         return f'value is not a valid enumeration member; permitted: {permitted}'
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -222,7 +222,8 @@ def enum_validator(v: Any, field: 'Field', config: 'BaseConfig') -> Enum:
     try:
         enum_v = field.type_(v)
     except ValueError:
-        raise errors.EnumError(enum_type=field.type_)
+        # field.type_ should be an enum, so will be iterable
+        raise errors.EnumError(enum_values=list(field.type_))  # type: ignore
     return enum_v.value if config.use_enum_values else enum_v
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -477,9 +477,10 @@ def test_enum_fails():
             'loc': ('tool',),
             'msg': 'value is not a valid enumeration member; permitted: 1, 2',
             'type': 'type_error.enum',
-            'ctx': {'enum_type': ToolEnum},
+            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench]},
         }
     ]
+    assert len(exc_info.value.json()) == 217
 
 
 def test_int_enum_successful_for_str_int():


### PR DESCRIPTION
## Change Summary

Fix problem with the `.json()` method for `EnumError`.

## Related issue number

#696 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
