### PR TITLE
Fix issue #701 Max recursion when stepping into Pydantic models with …

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 History
 -------
+v0.32 (unreleased)
+..................
+* fix ``self`` inspection for smart debuggers, #701 by @peter-boers, @pfrederiks
 
 v0.31.1 (2019-07-31)
 ....................

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -251,7 +251,11 @@ class MetaModel(ABCMeta):
             '_custom_root_type': _custom_root_type,
             **{n: v for n, v in namespace.items() if n not in fields},
         }
-        return super().__new__(mcs, name, bases, new_namespace)
+
+        # Necessary to not break smart debuggers when inspecting `self` like: WebPDB, VSCode, PyCharm..
+        obj = super().__new__(mcs, name, bases, new_namespace)
+        obj.__values__ = {}
+        return obj
 
 
 class BaseModel(metaclass=MetaModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -806,3 +806,15 @@ def test_custom_types_fail_without_keep_untouched():
     with pytest.raises(AttributeError) as e:
         Model.class_name
     assert str(e.value) == "type object 'Model' has no attribute 'class_name'"
+
+
+def test_init_inspection():
+    class Foobar(BaseModel):
+        x: int
+
+        def __init__(self, **data) -> None:
+            with pytest.raises(AttributeError):
+                assert self.x
+            super().__init__(**data)
+
+    Foobar(x=1)


### PR DESCRIPTION
…smart debuggers: @peter-boers @pfrederiks

<!-- Thank you for your contribution! -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->
<!-- Don't worry about making lots of commits on a pull request, they'll be squashed on merge anyway -->

## Change Summary

Make sure ``self.__values__`` exists on the BaseModels for smart debuggers
<!-- Please give a short summary of the changes. -->

## Related issue number
Solves #701 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated

