### PR TITLE
Include all annotated fields in order

### DIFF
--- a/changes/715-dmontagu.rst
+++ b/changes/715-dmontagu.rst
@@ -1,0 +1,1 @@
+make all annotated fields occur in the order declared

--- a/changes/715.rst
+++ b/changes/715.rst
@@ -1,0 +1,1 @@
+make all annotated fields occur in the order declared, #715 by @dmontagu

--- a/changes/715.rst
+++ b/changes/715.rst
@@ -1,1 +1,0 @@
-make all annotated fields occur in the order declared, #715 by @dmontagu

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -204,6 +204,12 @@ A few things to note on validators:
   - If validation fails on another field (or that field is missing) it will not be included in ``values``, hence
     ``if 'password1' in values and ...`` in this example.
 
+.. warning::
+
+   Be aware that mixing annotated and non-annotated fields may alter the order of your fields in metadata and errors,
+   and for validation: annotated fields will always come before non-annotated fields.
+   (Within each group fields remain in the order they were defined.)
+
 
 .. note::
 
@@ -896,11 +902,6 @@ Required Fields and mypy
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ellipsis notation ``...`` will not work with mypy, you need to use annotation only fields as in the example above.
-
-.. warning::
-
-   Be aware that using annotation only fields will alter the order of your fields in metadata and errors:
-   annotation only fields will always come first, but still in the order they were defined.
 
 To get round this you can use the ``Required`` (via ``from pydantic import Required``) field as an alias for
 ellipses or annotation only.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -175,45 +175,43 @@ class MetaModel(ABCMeta):
                 f.prepare()
 
         set_extra(config, name)
-        annotations = resolve_annotations(namespace.get('__annotations__', {}), namespace.get('__module__', None))
 
         class_vars = set()
-        new_fields: Dict[str, Field] = {}
         if (namespace.get('__module__'), namespace.get('__qualname__')) != ('pydantic.main', 'BaseModel'):
+            annotations = resolve_annotations(namespace.get('__annotations__', {}), namespace.get('__module__', None))
+            untouched_types = UNTOUCHED_TYPES + config.keep_untouched
             # annotation only fields need to come first in fields
             for ann_name, ann_type in annotations.items():
                 if is_classvar(ann_type):
                     class_vars.add(ann_name)
-                elif is_valid_field(ann_name) and ann_name not in namespace:
+                elif is_valid_field(ann_name):
                     validate_field_name(bases, ann_name)
-                    new_fields[ann_name] = Field.infer(
+                    value = namespace.get(ann_name, ...)
+                    if isinstance(value, untouched_types) and ann_type != PyObject:
+                        continue
+                    fields[ann_name] = Field.infer(
                         name=ann_name,
-                        value=...,
+                        value=value,
                         annotation=ann_type,
                         class_validators=vg.get_validators(ann_name),
                         config=config,
                     )
 
-            untouched_types = UNTOUCHED_TYPES + config.keep_untouched
             for var_name, value in namespace.items():
                 if (
-                    is_valid_field(var_name)
-                    and (annotations.get(var_name) == PyObject or not isinstance(value, untouched_types))
+                    var_name not in annotations
+                    and is_valid_field(var_name)
+                    and not isinstance(value, untouched_types)
                     and var_name not in class_vars
                 ):
                     validate_field_name(bases, var_name)
-                    new_fields[var_name] = Field.infer(
+                    fields[var_name] = Field.infer(
                         name=var_name,
                         value=value,
                         annotation=annotations.get(var_name),
                         class_validators=vg.get_validators(var_name),
                         config=config,
                     )
-        new_fields_ordering = [k for k in annotations if k in new_fields] + [
-            k for k in new_fields if k not in annotations
-        ]
-        for k in new_fields_ordering:
-            fields[k] = new_fields[k]
 
         _custom_root_type = '__root__' in fields
         if _custom_root_type:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -930,3 +930,14 @@ def test_init_inspection():
             super().__init__(**data)
 
     Foobar(x=1)
+
+
+def test_ignored_type():
+    def foobar():
+        pass
+
+    class Model(BaseModel):
+        a: int = foobar
+        b: int
+
+    assert Model.__fields__.keys() == {'b'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,8 +312,7 @@ def test_field_order():
         a: str
         d: dict = {}
 
-    # fields are ordered as defined except annotation-only fields come last
-    assert list(Model.__fields__.keys()) == ['c', 'a', 'b', 'd']
+    assert list(Model.__fields__.keys()) == ['c', 'b', 'a', 'd']
 
 
 def test_required():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Dict, Iterator, List, NewType, Pattern, Sequence, Set, Tuple
+from typing import Dict, Iterator, List, NewType, Optional, Pattern, Sequence, Set, Tuple
 from uuid import UUID
 
 import pytest
@@ -207,12 +207,12 @@ def test_constrained_str_too_long():
 
 
 class DsnModel(BaseModel):
-    db_name = 'foobar'
-    db_user = 'postgres'
+    db_name: Optional[str] = 'foobar'
+    db_user: Optional[str] = 'postgres'
     db_password: str = None
-    db_host = 'localhost'
-    db_port = '5432'
-    db_driver = 'postgres'
+    db_host: Optional[str] = 'localhost'
+    db_port: Optional[str] = '5432'
+    db_driver: str = 'postgres'
     db_query: dict = None
     dsn: DSN = None
 


### PR DESCRIPTION
## Change Summary

Modifies field ordering so that all annotated fields occur in the order included.

Note: non-annotated fields still come last; this is probably unavoidable.

This is a subtly breaking change, so, if desired, should probably be part of 1.0.

## Related issue number

Related to #674 #483 #203 #716

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `HISTORY.rst` has been updated
  * if this is the first change since a release, please add a new section
  * include the issue number or this pull request number `#<number>`
  * include your github username `@<whomever>`
