### PR TITLE
Remove old, deprecated code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,6 @@ may be be delayed, until after version 1 is released. If your PR is a bugfix for
 * [ ] Unit tests for the changes exist
 * [ ] Tests pass on CI and coverage remains at 100%
 * [ ] Documentation reflects the changes where applicable
-* [ ] change description file added to `changes/`, 
+* [ ] change description file added to `changes/` called `<pull request or issue id>-<github username>.rst`,
   see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details
   on the format

--- a/changes/720-samuelcolvin.rst
+++ b/changes/720-samuelcolvin.rst
@@ -1,0 +1,2 @@
+**Breaking Change:** ``get_validators`` is no longer recognised, use ``__get_validators__``.
+``Config.ignore_extra`` and ``Config.allow_extra`` are no longer recognised, use ``Config.extra``.

--- a/changes/README.md
+++ b/changes/README.md
@@ -3,10 +3,7 @@
 This directory contains files describing changes to pydantic since the last release.
 
 If you're creating a pull request, please add a new file to this directory called
-`<pull request or issue id>.rst`. It should be formatted as a single paragraph of
+`<pull request or issue id>-<github username>.rst`. It should be formatted as a single paragraph of
 [reStructuredText](http://docutils.sourceforge.net/rst.html).
 
-The paragraph should end with the pull request or issue ID and your github username
-eg. `fix foobar broken thing, #123 by @samuelcolvin`.
-
-The contents of this fill will be used to update `HISTORY.rst` before the next release.
+The contents of this file will be used to update `HISTORY.rst` before the next release.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import IntEnum
 from typing import (
     TYPE_CHECKING,
@@ -272,12 +271,6 @@ class Field:
         class_validators_ = self.class_validators.values()
         if not self.sub_fields:
             get_validators = getattr(self.type_, '__get_validators__', None)
-            if not get_validators:
-                get_validators = getattr(self.type_, 'get_validators', None)
-                if get_validators:
-                    warnings.warn(
-                        f'get_validators has been replaced by __get_validators__ (on {self.name})', DeprecationWarning
-                    )
             v_funcs = (
                 *[v.func for v in class_validators_ if not v.whole and v.pre],
                 *(get_validators() if get_validators else list(find_validators(self.type_, self.model_config))),

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -127,31 +127,7 @@ EXTRA_LINK = 'https://pydantic-docs.helpmanual.io/#model-config'
 
 
 def set_extra(config: Type[BaseConfig], cls_name: str) -> None:
-    has_ignore_extra, has_allow_extra = hasattr(config, 'ignore_extra'), hasattr(config, 'allow_extra')
-    if has_ignore_extra or has_allow_extra:
-        if getattr(config, 'allow_extra', False):
-            config.extra = Extra.allow
-        elif getattr(config, 'ignore_extra', True):
-            config.extra = Extra.ignore
-        else:
-            config.extra = Extra.forbid
-
-        if has_ignore_extra and has_allow_extra:
-            warnings.warn(
-                f'{cls_name}: "ignore_extra" and "allow_extra" are deprecated and replaced by "extra", '
-                f'see {EXTRA_LINK}',
-                DeprecationWarning,
-            )
-        elif has_ignore_extra:
-            warnings.warn(
-                f'{cls_name}: "ignore_extra" is deprecated and replaced by "extra", see {EXTRA_LINK}',
-                DeprecationWarning,
-            )
-        else:
-            warnings.warn(
-                f'{cls_name}: "allow_extra" is deprecated and replaced by "extra", see {EXTRA_LINK}', DeprecationWarning
-            )
-    elif not isinstance(config.extra, Extra):
+    if not isinstance(config.extra, Extra):
         try:
             config.extra = Extra(config.extra)
         except ValueError:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -738,24 +738,6 @@ def test_unable_to_infer():
     assert exc_info.value.args[0] == 'unable to infer type for attribute "x"'
 
 
-def test_get_validator():
-    class CustomClass:
-        @classmethod
-        def get_validators(cls):
-            yield cls.validate
-
-        @classmethod
-        def validate(cls, v):
-            return v * 2
-
-    with pytest.warns(DeprecationWarning):
-
-        class Model(BaseModel):
-            x: CustomClass
-
-    assert Model(x=42).x == 84
-
-
 def test_multiple_errors():
     class Model(BaseModel):
         a: Union[None, int, float, Decimal]
@@ -805,55 +787,6 @@ def test_validate_all():
         {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
         {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
     ]
-
-
-def test_ignore_extra_true():
-    with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
-
-        class Model(BaseModel):
-            foo: int
-
-            class Config:
-                ignore_extra = True
-
-    assert Model.__config__.extra is Extra.ignore
-
-
-def test_ignore_extra_false():
-    with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" is deprecated and replaced by "extra"'):
-
-        class Model(BaseModel):
-            foo: int
-
-            class Config:
-                ignore_extra = False
-
-    assert Model.__config__.extra is Extra.forbid
-
-
-def test_allow_extra():
-    with pytest.warns(DeprecationWarning, match='Model: "allow_extra" is deprecated and replaced by "extra"'):
-
-        class Model(BaseModel):
-            foo: int
-
-            class Config:
-                allow_extra = True
-
-    assert Model.__config__.extra is Extra.allow
-
-
-def test_ignore_extra_allow_extra():
-    with pytest.warns(DeprecationWarning, match='Model: "ignore_extra" and "allow_extra" are deprecated and'):
-
-        class Model(BaseModel):
-            foo: int
-
-            class Config:
-                ignore_extra = False
-                allow_extra = False
-
-    assert Model.__config__.extra is Extra.forbid
 
 
 def test_force_extra():
@@ -909,26 +842,6 @@ def test_multiple_inheritance_config():
     assert Child.__config__.allow_population_by_alias is True
     assert Child.__config__.extra is Extra.forbid
     assert Child.__config__.use_enum_values is True
-
-
-def test_multiple_inheritance_config_legacy_extra():
-    with pytest.warns(DeprecationWarning, match='Parent: "ignore_extra" and "allow_extra" are deprecated and'):
-
-        class Parent(BaseModel):
-            class Config:
-                allow_extra = False
-                ignore_extra = False
-
-        class Mixin(BaseModel):
-            pass
-
-        class Child(Mixin, Parent):
-            pass
-
-    assert BaseModel.__config__.extra is Extra.ignore
-    assert Parent.__config__.extra is Extra.forbid
-    assert Mixin.__config__.extra is Extra.ignore
-    assert Child.__config__.extra is Extra.forbid
 
 
 def test_submodel_different_type():


### PR DESCRIPTION
# Change Summary

Remove the following deprecated functions (all have had deprecation warnings for multiple releases):
* `get_validators` is no longer recognised, use `__get_validators__`
* `Config.ignore_extra` is no longer recognised, use `Config.extra`
* `Config.allow_extra` is no longer recognised, use `Config.extra`

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] change description file added to `changes/`, 
  see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details
  on the format
