### PR TITLE
fix(validate-assignment): do not validate extra fields when `vaidate_assignment` is on

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.32.1 (unreleased)
+....................
+* do not validate extra fields when `vaidate_assignment` is on, #724 by @YaraslauZhylko
+
 v0.32 (2019-08-08)
 ..................
 * add model name to ``ValidationError`` error message, #676 by @dmontagu

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -41,10 +41,12 @@ def _get_validators(cls: Type['DataclassType']) -> Generator[Any, None, None]:
 def setattr_validate_assignment(self: 'DataclassType', name: str, value: Any) -> None:
     if self.__initialised__:
         d = dict(self.__dict__)
-        d.pop(name)
-        value, error_ = self.__pydantic_model__.__fields__[name].validate(value, d, loc=name, cls=self.__class__)
-        if error_:
-            raise ValidationError([error_], type(self))
+        d.pop(name, None)
+        known_field = self.__pydantic_model__.__fields__.get(name, None)
+        if known_field:
+            value, error_ = known_field.validate(value, d, loc=name, cls=self.__class__)
+            if error_:
+                raise ValidationError([error_], type(self))
 
     object.__setattr__(self, name, value)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -283,15 +283,13 @@ class BaseModel(metaclass=MetaModel):
         elif not self.__config__.allow_mutation:
             raise TypeError(f'"{self.__class__.__name__}" is immutable and does not support item assignment')
         elif self.__config__.validate_assignment:
-            value_, error_ = self.fields[name].validate(value, self.dict(exclude={name}), loc=name)
-            if error_:
-                raise ValidationError([error_], type(self))
-            else:
-                self.__dict__[name] = value_
-                self.__fields_set__.add(name)
-        else:
-            self.__dict__[name] = value
-            self.__fields_set__.add(name)
+            known_field = self.fields.get(name, None)
+            if known_field:
+                value_, error_ = known_field.validate(value, self.dict(exclude={name}), loc=name)
+                if error_:
+                    raise ValidationError([error_], type(self))
+        self.__dict__[name] = value
+        self.__fields_set__.add(name)
 
     def __getstate__(self) -> 'DictAny':
         return {'__dict__': self.__dict__, '__fields_set__': self.__fields_set__}

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -285,7 +285,7 @@ class BaseModel(metaclass=MetaModel):
         elif self.__config__.validate_assignment:
             known_field = self.fields.get(name, None)
             if known_field:
-                value_, error_ = known_field.validate(value, self.dict(exclude={name}), loc=name)
+                value, error_ = known_field.validate(value, self.dict(exclude={name}), loc=name)
                 if error_:
                     raise ValidationError([error_], type(self))
         self.__dict__[name] = value

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -92,6 +92,23 @@ def test_not_validate_assignment():
     assert d.a == '7'
 
 
+def test_validate_assignment_extra():
+    class Config:
+        validate_assignment = True
+
+    @pydantic.dataclasses.dataclass(config=Config, frozen=False)
+    class MyDataclass:
+        a: int
+
+    d = MyDataclass(1)
+    assert d.a == 1
+
+    d.extra_field = 1.23
+    assert d.extra_field == 1.23
+    d.extra_field = 'bye'
+    assert d.extra_field == 'bye'
+
+
 def test_post_init():
     post_init_called = False
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 import pytest
 
 import pydantic
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, validator
 
 
 def test_simple():
@@ -90,6 +90,25 @@ def test_not_validate_assignment():
 
     d.a = '7'
     assert d.a == '7'
+
+
+def test_validate_assignment_value_change():
+    class Config:
+        validate_assignment = True
+
+    @pydantic.dataclasses.dataclass(config=Config, frozen=False)
+    class MyDataclass:
+        a: int
+
+        @validator('a')
+        def double_a(cls, v):
+            return v * 2
+
+    d = MyDataclass(2)
+    assert d.a == 4
+
+    d.a = 3
+    assert d.a == 6
 
 
 def test_validate_assignment_extra():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -108,12 +108,17 @@ def test_validate_whole_error():
 class ValidateAssignmentModel(BaseModel):
     a: int = 4
     b: str = ...
+    c: int = 0
 
     @validator('b')
     def b_length(cls, v, values, **kwargs):
         if 'a' in values and len(v) < values['a']:
             raise ValueError('b too short')
         return v
+
+    @validator('c')
+    def double_c(cls, v):
+        return v * 2
 
     class Config:
         validate_assignment = True
@@ -132,6 +137,16 @@ def test_validating_assignment_fail():
     p = ValidateAssignmentModel(b='hello')
     with pytest.raises(ValidationError):
         p.b = 'x'
+
+
+def test_validating_assignment_value_change():
+    p = ValidateAssignmentModel(b='hello', c=2)
+    assert p.c == 4
+
+    p = ValidateAssignmentModel(b='hello')
+    assert p.c == 0
+    p.c = 3
+    assert p.c == 6
 
 
 def test_validating_assignment_extra():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from pydantic import BaseModel, ConfigError, ValidationError, errors, validator
+from pydantic import BaseModel, ConfigError, Extra, ValidationError, errors, validator
 from pydantic.class_validators import make_generic_validator
 
 
@@ -117,6 +117,7 @@ class ValidateAssignmentModel(BaseModel):
 
     class Config:
         validate_assignment = True
+        extra = Extra.allow
 
 
 def test_validating_assignment_ok():
@@ -131,6 +132,17 @@ def test_validating_assignment_fail():
     p = ValidateAssignmentModel(b='hello')
     with pytest.raises(ValidationError):
         p.b = 'x'
+
+
+def test_validating_assignment_extra():
+    p = ValidateAssignmentModel(b='hello', extra_field=1.23)
+    assert p.extra_field == 1.23
+
+    p = ValidateAssignmentModel(b='hello')
+    p.extra_field = 1.23
+    assert p.extra_field == 1.23
+    p.extra_field = 'bye'
+    assert p.extra_field == 'bye'
 
 
 def test_validating_assignment_dict():


### PR DESCRIPTION
## Change Summary

Do not validate extra fields when `validate_assignment` option is set to `True`.

This prevent `KeyError` to be raised when trying to add an extra field.

Also, it seems more logical to validate only those fields that are explicitly set for the model.

See related bug description for details.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/723

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] change description file added to `changes/`, 
  see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details
  on the format