### PR TITLE
Fix generic required

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.32.2 (2019-08-11)
+....................
+* fix required fields validation on GenericModels classes
+
 v0.32.1 (2019-08-08)
 ....................
 * do not validate extra fields when ``validate_assignment`` is on, #724 by @YaraslauZhylko

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -2,6 +2,7 @@ from typing import Any, ClassVar, Dict, Generic, Tuple, Type, TypeVar, Union, ge
 
 from pydantic import BaseModel, create_model
 from pydantic.class_validators import gather_validators
+from pydantic.fields import Required
 
 _generic_types_cache: Dict[Tuple[Type[Any], Union[Any, Tuple[Any, ...]]], Type[BaseModel]] = {}
 GenericModelT = TypeVar('GenericModelT', bound='GenericModel')
@@ -43,7 +44,9 @@ class GenericModel(BaseModel):
         model_name = concrete_name(cls, params)
         validators = gather_validators(cls)
         fields: Dict[str, Tuple[Type[Any], Any]] = {
-            k: (v, cls.__fields__[k].default) for k, v in concrete_type_hints.items() if k in cls.__fields__
+            k: (v, cls.__fields__[k].default if not cls.__fields__[k].required else Required)
+            for k, v in concrete_type_hints.items()
+            if k in cls.__fields__
         }
         created_model = create_model(
             model_name=model_name,

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.32.1')
+VERSION = StrictVersion('0.32.2')

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -391,4 +391,4 @@ def test_optional_value():
         a: Optional[int] = 1
 
     model = MyModel[int]()
-    assert model.dict() == {"a": 1}
+    assert model.dict() == {'a': 1}

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -369,3 +369,26 @@ def test_complex_nesting():
     item = [{1: 'a', 'a': 'a'}]
     model = MyModel[str](item=item)
     assert model.item == item
+
+
+@skip_36
+def test_required_value():
+    T = TypeVar('T')
+
+    class MyModel(GenericModel, Generic[T]):
+        a: int
+
+    with pytest.raises(ValidationError) as exc_info:
+        MyModel[int]()
+    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'}]
+
+
+@skip_36
+def test_optional_value():
+    T = TypeVar('T')
+
+    class MyModel(GenericModel, Generic[T]):
+        a: Optional[int] = 1
+
+    model = MyModel[int]()
+    assert model.dict() == {"a": 1}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->

## Change Summary
Currently, required fields on GenericModel classes are being silently ignored and automatically being set to `None` as default value, This commit fixes this behavior, raising `ValidationError` when a value is not supplied.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
