### PR TITLE
Added initvars support to post_init_post_parse

### DIFF
--- a/changes/748-Raphael-C-Almeida.rst
+++ b/changes/748-Raphael-C-Almeida.rst
@@ -1,1 +1,1 @@
-Added ``initvars`` support to ``post_init_post_parse``.
+**Breaking change:** Added ``initvars`` support to ``post_init_post_parse``.

--- a/changes/748-Raphael-C-Almeida.rst
+++ b/changes/748-Raphael-C-Almeida.rst
@@ -1,0 +1,1 @@
+Added ``initvars`` support to ``post_init_post_parse``.

--- a/docs/examples/ex_post_init_post_parse_initvars.py
+++ b/docs/examples/ex_post_init_post_parse_initvars.py
@@ -1,0 +1,21 @@
+from dataclasses import InitVar
+from pathlib import Path
+from typing import Optional
+
+from pydantic.dataclasses import dataclass
+
+@dataclass
+class PathData:
+    path: Path
+    base_path: InitVar[Optional[Path]]
+
+    def __post_init__(self, base_path):
+        print(f"Received path={self.path!r}, base_path={base_path!r}")
+
+    def __post_init_post_parse__(self, base_path):
+        if base_path is not None:
+            self.path = base_path / self.path
+
+path_data = PathData('world', base_path="/hello")
+# Received path='world', base_path='/hello'
+assert path_data.path == Path('/hello/world')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -169,6 +169,13 @@ code before validation.
 
 (This script is complete, it should run “as is”)
 
+Since version ``v1.0``, any fields annotated with ``dataclasses.InitVar`` are passed to both ``__post_init__`` *and*
+``__post_init_post_parse__``.
+
+.. literalinclude:: examples/ex_post_init_post_parse_initvars.py
+
+(This script is complete, it should run “as is”)
+
 Choices
 .......
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -71,7 +71,7 @@ def _process_class(
         object.__setattr__(self, '__dict__', d)
         object.__setattr__(self, '__initialised__', True)
         if post_init_post_parse is not None:
-            post_init_post_parse(self)
+            post_init_post_parse(self, *initvars)
 
     _cls.__post_init__ = _pydantic_post_init
     cls = dataclasses._process_class(_cls, init, repr, eq, order, unsafe_hash, frozen)  # type: ignore

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -442,6 +442,22 @@ def test_derived_field_from_initvar():
         DerivedWithInitVar('Not A Number')
 
 
+def test_initvars_post_init_post_parse():
+    post_init_post_parse_vars = None
+
+    @pydantic.dataclasses.dataclass
+    class MyDataclass:
+        a: int
+        var: dataclasses.InitVar[str]
+
+        def __post_init_post_parse__(self, var):
+            nonlocal post_init_post_parse_vars
+            post_init_post_parse_vars = var
+
+    MyDataclass('1', var='initvars')
+    assert post_init_post_parse_vars == 'initvars'
+
+
 def test_classvar():
     @pydantic.dataclasses.dataclass
     class TestClassVar:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,6 +1,7 @@
 import dataclasses
 from datetime import datetime
-from typing import ClassVar
+from pathlib import Path
+from typing import ClassVar, Optional
 
 import pytest
 
@@ -442,20 +443,42 @@ def test_derived_field_from_initvar():
         DerivedWithInitVar('Not A Number')
 
 
-def test_initvars_post_init_post_parse():
-    post_init_post_parse_vars = None
-
+def test_initvars_post_init():
     @pydantic.dataclasses.dataclass
-    class MyDataclass:
-        a: int
-        var: dataclasses.InitVar[str]
+    class PathDataPostInit:
+        path: Path
+        base_path: dataclasses.InitVar[Optional[Path]] = None
 
-        def __post_init_post_parse__(self, var):
-            nonlocal post_init_post_parse_vars
-            post_init_post_parse_vars = var
+        def __post_init__(self, base_path):
+            if base_path is not None:
+                self.path = base_path / self.path
 
-    MyDataclass('1', var='initvars')
-    assert post_init_post_parse_vars == 'initvars'
+    path_data = PathDataPostInit('world')
+    assert 'path' in path_data.__dict__
+    assert 'base_path' not in path_data.__dict__
+    assert path_data.path == Path('world')
+
+    with pytest.raises(TypeError) as exc_info:
+        PathDataPostInit('world', base_path='/hello')
+    assert str(exc_info.value) == "unsupported operand type(s) for /: 'str' and 'str'"
+
+
+def test_initvars_post_init_post_parse():
+    @pydantic.dataclasses.dataclass
+    class PathDataPostInitPostParse:
+        path: Path
+        base_path: dataclasses.InitVar[Optional[Path]] = None
+
+        def __post_init_post_parse__(self, base_path):
+            if base_path is not None:
+                self.path = base_path / self.path
+
+    path_data = PathDataPostInitPostParse('world')
+    assert 'path' in path_data.__dict__
+    assert 'base_path' not in path_data.__dict__
+    assert path_data.path == Path('world')
+
+    assert PathDataPostInitPostParse('world', base_path='/hello').path == Path('/hello/world')
 
 
 def test_classvar():


### PR DESCRIPTION
## Change Summary

Currently only `__post_init__` has `initvars` support which is lacking on `__post_init_post_parse__`, that's seams inconsistent considering the use case of both methods.
My **PR** only add this functionality along with it's test case.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
