### PR TITLE
Fix custom Schema on GenericModel fields

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.32.2 (unreleased)
 ....................
 * fix ``__post_init__`` usage with dataclass inheritance, fix #739 by @samuelcolvin
 * fix required fields validation on GenericModels classes, #742 by @amitbl
+* fix defining custom ``Schema`` on ``GenericModel`` fields, by @amitbl
 
 v0.32.1 (2019-08-08)
 ....................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ v0.32.2 (unreleased)
 ....................
 * fix ``__post_init__`` usage with dataclass inheritance, fix #739 by @samuelcolvin
 * fix required fields validation on GenericModels classes, #742 by @amitbl
-* fix defining custom ``Schema`` on ``GenericModel`` fields, by @amitbl
+* fix defining custom ``Schema`` on ``GenericModel`` fields, #754 by @amitbl
 
 v0.32.1 (2019-08-08)
 ....................

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -2,7 +2,6 @@ from typing import Any, ClassVar, Dict, Generic, Tuple, Type, TypeVar, Union, ge
 
 from pydantic import BaseModel, create_model
 from pydantic.class_validators import gather_validators
-from pydantic.fields import Required
 
 _generic_types_cache: Dict[Tuple[Type[Any], Union[Any, Tuple[Any, ...]]], Type[BaseModel]] = {}
 GenericModelT = TypeVar('GenericModelT', bound='GenericModel')
@@ -44,9 +43,7 @@ class GenericModel(BaseModel):
         model_name = concrete_name(cls, params)
         validators = gather_validators(cls)
         fields: Dict[str, Tuple[Type[Any], Any]] = {
-            k: (v, cls.__fields__[k].default if not cls.__fields__[k].required else Required)
-            for k, v in concrete_type_hints.items()
-            if k in cls.__fields__
+            k: (v, cls.__fields__[k].schema) for k, v in concrete_type_hints.items() if k in cls.__fields__
         }
         created_model = create_model(
             model_name=model_name,

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar, Dict, Generic, List, Optional, TypeVar, Union
 
 import pytest
 
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, Schema, ValidationError, validator
 from pydantic.generics import GenericModel, _generic_types_cache
 
 skip_36 = pytest.mark.skipif(sys.version_info < (3, 7), reason='generics only supported for python 3.7 and above')
@@ -392,3 +392,14 @@ def test_optional_value():
 
     model = MyModel[int]()
     assert model.dict() == {'a': 1}
+
+
+@skip_36
+def test_custom_schema():
+    T = TypeVar('T')
+
+    class MyModel(GenericModel, Generic[T]):
+        a: int = Schema(1, description='Custom')
+
+    schema = MyModel[int].schema()
+    assert schema['properties']['a'].get('description') == 'Custom'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->

## Change Summary

Fix custom `Schema` definitions on fields of GenericModel subclasses being ignored

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
