### PR TITLE
Preserve annotations from bases

### DIFF
--- a/changes/757-dmontagu.rst
+++ b/changes/757-dmontagu.rst
@@ -1,0 +1,1 @@
+**Breaking Change:** preserve superclass annotations for field-determination when not provided in subclass

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -156,7 +156,9 @@ class MetaModel(ABCMeta):
         fields: Dict[str, Field] = {}
         config = BaseConfig
         validators: 'ValidatorListDict' = {}
+        all_annotations: Dict[str, AnyType] = {}
         for base in reversed(bases):
+            all_annotations.update(getattr(base, '__annotations__', {}))
             if issubclass(base, BaseModel) and base != BaseModel:
                 fields.update(deepcopy(base.__fields__))
                 config = inherit_config(base.__config__, config)
@@ -179,6 +181,7 @@ class MetaModel(ABCMeta):
         class_vars = set()
         if (namespace.get('__module__'), namespace.get('__qualname__')) != ('pydantic.main', 'BaseModel'):
             annotations = resolve_annotations(namespace.get('__annotations__', {}), namespace.get('__module__', None))
+            all_annotations.update(annotations)
             untouched_types = UNTOUCHED_TYPES + config.keep_untouched
             # annotation only fields need to come first in fields
             for ann_name, ann_type in annotations.items():
@@ -208,7 +211,7 @@ class MetaModel(ABCMeta):
                     fields[var_name] = Field.infer(
                         name=var_name,
                         value=value,
-                        annotation=annotations.get(var_name),
+                        annotation=all_annotations.get(var_name),
                         class_validators=vg.get_validators(var_name),
                         config=config,
                     )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -527,7 +527,7 @@ def test_inheritance():
 
     class Bar(Foo):
         x: float = 12.3
-        a = 123
+        a: int = 123
 
     assert Bar().dict() == {'x': 12.3, 'a': 123}
 
@@ -617,16 +617,27 @@ def test_partial_inheritance_config():
 
 def test_annotation_inheritance():
     class A(BaseModel):
-        value: int = 1
+        integer: int = 1
 
     class B(A):
-        value = 'G'
+        integer = 2
 
-    with pytest.raises(ValidationError) as exc_info:
-        B(value='G')
-    assert exc_info.value.errors() == [
-        {'loc': ('value',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
-    ]
+    assert B.__fields__['integer'].type_ == int
+
+    class C(A):
+        integer: str = 'G'
+
+    assert C.__fields__['integer'].type_ == str
+
+    with pytest.raises(TypeError) as exc_info:
+
+        class D(A):
+            integer = 'G'
+
+    assert str(exc_info.value) == (
+        'The type of D.integer differs from the new default value; '
+        'if you wish to change the type of this field, please use a type annotation'
+    )
 
 
 def test_string_none():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -527,9 +527,9 @@ def test_inheritance():
 
     class Bar(Foo):
         x: float = 12.3
-        a: int = 123
+        a = 123.0
 
-    assert Bar().dict() == {'x': 12.3, 'a': 123}
+    assert Bar().dict() == {'x': 12.3, 'a': 123.0}
 
 
 def test_invalid_type():
@@ -622,11 +622,13 @@ def test_annotation_inheritance():
     class B(A):
         integer = 2
 
+    assert B.__annotations__['integer'] == int
     assert B.__fields__['integer'].type_ == int
 
     class C(A):
         integer: str = 'G'
 
+    assert C.__annotations__['integer'] == str
     assert C.__fields__['integer'].type_ == str
 
     with pytest.raises(TypeError) as exc_info:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -615,6 +615,20 @@ def test_partial_inheritance_config():
     assert str(m) == "Child a=1 b='s'"
 
 
+def test_annotation_inheritance():
+    class A(BaseModel):
+        value: int = 1
+
+    class B(A):
+        value = 'G'
+
+    with pytest.raises(ValidationError) as exc_info:
+        B(value='G')
+    assert exc_info.value.errors() == [
+        {'loc': ('value',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+    ]
+
+
 def test_string_none():
     class Model(BaseModel):
         a: constr(min_length=20, max_length=1000) = ...


### PR DESCRIPTION
## Change Summary

Preserve annotations from superclasses when modified in subclasses, even if the annotation is not repeated. (This prevents the field from being inferred as a different type.)

## Related issue number

Fixes #757

## Checklist
@samuelcolvin I don't think this change affects any existing documentation, and it feels subtle enough to me that it probably doesn't merit new docs (I think people should have assumed things would work this way, like @kszucs did). But let me know if you'd prefer I add a note.

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
