### PR TITLE
Feature/frozenset support

### DIFF
--- a/changes/745-djpetti.rst
+++ b/changes/745-djpetti.rst
@@ -1,0 +1,2 @@
+- Added support for `FrozenSet` members in dataclasses.
+- Added a better error when attempting to use types from the `typing` module that are not supported by Pydantic.

--- a/changes/745-djpetti.rst
+++ b/changes/745-djpetti.rst
@@ -1,2 +1,1 @@
-- Added support for `FrozenSet` members in dataclasses.
-- Added a better error when attempting to use types from the `typing` module that are not supported by Pydantic.
+Added support for ``FrozenSet`` members in dataclasses, and a better error when attempting to use types from the ``typing`` module that are not supported by Pydantic.

--- a/docs/examples/ex_typing.py
+++ b/docs/examples/ex_typing.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -15,6 +15,7 @@ class Model(BaseModel):
 
     simple_set: set = None
     set_bytes: Set[bytes] = None
+    frozen_set: FrozenSet[int] = None
 
     str_or_bytes: Union[str, bytes] = None
     none_or_str: Optional[str] = None

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -143,6 +143,10 @@ class SetError(PydanticTypeError):
     msg_template = 'value is not a valid set'
 
 
+class FrozenSetError(PydanticTypeError):
+    msg_template = 'value is not a valid frozenset'
+
+
 class TupleError(PydanticTypeError):
     msg_template = 'value is not a valid tuple'
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -246,13 +246,15 @@ class Field:
         elif issubclass(origin, Sequence):
             self.type_ = self.type_.__args__[0]  # type: ignore
             self.shape = SHAPE_SEQUENCE
-        else:
-            assert issubclass(origin, Mapping)
+        elif issubclass(origin, Mapping):
             self.key_field = self._create_sub_type(
                 self.type_.__args__[0], 'key_' + self.name, for_keys=True  # type: ignore
             )
             self.type_ = self.type_.__args__[1]  # type: ignore
             self.shape = SHAPE_MAPPING
+        else:
+            raise TypeError("Type of field '{}' is not supported."
+                            .format(origin.__name__))
 
         if getattr(self.type_, '__origin__', None):
             # type_ has been refined eg. as the type of a List and sub_fields needs to be populated

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -368,9 +368,9 @@ class Field:
 
         if self.shape == SHAPE_SET:
             converted = set(result)
-        elif self.shape is SHAPE_FROZENSET:
+        elif self.shape == SHAPE_FROZENSET:
             converted = frozenset(result)
-        elif self.shape is SHAPE_TUPLE_ELLIPS:
+        elif self.shape == SHAPE_TUPLE_ELLIPS:
             converted = tuple(result)
         elif self.shape == SHAPE_SEQUENCE:
             if isinstance(v, tuple):

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -211,7 +211,7 @@ def change_exception(raise_exc: ExcType, *except_types: ExcType) -> Generator[No
 
 
 def sequence_like(v: AnyType) -> bool:
-    return isinstance(v, (list, tuple, set)) or inspect.isgenerator(v)
+    return isinstance(v, (list, tuple, set, frozenset)) or inspect.isgenerator(v)
 
 
 def validate_field_name(bases: List[Type['BaseModel']], field_name: str) -> None:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    FrozenSet,
     Generator,
     List,
     Optional,
@@ -224,6 +225,15 @@ def set_validator(v: Any) -> Set[Any]:
         raise errors.SetError()
 
 
+def frozenset_validator(v: Any) -> FrozenSet[Any]:
+    if isinstance(v, frozenset):
+        return v
+    elif sequence_like(v):
+        return frozenset(v)
+    else:
+        raise errors.FrozenSetError()
+
+
 def enum_validator(v: Any, field: 'Field', config: 'BaseConfig') -> Enum:
     try:
         enum_v = field.type_(v)
@@ -433,6 +443,7 @@ _VALIDATORS: List[Tuple[AnyType, List[Any]]] = [
     (list, [list_validator]),
     (tuple, [tuple_validator]),
     (set, [set_validator]),
+    (frozenset, [frozenset_validator]),
     (UUID, [not_none_validator, uuid_validator]),
     (Decimal, [not_none_validator, decimal_validator]),
     (IPv4Interface, [not_none_validator, ip_v4_interface_validator]),

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, Optional
+from typing import ClassVar, FrozenSet, Optional
 
 import pytest
 
@@ -489,3 +489,10 @@ def test_classvar():
 
     tcv = TestClassVar(2)
     assert tcv.klassvar == "I'm a Class variable"
+
+
+def test_unsupported_field_type():
+    with pytest.raises(TypeError):
+        @pydantic.dataclasses.dataclass
+        class TestUnsupported:
+            unsupported: FrozenSet

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, FrozenSet, MutableSet, Optional
+from typing import ClassVar, FrozenSet, Optional
 
 import pytest
 
@@ -491,14 +491,6 @@ def test_classvar():
     assert tcv.klassvar == "I'm a Class variable"
 
 
-def test_unsupported_field_type():
-    with pytest.raises(TypeError):
-
-        @pydantic.dataclasses.dataclass
-        class TestUnsupported:
-            unsupported: MutableSet[int]
-
-
 def test_frozenset_field():
     @pydantic.dataclasses.dataclass
     class TestFrozenSet:
@@ -508,24 +500,3 @@ def test_frozenset_field():
     object_under_test = TestFrozenSet(set=test_set)
 
     assert object_under_test.set == test_set
-
-
-def test_frozenset_field_conversion():
-    @pydantic.dataclasses.dataclass
-    class TestFrozenSet:
-        set: FrozenSet[int]
-
-    test_list = [1, 2, 3]
-    test_set = frozenset(test_list)
-    object_under_test = TestFrozenSet(set=test_list)
-
-    assert object_under_test.set == test_set
-
-
-def test_frozenset_field_not_convertible():
-    @pydantic.dataclasses.dataclass
-    class TestFrozenSet:
-        set: FrozenSet[int]
-
-    with pytest.raises(pydantic.ValidationError, match=r'frozenset'):
-        TestFrozenSet(set=42)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, FrozenSet, Optional
+from typing import ClassVar, FrozenSet, MutableSet, Optional
 
 import pytest
 
@@ -493,6 +493,39 @@ def test_classvar():
 
 def test_unsupported_field_type():
     with pytest.raises(TypeError):
+
         @pydantic.dataclasses.dataclass
         class TestUnsupported:
-            unsupported: FrozenSet
+            unsupported: MutableSet[int]
+
+
+def test_frozenset_field():
+    @pydantic.dataclasses.dataclass
+    class TestFrozenSet:
+        set: FrozenSet[int]
+
+    test_set = frozenset({1, 2, 3})
+    object_under_test = TestFrozenSet(set=test_set)
+
+    assert object_under_test.set == test_set
+
+
+def test_frozenset_field_conversion():
+    @pydantic.dataclasses.dataclass
+    class TestFrozenSet:
+        set: FrozenSet[int]
+
+    test_list = [1, 2, 3]
+    test_set = frozenset(test_list)
+    object_under_test = TestFrozenSet(set=test_list)
+
+    assert object_under_test.set == test_set
+
+
+def test_frozenset_field_not_convertible():
+    @pydantic.dataclasses.dataclass
+    class TestFrozenSet:
+        set: FrozenSet[int]
+
+    with pytest.raises(pydantic.ValidationError, match=r'frozenset'):
+        TestFrozenSet(set=42)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Dict, Iterator, List, NewType, Optional, Pattern, Sequence, Set, Tuple
+from typing import Dict, FrozenSet, Iterator, List, MutableSet, NewType, Optional, Pattern, Sequence, Set, Tuple
 from uuid import UUID
 
 import pytest
@@ -1789,3 +1789,39 @@ def test_literal_multiple():
             'ctx': {'given': 'c', 'permitted': ('b',)},
         },
     ]
+
+
+def test_unsupported_field_type():
+    with pytest.raises(TypeError, match=r'MutableSet(.*)not supported'):
+
+        class UnsupportedModel(BaseModel):
+            unsupported: MutableSet[int]
+
+
+def test_frozenset_field():
+    class FrozenSetModel(BaseModel):
+        set: FrozenSet[int]
+
+    test_set = frozenset({1, 2, 3})
+    object_under_test = FrozenSetModel(set=test_set)
+
+    assert object_under_test.set == test_set
+
+
+def test_frozenset_field_conversion():
+    class FrozenSetModel(BaseModel):
+        set: FrozenSet[int]
+
+    test_list = [1, 2, 3]
+    test_set = frozenset(test_list)
+    object_under_test = FrozenSetModel(set=test_list)
+
+    assert object_under_test.set == test_set
+
+
+def test_frozenset_field_not_convertible():
+    class FrozenSetModel(BaseModel):
+        set: FrozenSet[int]
+
+    with pytest.raises(ValidationError, match=r'frozenset'):
+        FrozenSetModel(set=42)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -39,6 +39,21 @@ def test_int_validation():
     assert Model(a=4.5).a == 4
 
 
+def test_frozenset_validation():
+    class Model(BaseModel):
+        a: frozenset
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='snap')
+    assert exc_info.value.errors() == [
+        {'loc': ('a',), 'msg': 'value is not a valid frozenset', 'type': 'type_error.frozenset'}
+    ]
+    assert Model(a={1, 2, 3}).a == frozenset({1, 2, 3})
+    assert Model(a=frozenset({1, 2, 3})).a == frozenset({1, 2, 3})
+    assert Model(a=[4, 5]).a == frozenset({4, 5})
+    assert Model(a=(6,)).a == frozenset({6})
+
+
 def test_validate_whole():
     class Model(BaseModel):
         a: List[int]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->

**NOTICE**: pydantic is currently pushing towards V1 release, 
see [issue 576](https://github.com/samuelcolvin/pydantic/issues/576). Changes not required to release version 1
may be be delayed until after version 1 is released. If your PR is a bugfix for v0.32, please base off and target the `v0.32.x` branch.

## Change Summary

- Added support for `FrozenSet` members in dataclasses.
- Added a better error when attempting to use types from the `typing` module that are not supported by Pydantic.

## Related issue number

[745](https://github.com/samuelcolvin/pydantic/issues/745) should be resolved by merging this.

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
