### PR TITLE
better error message for TypeError on datetime parsing

### DIFF
--- a/changes/766-samuelcolvin.rst
+++ b/changes/766-samuelcolvin.rst
@@ -1,0 +1,2 @@
+Improvements to ``datetime``/``date``/``time``/``timedelta`` types: more descriptive errors,
+change errors to ``value_error`` not ``type_error``, support bytes.

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -265,19 +265,19 @@ class DecimalWholeDigitsError(PydanticValueError):
         super().__init__(whole_digits=whole_digits)
 
 
-class DateTimeError(PydanticTypeError):
+class DateTimeError(PydanticValueError):
     msg_template = 'invalid datetime format'
 
 
-class DateError(PydanticTypeError):
+class DateError(PydanticValueError):
     msg_template = 'invalid date format'
 
 
-class TimeError(PydanticTypeError):
+class TimeError(PydanticValueError):
     msg_template = 'invalid time format'
 
 
-class DurationError(PydanticTypeError):
+class DurationError(PydanticValueError):
     msg_template = 'invalid duration format'
 
 

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -225,7 +225,7 @@ def test_model_type_errors(field, value, error_message):
 
 
 @pytest.mark.parametrize('field', ['dt', 'd', 't', 'dt'])
-def test_model_type_errors(field):
+def test_unicode_decode_error(field):
     class Model(BaseModel):
         dt: datetime = None
         d: date = None

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -10,7 +10,7 @@ from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
 
-from pydantic import errors
+from pydantic import BaseModel, ValidationError, errors
 from pydantic.datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
 
 
@@ -23,11 +23,13 @@ def create_tz(minutes):
     [
         # Valid inputs
         ('1494012444.883309', date(2017, 5, 5)),
+        (b'1494012444.883309', date(2017, 5, 5)),
         (1_494_012_444.883_309, date(2017, 5, 5)),
         ('1494012444', date(2017, 5, 5)),
         (1_494_012_444, date(2017, 5, 5)),
         (0, date(1970, 1, 1)),
         ('2012-04-23', date(2012, 4, 23)),
+        (b'2012-04-23', date(2012, 4, 23)),
         ('2012-4-9', date(2012, 4, 9)),
         (date(2012, 4, 9), date(2012, 4, 9)),
         (datetime(2012, 4, 9, 12, 15), date(2012, 4, 9)),
@@ -57,6 +59,7 @@ def test_date_parsing(value, result):
         ('09:15:00', time(9, 15)),
         ('10:10', time(10, 10)),
         ('10:20:30.400', time(10, 20, 30, 400_000)),
+        (b'10:20:30.400', time(10, 20, 30, 400_000)),
         ('4:8:16', time(4, 8, 16)),
         (time(4, 8, 16), time(4, 8, 16)),
         (3610, time(1, 0, 10)),
@@ -66,6 +69,7 @@ def test_date_parsing(value, result):
         (86400, errors.TimeError),
         ('xxx', errors.TimeError),
         ('091500', errors.TimeError),
+        (b'091500', errors.TimeError),
         ('09:15:90', errors.TimeError),
     ],
 )
@@ -85,6 +89,7 @@ def test_time_parsing(value, result):
         ('1494012444.883309', datetime(2017, 5, 5, 19, 27, 24, 883_309, tzinfo=timezone.utc)),
         (1_494_012_444.883_309, datetime(2017, 5, 5, 19, 27, 24, 883_309, tzinfo=timezone.utc)),
         ('1494012444', datetime(2017, 5, 5, 19, 27, 24, tzinfo=timezone.utc)),
+        (b'1494012444', datetime(2017, 5, 5, 19, 27, 24, tzinfo=timezone.utc)),
         (1_494_012_444, datetime(2017, 5, 5, 19, 27, 24, tzinfo=timezone.utc)),
         # values in ms
         ('1494012444000.883309', datetime(2017, 5, 5, 19, 27, 24, 883, tzinfo=timezone.utc)),
@@ -96,6 +101,7 @@ def test_time_parsing(value, result):
         ('2012-04-23T10:20:30.400+02:30', datetime(2012, 4, 23, 10, 20, 30, 400_000, create_tz(150))),
         ('2012-04-23T10:20:30.400+02', datetime(2012, 4, 23, 10, 20, 30, 400_000, create_tz(120))),
         ('2012-04-23T10:20:30.400-02', datetime(2012, 4, 23, 10, 20, 30, 400_000, create_tz(-120))),
+        (b'2012-04-23T10:20:30.400-02', datetime(2012, 4, 23, 10, 20, 30, 400_000, create_tz(-120))),
         (datetime(2017, 5, 5), datetime(2017, 5, 5)),
         (0, datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)),
         # Invalid inputs
@@ -159,6 +165,7 @@ def test_parse_python_format(delta):
         ('15:30.0001', timedelta(minutes=15, seconds=30, microseconds=100)),
         ('15:30.00001', timedelta(minutes=15, seconds=30, microseconds=10)),
         ('15:30.000001', timedelta(minutes=15, seconds=30, microseconds=1)),
+        (b'15:30.000001', timedelta(minutes=15, seconds=30, microseconds=1)),
         # negative
         ('-4 15:30', timedelta(days=-4, minutes=15, seconds=30)),
         ('-172800', timedelta(days=-2)),
@@ -175,6 +182,7 @@ def test_parse_python_format(delta):
         ('PT5M', timedelta(minutes=5)),
         ('PT5S', timedelta(seconds=5)),
         ('PT0.000005S', timedelta(microseconds=5)),
+        (b'PT0.000005S', timedelta(microseconds=5)),
     ],
 )
 def test_parse_durations(value, result):
@@ -183,3 +191,53 @@ def test_parse_durations(value, result):
             parse_duration(value)
     else:
         assert parse_duration(value) == result
+
+
+@pytest.mark.parametrize(
+    'field, value, error_message',
+    [
+        ('dt', [], 'invalid type; expected datetime, string, bytes, int or float'),
+        ('dt', {}, 'invalid type; expected datetime, string, bytes, int or float'),
+        ('dt', object, 'invalid type; expected datetime, string, bytes, int or float'),
+        ('d', [], 'invalid type; expected date, string, bytes, int or float'),
+        ('d', {}, 'invalid type; expected date, string, bytes, int or float'),
+        ('d', object, 'invalid type; expected date, string, bytes, int or float'),
+        ('t', [], 'invalid type; expected time, string, bytes, int or float'),
+        ('t', {}, 'invalid type; expected time, string, bytes, int or float'),
+        ('t', object, 'invalid type; expected time, string, bytes, int or float'),
+        ('td', [], 'invalid type; expected timedelta, string, bytes, int or float'),
+        ('td', {}, 'invalid type; expected timedelta, string, bytes, int or float'),
+        ('td', object, 'invalid type; expected timedelta, string, bytes, int or float'),
+    ],
+)
+def test_model_type_errors(field, value, error_message):
+    class Model(BaseModel):
+        dt: datetime = None
+        d: date = None
+        t: time = None
+        td: timedelta = None
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(**{field: value})
+    assert len(exc_info.value.errors()) == 1
+    error = exc_info.value.errors()[0]
+    assert error == {'loc': (field,), 'type': 'type_error', 'msg': error_message}
+
+
+@pytest.mark.parametrize('field', ['dt', 'd', 't', 'dt'])
+def test_model_type_errors(field):
+    class Model(BaseModel):
+        dt: datetime = None
+        d: date = None
+        t: time = None
+        td: timedelta = None
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(**{field: b'\x81'})
+    assert len(exc_info.value.errors()) == 1
+    error = exc_info.value.errors()[0]
+    assert error == {
+        'loc': (field,),
+        'type': 'value_error.unicodedecode',
+        'msg': "'utf-8' codec can't decode byte 0x81 in position 0: invalid start byte",
+    }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -477,10 +477,10 @@ def test_datetime_errors():
     with pytest.raises(ValueError) as exc_info:
         DatetimeModel(dt='2017-13-5T19:47:07', date_='XX1494012000', time_='25:20:30.400', duration='15:30.0001 broken')
     assert exc_info.value.errors() == [
-        {'loc': ('dt',), 'msg': 'invalid datetime format', 'type': 'type_error.datetime'},
-        {'loc': ('date_',), 'msg': 'invalid date format', 'type': 'type_error.date'},
-        {'loc': ('time_',), 'msg': 'invalid time format', 'type': 'type_error.time'},
-        {'loc': ('duration',), 'msg': 'invalid duration format', 'type': 'type_error.duration'},
+        {'loc': ('dt',), 'msg': 'invalid datetime format', 'type': 'value_error.datetime'},
+        {'loc': ('date_',), 'msg': 'invalid date format', 'type': 'value_error.date'},
+        {'loc': ('time_',), 'msg': 'invalid time format', 'type': 'value_error.time'},
+        {'loc': ('duration',), 'msg': 'invalid duration format', 'type': 'value_error.duration'},
     ]
 
 


### PR DESCRIPTION
## Change Summary

While working on #763 I discovered that we had no tests and ugly errors if anything other than a native datetime/date/time/timedelta, string, int or float was passed to those parsers.

Changes:
* fix the above - more descriptive error message
* add support for bytes by decoding them before regex matching
* change  invalid values to be `value_errors` not `type_errors` - more correct.

Github doesn't do a very good job of showing it, but this change is mainly just an indentation change plus adding `if isinstance(value, bytes): value = value.decode()`.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
