### PR TITLE
Fix error messages for Literal types with multiple allowed values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.32.3 (unreleased)
+....................
+* fix error messages for ``Literal`` types with multiple allowed values, #770 by @dmontagu
+
 v0.32.2 (2019-08-17)
 ....................
 * fix ``__post_init__`` usage with dataclass inheritance, fix #739 by @samuelcolvin

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -31,7 +31,6 @@ from .utils import (
     display_as_type,
     is_literal_type,
     lenient_issubclass,
-    literal_values,
     sequence_like,
 )
 from .validators import NoneType, constant_validator, dict_validator, find_validators
@@ -197,11 +196,7 @@ class Field:
             # python 3.7 only, Pattern is a typing object but without sub fields
             return
         if is_literal_type(self.type_):
-            values = literal_values(self.type_)
-            if len(values) > 1:
-                self.type_ = Union[tuple(Literal[value] for value in values)]
-            else:
-                return
+            return
         origin = getattr(self.type_, '__origin__', None)
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -817,7 +817,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
 
 
 def multivalue_literal_field_for_schema(values: Tuple[Any, ...], field: Field) -> Field:
-    field = Field(
+    return Field(
         name=field.name,
         type_=Union[tuple(Literal[value] for value in values)],
         class_validators=field.class_validators,
@@ -827,7 +827,6 @@ def multivalue_literal_field_for_schema(values: Tuple[Any, ...], field: Field) -
         alias=field.alias,
         schema=field.schema,
     )
-    return field
 
 
 def encode_default(dft: Any) -> Any:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -49,6 +49,7 @@ from .types import (
     constr,
 )
 from .utils import (
+    Literal,
     is_callable_type,
     is_literal_type,
     is_new_type,
@@ -758,8 +759,16 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     if is_new_type(field_type):
         field_type = new_type_supertype(field_type)
     if is_literal_type(field_type):
-        # If there were multiple literal values, field.sub_fields would not be falsy
-        literal_value = literal_values(field_type)[0]
+        values = literal_values(field_type)
+        if len(values) > 1:
+            return field_schema(
+                multivalue_literal_field_for_schema(values, field),
+                by_alias=by_alias,
+                model_name_map=model_name_map,
+                ref_prefix=ref_prefix,
+                known_models=known_models,
+            )
+        literal_value = values[0]
         field_type = type(literal_value)
         f_schema['const'] = literal_value
     if issubclass(field_type, Enum):
@@ -805,6 +814,20 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         else:
             return {'allOf': [schema_ref]}, definitions, nested_models
     raise ValueError(f'Value not declarable with JSON Schema, field: {field}')
+
+
+def multivalue_literal_field_for_schema(values: Tuple[Any, ...], field: Field) -> Field:
+    field = Field(
+        name=field.name,
+        type_=Union[tuple(Literal[value] for value in values)],
+        class_validators=field.class_validators,
+        model_config=field.model_config,
+        default=field.default,
+        required=field.required,
+        alias=field.alias,
+        schema=field.schema,
+    )
+    return field
 
 
 def encode_default(dft: Any) -> Any:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1730,14 +1730,8 @@ def test_literal_multiple():
     assert exc_info.value.errors() == [
         {
             'loc': ('a_or_b',),
-            'msg': "unexpected value; permitted: 'a'",
+            'msg': "unexpected value; permitted: 'a', 'b'",
             'type': 'value_error.const',
-            'ctx': {'given': 'c', 'permitted': ('a',)},
-        },
-        {
-            'loc': ('a_or_b',),
-            'msg': "unexpected value; permitted: 'b'",
-            'type': 'value_error.const',
-            'ctx': {'given': 'c', 'permitted': ('b',)},
-        },
+            'ctx': {'given': 'c', 'permitted': ('a', 'b')},
+        }
     ]


### PR DESCRIPTION
## Change Summary

Fix error messages for Literal types with multiple allowed values

## Related issue number

Fixes #768

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
