### PR TITLE
Improve auto-generated title in JSON schemas

### DIFF
--- a/changes/772-skewty.rst
+++ b/changes/772-skewty.rst
@@ -1,0 +1,1 @@
+Improved auto-generated ``title`` field in JSON schema by converting underscore to space.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -277,7 +277,7 @@ def field_schema(
     ref_prefix = ref_prefix or default_prefix
     schema_overrides = False
     schema = cast('Schema', field.schema)
-    s = dict(title=schema.title or field.alias.title())
+    s = dict(title=schema.title or field.alias.title().replace('_', ' '))
     if schema.title:
         schema_overrides = True
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -381,7 +381,7 @@ def test_schema():
         'properties': {
             'id': {'title': 'Id', 'type': 'integer'},
             'name': {'title': 'Name', 'default': 'John Doe', 'type': 'string'},
-            'signup_ts': {'title': 'Signup_Ts', 'type': 'string', 'format': 'date-time'},
+            'signup_ts': {'title': 'Signup Ts', 'type': 'string', 'format': 'date-time'},
         },
         'required': ['id'],
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -705,7 +705,7 @@ def test_ipv4address_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_address': {'title': 'Ip_Address', 'type': 'string', 'format': 'ipv4'}},
+        'properties': {'ip_address': {'title': 'Ip Address', 'type': 'string', 'format': 'ipv4'}},
         'required': ['ip_address'],
     }
 
@@ -718,7 +718,7 @@ def test_ipv6address_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_address': {'title': 'Ip_Address', 'type': 'string', 'format': 'ipv6'}},
+        'properties': {'ip_address': {'title': 'Ip Address', 'type': 'string', 'format': 'ipv6'}},
         'required': ['ip_address'],
     }
 
@@ -731,7 +731,7 @@ def test_ipvanyaddress_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_address': {'title': 'Ip_Address', 'type': 'string', 'format': 'ipvanyaddress'}},
+        'properties': {'ip_address': {'title': 'Ip Address', 'type': 'string', 'format': 'ipvanyaddress'}},
         'required': ['ip_address'],
     }
 
@@ -744,7 +744,7 @@ def test_ipv4interface_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_interface': {'title': 'Ip_Interface', 'type': 'string', 'format': 'ipv4interface'}},
+        'properties': {'ip_interface': {'title': 'Ip Interface', 'type': 'string', 'format': 'ipv4interface'}},
         'required': ['ip_interface'],
     }
 
@@ -757,7 +757,7 @@ def test_ipv6interface_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_interface': {'title': 'Ip_Interface', 'type': 'string', 'format': 'ipv6interface'}},
+        'properties': {'ip_interface': {'title': 'Ip Interface', 'type': 'string', 'format': 'ipv6interface'}},
         'required': ['ip_interface'],
     }
 
@@ -770,7 +770,7 @@ def test_ipvanyinterface_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_interface': {'title': 'Ip_Interface', 'type': 'string', 'format': 'ipvanyinterface'}},
+        'properties': {'ip_interface': {'title': 'Ip Interface', 'type': 'string', 'format': 'ipvanyinterface'}},
         'required': ['ip_interface'],
     }
 
@@ -783,7 +783,7 @@ def test_ipv4network_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_network': {'title': 'Ip_Network', 'type': 'string', 'format': 'ipv4network'}},
+        'properties': {'ip_network': {'title': 'Ip Network', 'type': 'string', 'format': 'ipv4network'}},
         'required': ['ip_network'],
     }
 
@@ -796,7 +796,7 @@ def test_ipv6network_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_network': {'title': 'Ip_Network', 'type': 'string', 'format': 'ipv6network'}},
+        'properties': {'ip_network': {'title': 'Ip Network', 'type': 'string', 'format': 'ipv6network'}},
         'required': ['ip_network'],
     }
 
@@ -809,7 +809,7 @@ def test_ipvanynetwork_type():
     assert model_schema == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'ip_network': {'title': 'Ip_Network', 'type': 'string', 'format': 'ipvanynetwork'}},
+        'properties': {'ip_network': {'title': 'Ip Network', 'type': 'string', 'format': 'ipvanynetwork'}},
         'required': ['ip_network'],
     }
 
@@ -1368,7 +1368,7 @@ def test_known_model_optimization():
         'type': 'object',
         'properties': {
             'dep': {'$ref': '#/definitions/Dep'},
-            'dep_l': {'title': 'Dep_L', 'type': 'array', 'items': {'$ref': '#/definitions/Dep'}},
+            'dep_l': {'title': 'Dep L', 'type': 'array', 'items': {'$ref': '#/definitions/Dep'}},
         },
         'required': ['dep', 'dep_l'],
         'definitions': {


### PR DESCRIPTION
Underscore is converted to space.
Closes #743

### NOTE the following unit test is not passing for me:
```
tests/test_validators.py:641 (test_assert_raises_validation_error)
def test_assert_raises_validation_error():
        class Model(BaseModel):
            a: str
    
            @validator('a')
            def check_a(cls, v):
                assert v == 'a', 'invalid a'
                return v
    
        Model(a='a')
    
        with pytest.raises(ValidationError) as exc_info:
            Model(a='snap')
        injected_by_pytest = "\nassert 'snap' == 'a'\n  - snap\n  + a"
>       assert exc_info.value.errors() == [
            {'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}
        ]
E       assert [{'loc': ('a',),\n  'msg': "invalid a\nassert 'snap' == 'a'",\n  'type': 'assertion_error'}] == [{'loc': ('a',),\n  'msg': "invalid a\nassert 'snap' == 'a'\n  - snap\n  + a",\n  'type': 'assertion_error'}]

tests/test_validators.py:656: AssertionError
```