### PR TITLE
Set additionalProperties to False on Extra.forbid models

### DIFF
--- a/changes/796-Code0x58.rst
+++ b/changes/796-Code0x58.rst
@@ -1,0 +1,1 @@
+Set ``additionalProperties`` to false in schema for models with extra fields disallowed.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -593,6 +593,8 @@ def model_type_schema(
         out_schema = {'type': 'object', 'properties': properties}
         if required:
             out_schema['required'] = required
+    if model.__config__.extra == 'forbid':
+        out_schema['additionalProperties'] = False
     return out_schema, definitions, nested_models
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 import pytest
 
-from pydantic import BaseModel, Schema, ValidationError, validator
+from pydantic import BaseModel, Extra, Schema, ValidationError, validator
 from pydantic.color import Color
 from pydantic.networks import AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, NameEmail, stricturl
 from pydantic.schema import (
@@ -1474,4 +1474,20 @@ def test_model_with_schema_extra():
         'properties': {'a': {'title': 'A', 'type': 'string'}},
         'required': ['a'],
         'examples': [{'a': 'Foo'}],
+    }
+
+
+def test_model_with_extra_forbidden():
+    class Model(BaseModel):
+        a: str
+
+        class Config:
+            extra = Extra.forbid
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'string'}},
+        'required': ['a'],
+        'additionalProperties': False,
     }


### PR DESCRIPTION
## Change Summary

Set [`"additionalProperties": False`](https://json-schema.org/understanding-json-schema/reference/object.html#properties) on schema for models with `Config.extra == Extra.forbid`.


## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] ~~Documentation reflects the changes where applicable~~
* [x] `changes/796-Code0x58.rst` file added describing change