### PR TITLE
Local part of email is now case-sensitive after validation per RFC 5321.

### DIFF
--- a/changes/798-henriklindgren.rst
+++ b/changes/798-henriklindgren.rst
@@ -1,1 +1,1 @@
-EmailStr validation method now returns local part case-sensitive per RFC 5321.
+``EmailStr`` validation method now returns local part case-sensitive per RFC 5321.

--- a/changes/798-henriklindgren.rst
+++ b/changes/798-henriklindgren.rst
@@ -1,0 +1,1 @@
+EmailStr validation method now returns local part case-sensitive per RFC 5321.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -380,4 +380,8 @@ def validate_email(value: str) -> Tuple[str, str]:
     except email_validator.EmailNotValidError as e:
         raise errors.EmailError() from e
 
-    return name or email[: email.index('@')], email.lower()
+    at_index = email.index('@')
+    local_part = email[:at_index]  # RFC 5321, local part must be case-sensitive.
+    global_part = email[at_index:].lower()
+
+    return name or local_part, local_part + global_part

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -309,7 +309,7 @@ def test_son():
         ('foo.bar@example.com ', 'foo.bar', 'foo.bar@example.com'),
         ('foo BAR <foobar@example.com >', 'foo BAR', 'foobar@example.com'),
         ('FOO bar   <foobar@example.com> ', 'FOO bar', 'foobar@example.com'),
-        ('<FOOBAR@example.com> ', 'FOOBAR', 'foobar@example.com'),
+        ('<FOOBAR@example.com> ', 'FOOBAR', 'FOOBAR@example.com'),
         ('ñoñó@example.com', 'ñoñó', 'ñoñó@example.com'),
         ('我買@example.com', '我買', '我買@example.com'),
         ('甲斐黒川日本@example.com', '甲斐黒川日本', '甲斐黒川日本@example.com'),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -499,8 +499,6 @@ def test_string_success():
         str_min_length: constr(min_length=5) = ...
         str_curtailed: constr(curtail_length=5) = ...
         str_email: EmailStr = ...
-        str_email_local_case_sensitive: EmailStr = ...
-        str_email_global_case_insensitive: EmailStr = ...
         name_email: NameEmail = ...
 
     m = MoreStringsModel(
@@ -510,8 +508,6 @@ def test_string_success():
         str_min_length='12345',
         str_curtailed='123456',
         str_email='foobar@example.com  ',
-        str_email_local_case_sensitive='FoObAr@example.com',
-        str_email_global_case_insensitive='foobar@ExAmPle.com',
         name_email='foo bar  <foobaR@example.com>',
     )
     assert m.str_strip_enabled == 'xxx123'
@@ -519,8 +515,6 @@ def test_string_success():
     assert m.str_regex == 'xxx123'
     assert m.str_curtailed == '12345'
     assert m.str_email == 'foobar@example.com'
-    assert m.str_email_local_case_sensitive == 'FoObAr@example.com'
-    assert m.str_email_global_case_insensitive == 'foobar@example.com'
     assert repr(m.name_email) == '<NameEmail("foo bar <foobaR@example.com>")>'
     assert m.name_email.name == 'foo bar'
     assert m.name_email.email == 'foobaR@example.com'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -499,6 +499,8 @@ def test_string_success():
         str_min_length: constr(min_length=5) = ...
         str_curtailed: constr(curtail_length=5) = ...
         str_email: EmailStr = ...
+        str_email_local_case_sensitive: EmailStr = ...
+        str_email_global_case_insensitive: EmailStr = ...
         name_email: NameEmail = ...
 
     m = MoreStringsModel(
@@ -508,6 +510,8 @@ def test_string_success():
         str_min_length='12345',
         str_curtailed='123456',
         str_email='foobar@example.com  ',
+        str_email_local_case_sensitive='FoObAr@example.com',
+        str_email_global_case_insensitive='foobar@ExAmPle.com',
         name_email='foo bar  <foobaR@example.com>',
     )
     assert m.str_strip_enabled == 'xxx123'
@@ -515,6 +519,8 @@ def test_string_success():
     assert m.str_regex == 'xxx123'
     assert m.str_curtailed == '12345'
     assert m.str_email == 'foobar@example.com'
+    assert m.str_email_local_case_sensitive == 'FoObAr@example.com'
+    assert m.str_email_global_case_insensitive == 'foobar@example.com'
     assert repr(m.name_email) == '<NameEmail("foo bar <foobar@example.com>")>'
     assert m.name_email.name == 'foo bar'
     assert m.name_email.email == 'foobar@example.com'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -521,9 +521,9 @@ def test_string_success():
     assert m.str_email == 'foobar@example.com'
     assert m.str_email_local_case_sensitive == 'FoObAr@example.com'
     assert m.str_email_global_case_insensitive == 'foobar@example.com'
-    assert repr(m.name_email) == '<NameEmail("foo bar <foobar@example.com>")>'
+    assert repr(m.name_email) == '<NameEmail("foo bar <foobaR@example.com>")>'
     assert m.name_email.name == 'foo bar'
-    assert m.name_email.email == 'foobar@example.com'
+    assert m.name_email.email == 'foobaR@example.com'
 
 
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')


### PR DESCRIPTION
## Change Summary

Local part of email is now case-sensitive after validation by EmailStr per RFC 5321.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/798

## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
