### PR TITLE
Make the build reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class ReplaceLinks:
         return f'{m.group(1)}`@{name}`_'
 
     def extra(self):
-        return '\n\n' + '\n'.join(self.links) + '\n'
+        return '\n\n' + '\n'.join(sorted(self.links)) + '\n'
 
 
 description = 'Data validation and settings management using python 3.6 type hinting'


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that `pydantic` could not be built reproducibly. This is due to it generating the contents of the `PKG-INFO` file via iterating over the contents of a `set`.

This was originally filed in Debian as [#940156](https://bugs.debian.org/940156).