### PR TITLE
Add support for Type[T] typehints when arbitrary_types_allowed==True.

### DIFF
--- a/changes/807-timonbimon.rst
+++ b/changes/807-timonbimon.rst
@@ -1,1 +1,1 @@
-add support for Type[T] type hints when arbitrary_types_allowd is True
+add support for ``Type[T]`` type hints

--- a/changes/807-timonbimon.rst
+++ b/changes/807-timonbimon.rst
@@ -1,0 +1,1 @@
+add support for Type[T] type hints when arbitrary_types_allowd is True

--- a/docs/examples/bare_type_type.py
+++ b/docs/examples/bare_type_type.py
@@ -1,0 +1,22 @@
+from typing import Type
+
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+class Foo:
+    pass
+
+class LenientSimpleModel(BaseModel):
+    any_class_goes: Type
+
+LenientSimpleModel(any_class_goes=int)
+LenientSimpleModel(any_class_goes=Foo)
+try:
+    LenientSimpleModel(just_subclasses=Foo())
+except ValidationError as e:
+    print(e)
+"""
+1 validation error
+any_class_goes
+  subclass of type expected (type=type_error.class)
+"""

--- a/docs/examples/bare_type_type.py
+++ b/docs/examples/bare_type_type.py
@@ -1,18 +1,20 @@
 from typing import Type
 
-from pydantic import BaseModel
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
 
 class Foo:
     pass
 
+
 class LenientSimpleModel(BaseModel):
     any_class_goes: Type
+
 
 LenientSimpleModel(any_class_goes=int)
 LenientSimpleModel(any_class_goes=Foo)
 try:
-    LenientSimpleModel(just_subclasses=Foo())
+    LenientSimpleModel(any_class_goes=Foo())
 except ValidationError as e:
     print(e)
 """

--- a/docs/examples/type_type.py
+++ b/docs/examples/type_type.py
@@ -1,0 +1,29 @@
+from typing import Type
+
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+class Foo:
+    pass
+
+class Bar(Foo):
+    pass
+
+class Other:
+    pass
+
+class SimpleModel(BaseModel):
+    just_subclasses: Type[Foo]
+
+
+SimpleModel(just_subclasses=Foo)
+SimpleModel(just_subclasses=Bar)
+try:
+    SimpleModel(just_subclasses=Other)
+except ValidationError as e:
+    print(e)
+"""
+1 validation error
+just_subclasses
+  subclass of Foo expected (type=type_error.class)
+"""

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -898,8 +898,8 @@ Options:
 :error_msg_templates: let's you to override default error message templates.
     Pass in a dictionary with keys matching the error messages you want to override (default: ``{}``)
 :arbitrary_types_allowed: whether to allow arbitrary user types for fields (they are validated simply by checking if the
-    value is instance of that type or in the case of a Type[T] type whether the value is a subclass of the user type T).
-    If False - RuntimeError will be raised on model declaration (default: ``False``)
+    value is instance of that type or in the case of a ``Type[T]`` type whether the value is a subclass of the user type ``T``).
+    If ``False`` - ``RuntimeError`` will be raised on model declaration (default: ``False``)
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -820,8 +820,9 @@ With proper ordering in an annotated ``Union``, you can use this to parse types 
 
 Type Type
 ............
+
 Pydantic supports the use of ``Type[T]`` to specify that a field may only accept classes (not instances)
-that are subclasses of T.
+that are subclasses of ``T``.
 
 .. literalinclude:: examples/type_type.py
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -898,7 +898,8 @@ Options:
 :error_msg_templates: let's you to override default error message templates.
     Pass in a dictionary with keys matching the error messages you want to override (default: ``{}``)
 :arbitrary_types_allowed: whether to allow arbitrary user types for fields (they are validated simply by checking if the
-    value is instance of that type). If False - RuntimeError will be raised on model declaration (default: ``False``)
+    value is instance of that type or in the case of a Type[T] type whether the value is a subclass of the user type T).
+    If False - RuntimeError will be raised on model declaration (default: ``False``)
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -898,8 +898,7 @@ Options:
 :error_msg_templates: let's you to override default error message templates.
     Pass in a dictionary with keys matching the error messages you want to override (default: ``{}``)
 :arbitrary_types_allowed: whether to allow arbitrary user types for fields (they are validated simply by checking if the
-    value is instance of that type or in the case of a ``Type[T]`` type whether the value is a subclass of the user type ``T``).
-    If ``False`` - ``RuntimeError`` will be raised on model declaration (default: ``False``)
+    value is instance of that type). If ``False`` - ``RuntimeError`` will be raised on model declaration (default: ``False``)
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -818,6 +818,17 @@ With proper ordering in an annotated ``Union``, you can use this to parse types 
 
 (This script is complete, it should run "as is")
 
+Type Type
+............
+Pydantic supports the use of ``Type[T]`` to specify that a field may only accept classes (not instances)
+that are subclasses of T.
+
+.. literalinclude:: examples/type_type.py
+
+You may also use ``Type`` to specify that any class is allowed.
+
+.. literalinclude:: examples/bare_type_type.py
+
 Custom Data Types
 .................
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -326,7 +326,7 @@ class ArbitraryTypeError(PydanticTypeError):
 
 class ClassError(PydanticTypeError):
     code = 'class'
-    msg_template = 'class expected'
+    msg_template = 'a class is expected'
 
 
 class SubclassError(PydanticTypeError):

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -323,6 +323,7 @@ class ArbitraryTypeError(PydanticTypeError):
     def __init__(self, *, expected_arbitrary_type: AnyType) -> None:
         super().__init__(expected_arbitrary_type=display_as_type(expected_arbitrary_type))
 
+
 class ArbitraryClassError(PydanticTypeError):
     code = 'arbitrary_class'
     msg_template = 'subclass of {expected_arbitrary_class} expected'

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -326,6 +326,11 @@ class ArbitraryTypeError(PydanticTypeError):
 
 class ClassError(PydanticTypeError):
     code = 'class'
+    msg_template = 'class expected'
+
+
+class SubclassError(PydanticTypeError):
+    code = 'subclass'
     msg_template = 'subclass of {expected_class} expected'
 
     def __init__(self, *, expected_class: AnyType) -> None:

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -324,12 +324,12 @@ class ArbitraryTypeError(PydanticTypeError):
         super().__init__(expected_arbitrary_type=display_as_type(expected_arbitrary_type))
 
 
-class ArbitraryClassError(PydanticTypeError):
-    code = 'arbitrary_class'
-    msg_template = 'subclass of {expected_arbitrary_class} expected'
+class ClassError(PydanticTypeError):
+    code = 'class'
+    msg_template = 'subclass of {expected_class} expected'
 
-    def __init__(self, *, expected_arbitrary_class: AnyType) -> None:
-        super().__init__(expected_arbitrary_class=display_as_type(expected_arbitrary_class))
+    def __init__(self, *, expected_class: AnyType) -> None:
+        super().__init__(expected_class=display_as_type(expected_class))
 
 
 class JsonError(PydanticValueError):

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -323,6 +323,13 @@ class ArbitraryTypeError(PydanticTypeError):
     def __init__(self, *, expected_arbitrary_type: AnyType) -> None:
         super().__init__(expected_arbitrary_type=display_as_type(expected_arbitrary_type))
 
+class ArbitraryClassError(PydanticTypeError):
+    code = 'arbitrary_class'
+    msg_template = 'subclass of {expected_arbitrary_class} expected'
+
+    def __init__(self, *, expected_arbitrary_class: AnyType) -> None:
+        super().__init__(expected_arbitrary_class=display_as_type(expected_arbitrary_class))
+
 
 class JsonError(PydanticValueError):
     msg_template = 'Invalid JSON'

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -249,7 +249,7 @@ class Field:
             )
             self.type_ = self.type_.__args__[1]  # type: ignore
             self.shape = SHAPE_MAPPING
-        elif issubclass(origin, Type):
+        elif issubclass(origin, Type):  # type: ignore
             self.type_ = self.type_.__args__[0]  # type: ignore
             self.shape = SHAPE_TYPE
         else:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -273,7 +273,11 @@ class Field:
             get_validators = getattr(self.type_, '__get_validators__', None)
             v_funcs = (
                 *[v.func for v in class_validators_ if not v.whole and v.pre],
-                *(get_validators() if get_validators else list(find_validators(self.type_, self.shape, self.model_config))),
+                *(
+                    get_validators()
+                    if get_validators
+                    else list(find_validators(self.type_, self.shape, self.model_config))
+                ),
                 self.schema is not None and self.schema.const and constant_validator,
                 *[v.func for v in class_validators_ if not v.whole and not v.pre],
             )

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -271,11 +271,7 @@ class Field:
             get_validators = getattr(self.type_, '__get_validators__', None)
             v_funcs = (
                 *[v.func for v in class_validators_ if not v.whole and v.pre],
-                *(
-                    get_validators()
-                    if get_validators
-                    else list(find_validators(self.type_, self.model_config))
-                ),
+                *(get_validators() if get_validators else list(find_validators(self.type_, self.model_config))),
                 self.schema is not None and self.schema.const and constant_validator,
                 *[v.func for v in class_validators_ if not v.whole and not v.pre],
             )

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -54,7 +54,6 @@ SHAPE_TUPLE = 5
 SHAPE_TUPLE_ELLIPS = 6
 SHAPE_SEQUENCE = 7
 SHAPE_FROZENSET = 8
-SHAPE_TYPE = 9
 
 
 class Field:
@@ -250,8 +249,7 @@ class Field:
             self.type_ = self.type_.__args__[1]  # type: ignore
             self.shape = SHAPE_MAPPING
         elif issubclass(origin, Type):  # type: ignore
-            self.type_ = self.type_.__args__[0]  # type: ignore
-            self.shape = SHAPE_TYPE
+            return
         else:
             raise TypeError(f'Fields of type "{origin}" are not supported.')
 
@@ -276,7 +274,7 @@ class Field:
                 *(
                     get_validators()
                     if get_validators
-                    else list(find_validators(self.type_, self.shape, self.model_config))
+                    else list(find_validators(self.type_, self.model_config))
                 ),
                 self.schema is not None and self.schema.const and constant_validator,
                 *[v.func for v in class_validators_ if not v.whole and not v.pre],
@@ -310,7 +308,7 @@ class Field:
             if errors:
                 return v, errors
 
-        if self.shape == SHAPE_SINGLETON or self.shape == SHAPE_TYPE:
+        if self.shape == SHAPE_SINGLETON:
             v, errors = self._validate_singleton(v, values, loc, cls)
         elif self.shape == SHAPE_MAPPING:
             v, errors = self._validate_mapping(v, values, loc, cls)

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -195,7 +195,7 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
             update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
 
 
-def _get_class(type_: AnyType) -> Optional[AnyType]:
+def get_class(type_: AnyType) -> Optional[AnyType]:
     origin = getattr(type_, '__origin__', None)
     if origin is not None and issubclass(origin, Type):  # type: ignore
         return type_.__args__[0]  # type: ignore

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -196,9 +196,18 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
 
 
 def get_class(type_: AnyType) -> Optional[Union[AnyType, bool]]:
-    origin = getattr(type_, '__origin__', None)
-    if origin is not None and issubclass(origin, Type):  # type: ignore
-        if type_.__args__ is None or not isinstance(type_.__args__[0], type):
-            return True
-        return type_.__args__[0]
+    """
+    Tries to get the class of a Type[T] annotation. Returns True if Type is used
+    without brackets. Otherwise returns None.
+    """
+    try:
+        origin = getattr(type_, '__origin__')
+        if origin is None:  # Python 3.6
+            origin = type_
+        if issubclass(origin, Type):  # type: ignore
+            if type_.__args__ is None or not isinstance(type_.__args__[0], type):
+                return True
+            return type_.__args__[0]
+    except AttributeError:
+        pass
     return None

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -195,7 +195,7 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
             update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
 
 
-def _get_class(type_):
+def _get_class(type_: AnyType) -> Optional[AnyType]:
     origin = getattr(type_, '__origin__', None)
     if origin is not None and issubclass(origin, Type):  # type: ignore
         return type_.__args__[0]  # type: ignore

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -16,6 +16,8 @@ from typing import (  # type: ignore
     _eval_type,
 )
 
+import typing
+
 try:
     from typing import _TypingBase as typing_base  # type: ignore
 except ImportError:
@@ -198,4 +200,6 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
 def get_class(type_: AnyType) -> Optional[AnyType]:
     origin = getattr(type_, '__origin__', None)
     if origin is not None and issubclass(origin, Type):  # type: ignore
+        if type_.__args__ is None or type_.__args__[0] == typing.CT_co:
+            return typing.CT_co
         return type_.__args__[0]  # type: ignore

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -193,3 +193,10 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
     if field.sub_fields:
         for sub_f in field.sub_fields:
             update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
+
+
+def _get_class(type_):
+    origin = getattr(type_, '__origin__', None)
+    if origin is not None and issubclass(origin, Type):  # type: ignore
+        return type_.__args__[0]  # type: ignore
+    return None

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -195,7 +195,7 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
             update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
 
 
-def get_class(type_: AnyType) -> Optional[Union[AnyType, bool]]:
+def get_class(type_: AnyType) -> Union[None, bool, AnyType]:
     """
     Tries to get the class of a Type[T] annotation. Returns True if Type is used
     without brackets. Otherwise returns None.

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -1,5 +1,4 @@
 import sys
-import typing
 from enum import Enum
 from typing import (  # type: ignore
     TYPE_CHECKING,
@@ -196,9 +195,10 @@ def update_field_forward_refs(field: 'Field', globalns: Any, localns: Any) -> No
             update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
 
 
-def get_class(type_: AnyType) -> Optional[AnyType]:
+def get_class(type_: AnyType) -> Optional[Union[AnyType, bool]]:
     origin = getattr(type_, '__origin__', None)
     if origin is not None and issubclass(origin, Type):  # type: ignore
-        if type_.__args__ is None or type_.__args__[0] == typing.CT_co:
-            return typing.CT_co
-        return type_.__args__[0]  # type: ignore
+        if type_.__args__ is None or not isinstance(type_.__args__[0], type):
+            return True
+        return type_.__args__[0]
+    return None

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -1,4 +1,5 @@
 import sys
+import typing
 from enum import Enum
 from typing import (  # type: ignore
     TYPE_CHECKING,
@@ -15,8 +16,6 @@ from typing import (  # type: ignore
     Union,
     _eval_type,
 )
-
-import typing
 
 try:
     from typing import _TypingBase as typing_base  # type: ignore

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -24,11 +24,9 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic.typing import get_class
-
 from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
-from .typing import AnyCallable, AnyType, ForwardRef, display_as_type, is_callable_type, is_literal_type
+from .typing import AnyCallable, AnyType, ForwardRef, display_as_type, get_class, is_callable_type, is_literal_type
 from .utils import almost_equal_floats, change_exception, sequence_like
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -400,6 +400,7 @@ def make_arbitrary_type_validator(type_: Type[T]) -> Callable[[T], T]:
         if isinstance(v, type_):
             return v
         raise errors.ArbitraryTypeError(expected_arbitrary_type=type_)
+
     return arbitrary_type_validator
 
 
@@ -408,8 +409,8 @@ def make_arbitrary_class_validator(type_: Type[T]) -> Callable[[T], T]:
         if issubclass(v, type_):
             return v
         raise errors.ArbitraryClassError(expected_arbitrary_class=type_)
-    return arbitrary_class_validator
 
+    return arbitrary_class_validator
 
 
 def pattern_validator(v: Any) -> Pattern[str]:
@@ -529,7 +530,6 @@ def _get_arbitrary_class(type_):
     if origin is not None and issubclass(origin, Type):  # type: ignore
         return type_.__args__[0]  # type: ignore
     return None
-
 
 
 def _find_supertype(type_: AnyType) -> Optional[AnyType]:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -27,7 +27,7 @@ from uuid import UUID
 from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
 from .typing import AnyCallable, AnyType, ForwardRef, display_as_type, get_class, is_callable_type, is_literal_type
-from .utils import almost_equal_floats, change_exception, sequence_like
+from .utils import almost_equal_floats, change_exception, lenient_issubclass, sequence_like
 
 if TYPE_CHECKING:  # pragma: no cover
     from .fields import Field
@@ -406,7 +406,7 @@ def make_arbitrary_type_validator(type_: Type[T]) -> Callable[[T], T]:
 
 def make_class_validator(type_: Type[T]) -> Callable[[Any], Type[T]]:
     def class_validator(v: Any) -> Type[T]:
-        if issubclass(v, type_):
+        if lenient_issubclass(v, type_):
             return v
         raise errors.SubclassError(expected_class=type_)
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -410,18 +410,15 @@ def make_class_validator(type_: Type[T]) -> Callable[[Any], Type[T]]:
     def class_validator(v: Any) -> Type[T]:
         if issubclass(v, type_):
             return v
-        raise errors.ClassError(expected_class=type_)
+        raise errors.SubclassError(expected_class=type_)
 
     return class_validator
 
 
-def make_any_class_validator() -> Callable[[Any], Type[T]]:
-    def any_class_validator(v: Any) -> Type[T]:
-        if isinstance(v, type):
-            return v
-        raise errors.ClassError(expected_class=type)
-
-    return any_class_validator
+def any_class_validator(v: Any) -> Type[T]:
+    if isinstance(v, type):
+        return v
+    raise errors.ClassError()
 
 
 def pattern_validator(v: Any) -> Pattern[str]:
@@ -511,7 +508,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         if isinstance(class_, type):
             yield make_class_validator(class_)
         else:
-            yield make_any_class_validator()
+            yield any_class_validator
         return
 
     supertype = _find_supertype(type_)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -411,6 +411,7 @@ def make_class_validator(type_: Type[T]) -> Callable[[T], T]:
         if issubclass(v, type_):
             return v
         raise errors.ClassError(expected_class=type_)
+
     def any_class_validator(v: Any) -> T:
         if isinstance(v, type):
             return v

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -25,6 +25,7 @@ from typing import (
 from uuid import UUID
 
 from pydantic.typing import _get_class
+
 from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
 from .typing import AnyCallable, AnyType, ForwardRef, display_as_type, is_callable_type, is_literal_type

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -400,11 +400,14 @@ def make_arbitrary_validator(type_: Type[T], shape: int) -> Callable[[T], T]:
         if isinstance(v, type_):
             return v
         raise errors.ArbitraryTypeError(expected_arbitrary_type=type_)
+
     def arbitrary_class_validator(v: Any) -> T:
         if issubclass(v, type_):
             return v
         raise errors.ArbitraryClassError(expected_arbitrary_class=type_)
+
     from .fields import SHAPE_TYPE
+
     if shape == SHAPE_TYPE:
         return arbitrary_class_validator
     return arbitrary_type_validator

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -411,8 +411,14 @@ def make_class_validator(type_: Type[T]) -> Callable[[T], T]:
         if issubclass(v, type_):
             return v
         raise errors.ClassError(expected_class=type_)
+    def any_class_validator(v: Any) -> T:
+        if isinstance(v, type):
+            return v
+        raise errors.ClassError(expected_class=type)
 
-    return class_validator
+    if isinstance(type_, type):
+        return class_validator
+    return any_class_validator
 
 
 def pattern_validator(v: Any) -> Pattern[str]:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -24,7 +24,7 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic.typing import _get_class
+from pydantic.typing import get_class
 
 from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
@@ -497,7 +497,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         yield make_literal_validator(type_)
         return
 
-    class_ = _get_class(type_)
+    class_ = get_class(type_)
     if class_ is not None:
         yield make_class_validator(class_)
         return

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -567,14 +567,7 @@ def test_bare_type_type_validation_fails():
     arbitrary_type = ArbitraryType()
     with pytest.raises(ValidationError) as exc_info:
         ArbitraryClassAllowedModel(t=arbitrary_type)
-    assert exc_info.value.errors() == [
-        {
-            'loc': ('t',),
-            'msg': 'subclass of type expected',
-            'type': 'type_error.class',
-            'ctx': {'expected_class': 'type'},
-        }
-    ]
+    assert exc_info.value.errors() == [{'loc': ('t',), 'msg': 'class expected', 'type': 'type_error.class'}]
 
 
 def test_type_type_validation_fails():
@@ -590,7 +583,7 @@ def test_type_type_validation_fails():
         {
             'loc': ('t',),
             'msg': 'subclass of ArbitraryType expected',
-            'type': 'type_error.class',
+            'type': 'type_error.subclass',
             'ctx': {'expected_class': 'ArbitraryType'},
         }
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -530,7 +530,7 @@ def test_arbitrary_types_not_allowed():
     assert exc_info.value.args[0].startswith('no validator found for')
 
 
-def test_arbitrary_class_allowed_validation_success():
+def test_type_type_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
 
@@ -539,7 +539,7 @@ def test_arbitrary_class_allowed_validation_success():
     assert m.t == arbitrary_type_class
 
 
-def test_arbitrary_subclass_allowed_validation_success():
+def test_type_type_subclass_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
 
@@ -550,8 +550,30 @@ def test_arbitrary_subclass_allowed_validation_success():
     m = ArbitraryClassAllowedModel(t=arbitrary_type_class)
     assert m.t == arbitrary_type_class
 
+def test_bare_type_type_validation_success():
+    class ArbitraryClassAllowedModel(BaseModel):
+        t: Type
+    arbitrary_type_class = ArbitraryType
+    m = ArbitraryClassAllowedModel(t=arbitrary_type_class)
+    assert m.t == arbitrary_type_class
 
-def test_arbitrary_class_allowed_validation_fails():
+def test_bare_type_type_validation_fails():
+    class ArbitraryClassAllowedModel(BaseModel):
+        t: Type
+    arbitrary_type = ArbitraryType()
+    with pytest.raises(ValidationError) as exc_info:
+        ArbitraryClassAllowedModel(t=arbitrary_type)
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('t',),
+            'msg': 'subclass of type expected',
+            'type': 'type_error.class',
+            'ctx': {'expected_class': 'type'},
+        }
+    ]
+
+
+def test_type_type_validation_fails():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -550,16 +550,20 @@ def test_type_type_subclass_validation_success():
     m = ArbitraryClassAllowedModel(t=arbitrary_type_class)
     assert m.t == arbitrary_type_class
 
+
 def test_bare_type_type_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type
+
     arbitrary_type_class = ArbitraryType
     m = ArbitraryClassAllowedModel(t=arbitrary_type_class)
     assert m.t == arbitrary_type_class
 
+
 def test_bare_type_type_validation_fails():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type
+
     arbitrary_type = ArbitraryType()
     with pytest.raises(ValidationError) as exc_info:
         ArbitraryClassAllowedModel(t=arbitrary_type)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -551,6 +551,41 @@ def test_type_type_subclass_validation_success():
     assert m.t == arbitrary_type_class
 
 
+def test_type_type_validation_fails_for_instance():
+    class ArbitraryClassAllowedModel(BaseModel):
+        t: Type[ArbitraryType]
+
+    class C:
+        pass
+
+    with pytest.raises(ValidationError) as exc_info:
+        ArbitraryClassAllowedModel(t=C)
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('t',),
+            'msg': 'subclass of ArbitraryType expected',
+            'type': 'type_error.subclass',
+            'ctx': {'expected_class': 'ArbitraryType'},
+        }
+    ]
+
+
+def test_type_type_validation_fails_for_basic_type():
+    class ArbitraryClassAllowedModel(BaseModel):
+        t: Type[ArbitraryType]
+
+    with pytest.raises(ValidationError) as exc_info:
+        ArbitraryClassAllowedModel(t=1)
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('t',),
+            'msg': 'subclass of ArbitraryType expected',
+            'type': 'type_error.subclass',
+            'ctx': {'expected_class': 'ArbitraryType'},
+        }
+    ]
+
+
 def test_bare_type_type_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type
@@ -568,25 +603,6 @@ def test_bare_type_type_validation_fails():
     with pytest.raises(ValidationError) as exc_info:
         ArbitraryClassAllowedModel(t=arbitrary_type)
     assert exc_info.value.errors() == [{'loc': ('t',), 'msg': 'a class is expected', 'type': 'type_error.class'}]
-
-
-def test_type_type_validation_fails():
-    class ArbitraryClassAllowedModel(BaseModel):
-        t: Type[ArbitraryType]
-
-    class C:
-        pass
-
-    with pytest.raises(ValidationError) as exc_info:
-        ArbitraryClassAllowedModel(t=C)
-    assert exc_info.value.errors() == [
-        {
-            'loc': ('t',),
-            'msg': 'subclass of ArbitraryType expected',
-            'type': 'type_error.subclass',
-            'ctx': {'expected_class': 'ArbitraryType'},
-        }
-    ]
 
 
 def test_annotation_field_name_shadows_attribute():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -534,9 +534,6 @@ def test_arbitrary_class_allowed_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
 
-        class Config:
-            arbitrary_types_allowed = True
-
     arbitrary_type_class = ArbitraryType
     m = ArbitraryClassAllowedModel(t=arbitrary_type_class)
     assert m.t == arbitrary_type_class
@@ -545,9 +542,6 @@ def test_arbitrary_class_allowed_validation_success():
 def test_arbitrary_subclass_allowed_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
-
-        class Config:
-            arbitrary_types_allowed = True
 
     class ArbitrarySubType(ArbitraryType):
         pass
@@ -560,9 +554,6 @@ def test_arbitrary_subclass_allowed_validation_success():
 def test_arbitrary_class_allowed_validation_fails():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
-
-        class Config:
-            arbitrary_types_allowed = True
 
     class C:
         pass
@@ -577,15 +568,6 @@ def test_arbitrary_class_allowed_validation_fails():
             'ctx': {'expected_arbitrary_class': 'ArbitraryType'},
         }
     ]
-
-
-def test_arbitrary_class_not_allowed():
-    with pytest.raises(RuntimeError) as exc_info:
-
-        class ArbitraryClassNotAllowedModel(BaseModel):
-            t: Type[ArbitraryType]
-
-    assert exc_info.value.args[0].startswith('no validator found for')
 
 
 def test_annotation_field_name_shadows_attribute():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -529,6 +529,7 @@ def test_arbitrary_types_not_allowed():
 
     assert exc_info.value.args[0].startswith('no validator found for')
 
+
 def test_arbitrary_class_allowed_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):
         t: Type[ArbitraryType]
@@ -539,6 +540,7 @@ def test_arbitrary_class_allowed_validation_success():
     arbitrary_type_class = ArbitraryType
     m = ArbitraryClassAllowedModel(t=arbitrary_type_class)
     assert m.t == arbitrary_type_class
+
 
 def test_arbitrary_subclass_allowed_validation_success():
     class ArbitraryClassAllowedModel(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -564,8 +564,8 @@ def test_arbitrary_class_allowed_validation_fails():
         {
             'loc': ('t',),
             'msg': 'subclass of ArbitraryType expected',
-            'type': 'type_error.arbitrary_class',
-            'ctx': {'expected_arbitrary_class': 'ArbitraryType'},
+            'type': 'type_error.class',
+            'ctx': {'expected_class': 'ArbitraryType'},
         }
     ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -567,7 +567,7 @@ def test_bare_type_type_validation_fails():
     arbitrary_type = ArbitraryType()
     with pytest.raises(ValidationError) as exc_info:
         ArbitraryClassAllowedModel(t=arbitrary_type)
-    assert exc_info.value.errors() == [{'loc': ('t',), 'msg': 'class expected', 'type': 'type_error.class'}]
+    assert exc_info.value.errors() == [{'loc': ('t',), 'msg': 'a class is expected', 'type': 'type_error.class'}]
 
 
 def test_type_type_validation_fails():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
If arbitrary_types_allowed is True, there is now also support for using Type[T] typehints to validate if the field is a subclass of T.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Should resolve #807 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
=> 99.13% same as it was before
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
