### PR TITLE
Add ability to parse and dump objects as the specified type

### DIFF
--- a/benchmarks/serialize.py
+++ b/benchmarks/serialize.py
@@ -1,0 +1,94 @@
+from contextlib import contextmanager
+import time
+from datetime import datetime
+from typing import List, Dict, Iterator
+
+from pydantic import BaseModel
+
+
+class DoubleNestedModel(BaseModel):
+    number: int
+    message: str
+
+
+class SubDoubleNestedModel(DoubleNestedModel):
+    timestamps: List[datetime]
+
+
+class NestedModel(BaseModel):
+    number: int
+    message: str
+    double_nested: DoubleNestedModel
+
+
+class SubNestedModel(NestedModel):
+    timestamps: List[datetime]
+
+
+class Model(BaseModel):
+    nested: List[Dict[str, NestedModel]]
+
+
+class SubModel(Model):
+    other_nested: Dict[str, List[NestedModel]]
+    timestamps: List[datetime]
+
+
+# "Secure cloned field" -- as currently implemented with FastAPI
+
+class DoubleNestedModel2(BaseModel):
+    number: int
+    message: str
+
+
+class NestedModel2(BaseModel):
+    number: int
+    message: str
+    double_nested: DoubleNestedModel2
+
+
+class Model2(BaseModel):
+    nested: List[Dict[str, NestedModel2]]
+
+
+def get_sub_model() -> SubModel:
+    timestamp = datetime.utcnow()
+    timestamps = [timestamp] * 5
+    sub_double_nested = SubDoubleNestedModel(number=1, message="a", timestamps=timestamps)
+    sub_nested = SubNestedModel(number=2, message="b", double_nested=sub_double_nested, timestamps=timestamps)
+
+    nested = [{letter: sub_nested for letter in 'abcdefg'}]
+    other_nested = {letter: [sub_nested] * 5 for letter in 'abcdefg'}
+    return SubModel(nested=nested, other_nested=other_nested, timestamps=timestamps)
+
+
+@contextmanager
+def basic_profile(label: str) -> Iterator[None]:
+    t0 = time.time()
+    yield
+    t1 = time.time()
+    print(f"{label}: {(t1 - t0):,.3f}s")
+
+
+def run():
+    n_warmup_runs = 1000
+    n_runs = 10000
+    sub_model = get_sub_model()
+
+    for _ in range(n_warmup_runs):
+        sub_model.dict()
+
+    with basic_profile("regular .dict()"):
+        for _ in range(n_runs):
+            sub_model.dict()
+
+    with basic_profile("as_type .dict()"):
+        for _ in range(n_runs):
+            sub_model.dict(as_type=Model)
+
+    with basic_profile("cloned field .dict()"):
+        for _ in range(n_runs):
+            Model2.parse_obj(sub_model).dict()
+
+
+run()

--- a/changes/812-dmontagu.rst
+++ b/changes/812-dmontagu.rst
@@ -1,0 +1,1 @@
+Add ability to parse and dump objects as the specified type

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -8,5 +8,6 @@ from .fields import Field, Required, Schema
 from .main import *
 from .networks import *
 from .parse import Protocol
+from .tools import *
 from .types import *
 from .version import VERSION

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -747,9 +747,7 @@ def _iter(
     as_type: Optional[Type['BaseModel']] = None,
 ) -> 'TupleGenerator':
     if not (include or exclude):
-        yield from _iter_fast(
-            model, to_dict, by_alias, allowed_keys, skip_defaults, as_type
-        )
+        yield from _iter_fast(model, to_dict, by_alias, allowed_keys, skip_defaults, as_type)
         return
     value_exclude = ValueItems(model, exclude) if exclude else None
     value_include = ValueItems(model, include) if include else None
@@ -789,11 +787,7 @@ def _iter_fast(
                 if _requires_casting(v, target_field, self_type.__fields__[k]):
                     casting_type = target_field.type_
             yield k, _get_value_fast(
-                v,
-                to_dict=to_dict,
-                by_alias=by_alias,
-                skip_defaults=skip_defaults,
-                as_type=casting_type,
+                v, to_dict=to_dict, by_alias=by_alias, skip_defaults=skip_defaults, as_type=casting_type
             )
 
 
@@ -815,9 +809,7 @@ def _get_value(
         else:
             return v.copy(include=include, exclude=exclude)
     if not (include or exclude):
-        return _get_value_fast(
-            v, to_dict, by_alias, skip_defaults, as_type
-        )
+        return _get_value_fast(v, to_dict, by_alias, skip_defaults, as_type)
 
     value_exclude = ValueItems(v, exclude) if exclude else None
     value_include = ValueItems(v, include) if include else None
@@ -835,7 +827,7 @@ def _get_value(
             )
             for k_, v_ in v.items()
             if (not value_exclude or not value_exclude.is_excluded(k_))
-               and (not value_include or value_include.is_included(k_))
+            and (not value_include or value_include.is_included(k_))
         }
 
     elif isinstance(v, (list, set, tuple)):
@@ -862,41 +854,23 @@ def _get_value(
 
 @no_type_check
 def _get_value_fast(
-    v: Any,
-    to_dict: bool,
-    by_alias: bool,
-    skip_defaults: bool,
-    as_type: Optional[Type[Any]] = None,
+    v: Any, to_dict: bool, by_alias: bool, skip_defaults: bool, as_type: Optional[Type[Any]] = None
 ) -> Any:
     if isinstance(v, BaseModel):
         if to_dict:
-            return v.dict(
-                by_alias=by_alias, skip_defaults=skip_defaults, as_type=as_type
-            )
+            return v.dict(by_alias=by_alias, skip_defaults=skip_defaults, as_type=as_type)
         else:
             return v.copy()
 
     if isinstance(v, dict):
         return {
-            k_: _get_value_fast(
-                v_,
-                to_dict=to_dict,
-                by_alias=by_alias,
-                skip_defaults=skip_defaults,
-                as_type=as_type,
-            )
+            k_: _get_value_fast(v_, to_dict=to_dict, by_alias=by_alias, skip_defaults=skip_defaults, as_type=as_type)
             for k_, v_ in v.items()
         }
 
     elif isinstance(v, (list, set, tuple)):
         return type(v)(
-            _get_value_fast(
-                v_,
-                to_dict=to_dict,
-                by_alias=by_alias,
-                skip_defaults=skip_defaults,
-                as_type=as_type,
-            )
+            _get_value_fast(v_, to_dict=to_dict, by_alias=by_alias, skip_defaults=skip_defaults, as_type=as_type)
             for i, v_ in enumerate(v)
         )
 

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -1,10 +1,6 @@
 from functools import lru_cache
 from typing import Any, Type, TypeVar
 
-from pydantic.utils import lenient_issubclass
-
-from .fields import ModelField
-
 __all__ = ('parse_as_type', 'dump_as_type')
 
 
@@ -29,13 +25,3 @@ def dump_as_type(obj: T, type_: Type[T]) -> Any:
     model = model_type(obj=obj)
     model_dict = model.dict(as_type=model_type)
     return model_dict['obj']
-
-
-def requires_casting(obj: Any, old_field: ModelField, new_field: ModelField) -> bool:
-    from pydantic.main import BaseModel
-
-    if old_field.type_ != new_field.type_:
-        return True
-    if lenient_issubclass(old_field.type_, BaseModel):
-        return type(obj) != old_field.type_
-    return False

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -3,7 +3,7 @@ from typing import Any, Type, TypeVar
 
 from pydantic.utils import lenient_issubclass
 
-from .fields import Field
+from .fields import ModelField
 
 __all__ = ('parse_as_type', 'dump_as_type')
 
@@ -31,7 +31,7 @@ def dump_as_type(obj: T, type_: Type[T]) -> Any:
     return model_dict['obj']
 
 
-def requires_casting(obj: Any, old_field: Field, new_field: Field) -> bool:
+def requires_casting(obj: Any, old_field: ModelField, new_field: ModelField) -> bool:
     from pydantic.main import BaseModel
 
     if old_field.type_ != new_field.type_:

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -1,0 +1,41 @@
+from functools import lru_cache
+from typing import Any, Type, TypeVar
+
+from pydantic.utils import lenient_issubclass
+
+from .fields import Field
+
+__all__ = ('parse_as_type', 'dump_as_type')
+
+
+@lru_cache(maxsize=None)
+def _get_parsing_type(type_: Any, source: str) -> Any:
+    from pydantic.main import create_model
+
+    type_name = getattr(type_, '__name__', str(type_))
+    return create_model(f'ParsingModel[{type_name}] (for {source})', obj=(type_, ...))
+
+
+T = TypeVar('T')
+
+
+def parse_as_type(obj: Any, type_: Type[T]) -> T:
+    model_type = _get_parsing_type(type_, source=parse_as_type.__name__)
+    return model_type(obj=obj).obj
+
+
+def dump_as_type(obj: T, type_: Type[T]) -> Any:
+    model_type = _get_parsing_type(type_, source=dump_as_type.__name__)
+    model = model_type(obj=obj)
+    model_dict = model.dict(as_type=model_type)
+    return model_dict['obj']
+
+
+def requires_casting(obj: Any, old_field: Field, new_field: Field) -> bool:
+    from pydantic.main import BaseModel
+
+    if old_field.type_ != new_field.type_:
+        return True
+    if lenient_issubclass(old_field.type_, BaseModel):
+        return type(obj) != old_field.type_
+    return False

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,109 @@
+from typing import Dict, List, Mapping
+
+import pytest
+
+from pydantic import BaseModel, ValidationError, dump_as_type, parse_as_type
+
+
+def test_parse_as_type():
+    class ModelA(BaseModel):
+        a: Mapping[int, str]
+
+    class ModelB(ModelA):
+        b: int
+
+    model_b = ModelB(a={1: 'f'}, b=2)
+
+    parsed = parse_as_type([model_b], List[ModelA])
+    assert parsed == [model_b]
+
+
+def test_dump_as_type():
+    class SubmodelA(BaseModel):
+        a: int
+
+    class SubmodelB(SubmodelA):
+        b: int
+
+    class ModelA(BaseModel):
+        int1: int
+        a: SubmodelA
+        list_a: List[SubmodelA]
+        map_a: Dict[str, SubmodelA]
+
+        submodel_list: List[SubmodelA]
+        submodel_map: Mapping[int, SubmodelA]
+
+    class ModelB(ModelA):
+        int2: int
+
+        b: SubmodelB
+        list_b: List[SubmodelB]
+        map_b: Dict[str, SubmodelB]
+
+        submodel_list: List[SubmodelB]
+        submodel_map: Mapping[int, SubmodelB]
+
+    submodel_a = SubmodelA(a=1)
+    submodel_b = SubmodelB(a=1, b=2)
+
+    model_b = ModelB(
+        int1=1,
+        int2=2,
+        a=submodel_a,
+        list_a=[submodel_a],
+        map_a={'a': submodel_a},
+        b=submodel_b,
+        list_b=[submodel_b],
+        map_b={'b': submodel_b},
+        submodel_list=[submodel_b],
+        submodel_map={1: submodel_b},
+    )
+
+    expected_dumped_model = {
+        'a': {'a': 1},
+        'int1': 1,
+        'list_a': [{'a': 1}],
+        'map_a': {'a': {'a': 1}},
+        'submodel_list': [{'a': 1}],
+        'submodel_map': {1: {'a': 1}},
+    }
+
+    dumped_model = dump_as_type(model_b, ModelA)
+    assert dumped_model == expected_dumped_model
+
+    dumped_map = dump_as_type({1: model_b}, Dict[int, ModelA])
+    assert dumped_map == {1: expected_dumped_model}
+
+    dumped_list = dump_as_type([model_b], List[ModelA])
+    assert dumped_list == [expected_dumped_model]
+
+
+def test_dump_as_type_fails():
+    class Model(BaseModel):
+        x: int
+
+    class SubModel(BaseModel):
+        x: str
+
+    submodel = SubModel(x='a')
+
+    with pytest.raises(ValidationError) as exc_info:
+        dump_as_type(submodel, Model)
+    assert exc_info.value.errors() == [
+        {'loc': ('obj', 'x'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+    ]
+    assert exc_info.value.model.__name__ == 'ParsingModel[Model] (for dump_as_type)'
+
+
+def test_parse_as_type_succeeds():
+    assert parse_as_type('1', int) == 1
+
+
+def test_parse_as_type_fails():
+    with pytest.raises(ValidationError) as exc_info:
+        parse_as_type('a', int)
+    assert exc_info.value.errors() == [
+        {'loc': ('obj',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+    ]
+    assert exc_info.value.model.__name__ == 'ParsingModel[int] (for parse_as_type)'


### PR DESCRIPTION
## Change Summary

Adds the capability to parse and dump objects as a specified type.

This can be useful for the sake of dumping a model as though it were one of its superclasses in order to prevent inclusion of subfields, and works even with generic containers.

## Related issue number

#811 (see that issue for more discussion/motivation)

## Checklist

Although the tests currently pass with full coverage, I haven't thought about or added appropriate error messages in casing parsing/dumping fails, (and obviously haven't added any tests for those error messages).

Also, I'm aware that the current tests don't do a good job of stress-testing the capability; I'll add more once I get feedback about whether this might have a chance at getting merged.

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
