### PR TITLE
improvements to 'from_orm' to work better with root validators

### DIFF
--- a/changes/821-samuelcolvin.rst
+++ b/changes/821-samuelcolvin.rst
@@ -1,0 +1,1 @@
+allow ``getter_dict`` on ``Config`` improve ``GetterDict`` to be easier to work with

--- a/changes/821-samuelcolvin.rst
+++ b/changes/821-samuelcolvin.rst
@@ -1,1 +1,2 @@
-allow ``getter_dict`` on ``Config`` improve ``GetterDict`` to be easier to work with
+allow ``getter_dict`` on ``Config``, modify ``GetterDict`` to be a proper ``Mapping`` object adn thus easier to work
+with.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -975,11 +975,12 @@ Options:
 :json_encoders: customise the way types are encoded to json, see :ref:`JSON Serialisation <json_dump>` for more
     details.
 :orm_mode: allows usage of :ref:`ORM mode <orm_mode>`
+:getter_dict: custom class (should inherit from ``GetterDict``) to use when decomposing ORM classes for validation,
+  use with ``orm_mode``
 :alias_generator: callable that takes field name and returns alias for it
 :keep_untouched: tuple of types (e. g. descriptors) that won't change during model creation and won't be
   included in the model schemas.
 :schema_extra: takes a ``dict`` to extend/update the generated JSON Schema
-:getter_dict: custom class (should inherit from ``GetterDict``) to use when decomposing ORM classes for validation
 
 .. warning::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -393,9 +393,9 @@ Here a vanilla class is used to demonstrate the principle, but any ORM could be 
 
 (This script is complete, it should run "as is")
 
-Arbitrary classes are processed by *pydantic* using the ``GetterDict``
-(see `utils.py <https://github.com/samuelcolvin/pydantic/blob/master/pydantic/utils.py>`__) class which attempts to
-provide a "dictionary-like" interface to any class. You can customise how this works by setting your own
+Arbitrary classes are processed by *pydantic* using the ``GetterDict`` class
+(see `utils.py <https://github.com/samuelcolvin/pydantic/blob/master/pydantic/utils.py>`__) which attempts to
+provide a dictionary-like interface to any class. You can customise how this works by setting your own
 sub-class of ``GetterDict`` in ``Config.getter_dict`` (see :ref:`config <config>`).
 
 You can also customise class validation using :ref:`root_validators <root_validators>` with ``pre=True``, in this case

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -257,6 +257,8 @@ to set a dynamic default value.
 You'll often want to use this together with ``pre`` since otherwise with ``always=True``
 *pydantic* would try to validate the default ``None`` which would cause an error.
 
+.. _root_validators:
+
 Root Validators
 ~~~~~~~~~~~~~~~
 
@@ -390,6 +392,14 @@ Here a vanilla class is used to demonstrate the principle, but any ORM could be 
 .. literalinclude:: examples/orm_mode_recursive.py
 
 (This script is complete, it should run "as is")
+
+Arbitrary classes are processed by *pydantic* using the ``GetterDict``
+(see `utils.py <https://github.com/samuelcolvin/pydantic/blob/master/pydantic/utils.py>`__) class which attempts to
+provide a "dictionary-like" interface to any class. You can customise how this works by setting your own
+sub-class of ``GetterDict`` in ``Config.getter_dict`` (see :ref:`config <config>`).
+
+You can also customise class validation using :ref:`root_validators <root_validators>` with ``pre=True``, in this case
+your validator function will be passed a ``GetterDict`` instance which you may copy and modify.
 
 .. _schema:
 
@@ -969,6 +979,7 @@ Options:
 :keep_untouched: tuple of types (e. g. descriptors) that won't change during model creation and won't be
   included in the model schemas.
 :schema_extra: takes a ``dict`` to extend/update the generated JSON Schema
+:getter_dict: custom class (should inherit from ``GetterDict``) to use when decomposing ORM classes for validation
 
 .. warning::
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -65,10 +65,10 @@ class BaseConfig:
     arbitrary_types_allowed = False
     json_encoders: Dict[AnyType, AnyCallable] = {}
     orm_mode: bool = False
+    getter_dict: Type[GetterDict] = GetterDict
     alias_generator: Optional[Callable[[str], str]] = None
     keep_untouched: Tuple[type, ...] = ()
     schema_extra: Dict[str, Any] = {}
-    getter_dict: Type[GetterDict] = GetterDict
 
     @classmethod
     def get_field_schema(cls, name: str) -> Dict[str, str]:

--- a/tests/test_orm_mode.py
+++ b/tests/test_orm_mode.py
@@ -34,8 +34,12 @@ def test_getdict():
     assert gd.get('d', None) == 4
     assert gd.get('e', None) == 5
     assert gd.get('f', 'missing') == 'missing'
+    assert list(gd.values()) == [1, 3, 4]
+    assert list(gd.items()) == [('a', 1), ('c', 3), ('d', 4)]
     assert list(gd) == ['a', 'c', 'd']
-    assert gd.as_dict() == {'a': 1, 'd': 4, 'c': 3}
+    assert gd.as_dict() == {'a': 1, 'c': 3, 'd': 4}
+    assert gd == {'a': 1, 'c': 3, 'd': 4}
+    assert 'a' in gd
     assert len(gd) == 3
     assert str(gd) == "<GetterDict(TestCls) {'a': 1, 'c': 3, 'd': 4}>"
 


### PR DESCRIPTION
Fix #821

## Change Summary

* add `getter_dict` to `Config`
* modify `GetterDict` to be a proper ``Mapping`` object and thus easier to work with
* add tests demonstrating usage of `getter_dict` and `root_validator(pre=True)` for ORM decomposition

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
