### PR TITLE
Support use of TypeVar on generic subclasses

### DIFF
--- a/changes/842-zpencerq.rst
+++ b/changes/842-zpencerq.rst
@@ -1,1 +1,1 @@
-only check TypeVar param on base GenericModel class
+Only check ``TypeVar`` param on base ``GenericModel`` class

--- a/changes/842-zpencerq.rst
+++ b/changes/842-zpencerq.rst
@@ -1,0 +1,1 @@
+only check TypeVar param on base GenericModel class

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -27,7 +27,7 @@ class GenericModel(BaseModel):
             raise TypeError('Cannot parameterize a concrete instantiation of a generic model')
         if not isinstance(params, tuple):
             params = (params,)
-        if any(isinstance(param, TypeVar) for param in params):  # type: ignore
+        if cls == GenericModel and any(isinstance(param, TypeVar) for param in params):  # type: ignore
             raise TypeError(f'Type parameters should be placed on typing.Generic, not GenericModel')
         if Generic not in cls.__bases__:
             raise TypeError(f'Type {cls.__name__} must inherit from typing.Generic before being parameterized')

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -27,7 +27,7 @@ class GenericModel(BaseModel):
             raise TypeError('Cannot parameterize a concrete instantiation of a generic model')
         if not isinstance(params, tuple):
             params = (params,)
-        if cls == GenericModel and any(isinstance(param, TypeVar) for param in params):  # type: ignore
+        if cls is GenericModel and any(isinstance(param, TypeVar) for param in params):  # type: ignore
             raise TypeError(f'Type parameters should be placed on typing.Generic, not GenericModel')
         if Generic not in cls.__bases__:
             raise TypeError(f'Type {cls.__name__} must inherit from typing.Generic before being parameterized')

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -177,6 +177,7 @@ def test_parameters_must_be_typevar():
 @skip_36
 def test_subclass_can_be_genericized():
     T = TypeVar('T')
+
     class Result(GenericModel, Generic[T]):
         pass
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -175,6 +175,15 @@ def test_parameters_must_be_typevar():
 
 
 @skip_36
+def test_subclass_can_be_genericized():
+    T = TypeVar('T')
+    class Result(GenericModel, Generic[T]):
+        pass
+
+    Result[T]
+
+
+@skip_36
 def test_parameter_count():
     T = TypeVar('T')
     S = TypeVar('S')


### PR DESCRIPTION
This change was originally introduced to support generic functions on generic types defined for `pydantic`.

Notably, passing a `TypeVar` on a `GenericModel` subclass raises a `TypeError` (presumably?) meant for assisting users in defining their generic model classes. 

Example:
```python
import typing
from pydantic.generics import GenericModel

T = typing.TypeVar('T')
R = typing.TypeVar('R')

class Model(GenericModel, typing.Generic[T]):
  items: typing.List[T]

# Next line raises: 
# TypeError: Type parameters should be placed on typing.Generic, not GenericModel
def convert(model: Model[T], mapper: typing.Callable[[T], R]) -> Model[R]: 
  return Model[R](items=list([mapper(item) for item in model.items]))
```

## Change Summary

* Allow use of `TypeVar` on `GenericModel` subclasses.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
