### PR TITLE
Fix for example with datetime JSON encoder

### DIFF
--- a/docs/examples/export_json.py
+++ b/docs/examples/export_json.py
@@ -20,7 +20,7 @@ class WithCustomEncoders(BaseModel):
 
     class Config:
         json_encoders = {
-            datetime: lambda v: (v - datetime(1970, 1, 1)).total_seconds(),
+            datetime: lambda v: v.timestamp(),
             timedelta: timedelta_isoformat,
         }
 


### PR DESCRIPTION
## Change Summary
Using canonical method to convert datetime to UNIX timestamp that works both for naive and tz-aware datetime objects. The current example, while working, will break if tz-aware datetime object is provided. I think it worth for examples to provide best-practices for already convoluted subject such as dates/tz.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
