### PR TITLE
change how env variables work with settings

### DIFF
--- a/changes/847-samuelcolvin.rst
+++ b/changes/847-samuelcolvin.rst
@@ -1,0 +1,2 @@
+**Breaking Change:** ``BaseSettings`` now uses the special ``env`` settings to define which environment variables to
+read, not aliases.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1025,23 +1025,35 @@ environment variables or keyword arguments (e.g. in unit tests).
 
 (This script is complete, it should run "as is")
 
-Here ``redis_port`` could be modified via ``export MY_PREFIX_REDIS_PORT=6380`` or ``auth_key`` by
-``export my_api_key=6380``. By default, environment variables are treated as case-insensitive, so
-``export my_prefix_redis_port=6380`` would work as well.
-(Aliases are always sensitive to case, so ``export MY_API_KEY=6380`` would not work.)
+The following rules apply when finding and interpreting environment variables:
+
+* When no custom environment variable name(s) are given, the environment variable name is built using the field
+  name and prefix, eg to override ``special_function`` use ``export my_prefix_special_function='foo.bar'``, the default
+  prefix is an empty string. aliases are ignored for building the environment variable name.
+* Custom environment variable names can be set using with ``Config.fields.[field name].env`` or ``Field(..., env=...)``,
+  in the above example ``auth_key`` and ``api_key``'s environment variable setups are the equivalent.
+* In these cases ``env`` can either be a string or a list of strings. When a list of strings order is important:
+  in the case of ``redis_dsn`` ``service_redis_dsn`` would take precedence over ``redis_url``.
+
+.. warning::
+
+   Since V1 *pydantic* does not consider field aliases when finding environment variables to populate settings
+   models, use ``env`` instead as described above.
+
+   To aid the transition from aliases to ``env``, a warning will be raised when aliases are used on settings models
+   without a custom env var name. If you really mean to use aliases, either ignore the warning or set ``env`` to
+   suppress it.
 
 By default ``BaseSettings`` considers field values in the following priority (where 3. has the highest priority
 and overrides the other two):
 
 1. The default values set in your ``Settings`` class.
-2. Environment variables, e.g. ``MY_PREFIX_REDIS_PORT`` as described above.
+2. Environment variables, e.g. ``my_prefix_special_function`` as described above.
 3. Arguments passed to the ``Settings`` class on initialisation.
 
-This behaviour can be changed by overriding the ``_build_values`` method on ``BaseSettings``.
+Complex types like ``list``, ``set``, ``dict`` and sub-models can be set by using JSON environment variables.
 
-Complex types like ``list``, ``set``, ``dict`` and submodels can be set by using JSON environment variables.
-
-Case-sensitivity can be turned on through the ``Config``:
+Case-sensitivity can be turned on through ``Config``:
 
 .. literalinclude:: examples/settings_case_sensitive.py
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1004,9 +1004,6 @@ Version for models based on ``@dataclass`` decorator:
 
 (This script is complete, it should run "as is")
 
-.. _settings:
-
-
 Alias Generator
 ~~~~~~~~~~~~~~~
 If data source field names do not match your code style (e. g. CamelCase fields),
@@ -1016,6 +1013,7 @@ you can automatically generate aliases using ``alias_generator``:
 
 (This script is complete, it should run "as is")
 
+.. _settings:
 
 Settings
 ........

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,7 +1,9 @@
 import os
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Iterable, Optional, cast
 
+from .fields import ModelField
 from .main import BaseModel, Extra
+from .typing import display_as_type
 
 
 class SettingsError(ValueError):
@@ -35,21 +37,25 @@ class BaseSettings(BaseModel):
             env_vars = {k.lower(): v for k, v in os.environ.items()}
 
         for field in self.__fields__.values():
-            if field.has_alias:
-                env_name = field.alias
-            else:
-                env_name = self.__config__.env_prefix + field.name.upper()
+            env_val: Optional[str] = None
+            for env_name in field.field_info.extra['env_names']:  # type: ignore
+                env_name_ = env_name if self.__config__.case_sensitive else env_name.lower()
+                try:
+                    env_val = env_vars[env_name_]
+                except KeyError:
+                    pass
+                else:
+                    break
 
-            env_name_ = env_name if self.__config__.case_sensitive else env_name.lower()
-            env_val = env_vars.get(env_name_, None)
+            if env_val is None:
+                continue
 
-            if env_val:
-                if field.is_complex():
-                    try:
-                        env_val = self.__config__.json_loads(env_val)  # type: ignore
-                    except ValueError as e:
-                        raise SettingsError(f'error parsing JSON for "{env_name}"') from e
-                d[field.alias] = env_val
+            if field.is_complex():
+                try:
+                    env_val = self.__config__.json_loads(env_val)  # type: ignore
+                except ValueError as e:
+                    raise SettingsError(f'error parsing JSON for "{env_name}"') from e
+            d[field.alias] = env_val
         return d
 
     class Config:
@@ -58,5 +64,23 @@ class BaseSettings(BaseModel):
         extra = Extra.forbid
         arbitrary_types_allowed = True
         case_sensitive = False
+
+        @classmethod
+        def prepare_field(cls, field: ModelField) -> None:
+            if not field.field_info:
+                return
+
+            env_names: Iterable[str]
+            env = field.field_info.extra.pop('env', None)
+            if isinstance(env, str):
+                env_names = {env}
+            elif isinstance(env, (list, set, tuple)):
+                env_names = env
+            elif env is not None:
+                raise TypeError(f'invalid field env: {env!r} ({display_as_type(env)}); should be string, list or set')
+            else:
+                env_names = [cls.env_prefix + field.name]
+
+            field.field_info.extra['env_names'] = env_names
 
     __config__: Config  # type: ignore

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Any, Dict, Iterable, Optional, cast
 
 from .fields import ModelField
@@ -72,14 +73,20 @@ class BaseSettings(BaseModel):
 
             env_names: Iterable[str]
             env = field.field_info.extra.pop('env', None)
-            if isinstance(env, str):
+            if env is None:
+                if field.has_alias:
+                    warnings.warn(
+                        'aliases are no longer used by BaseSettings to define which environment variables to read. '
+                        'Instead use the "env" field setting. See https://pydantic-docs.helpmanual.io/#settings',
+                        DeprecationWarning,
+                    )
+                env_names = [cls.env_prefix + field.name]
+            elif isinstance(env, str):
                 env_names = {env}
             elif isinstance(env, (list, set, tuple)):
                 env_names = env
-            elif env is not None:
-                raise TypeError(f'invalid field env: {env!r} ({display_as_type(env)}); should be string, list or set')
             else:
-                env_names = [cls.env_prefix + field.name]
+                raise TypeError(f'invalid field env: {env!r} ({display_as_type(env)}); should be string, list or set')
 
             field.field_info.extra['env_names'] = env_names
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -229,6 +229,7 @@ class ModelField:
         self.post_validators: Optional['ValidatorsList'] = None
         self.parse_json: bool = False
         self.shape: int = SHAPE_SINGLETON
+        self.model_config.prepare_field(self)
         self.prepare()
 
     @classmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -73,7 +73,7 @@ class BaseConfig:
     json_encoders: Dict[AnyType, AnyCallable] = {}
 
     @classmethod
-    def get_field_info(cls, name: str) -> Dict[str, str]:
+    def get_field_info(cls, name: str) -> Dict[str, Any]:
         field_info = cls.fields.get(name) or {}
         if isinstance(field_info, str):
             field_info = {'alias': field_info}
@@ -83,6 +83,13 @@ class BaseConfig:
                 raise TypeError(f'Config.alias_generator must return str, not {type(alias)}')
             field_info['alias'] = alias
         return field_info
+
+    @classmethod
+    def prepare_field(cls, field: 'ModelField') -> None:
+        """
+        Optional hook to check or modify fields during model creation.
+        """
+        pass
 
 
 def inherit_config(self_config: 'ConfigType', parent_config: 'ConfigType') -> 'ConfigType':

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,19 +10,15 @@ from pydantic.env_settings import SettingsError
 class SimpleSettings(BaseSettings):
     apple: str
 
-    class Config:
-        env_prefix = 'APP_'
-        case_sensitive = True
-
 
 def test_sub_env(env):
-    env.set('APP_APPLE', 'hello')
+    env.set('apple', 'hello')
     s = SimpleSettings()
     assert s.apple == 'hello'
 
 
 def test_sub_env_override(env):
-    env.set('APP_APPLE', 'hello')
+    env.set('apple', 'hello')
     s = SimpleSettings(apple='goodbye')
     assert s.apple == 'goodbye'
 
@@ -33,20 +29,23 @@ def test_sub_env_missing():
     assert exc_info.value.errors() == [{'loc': ('apple',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
-def test_other_setting(env):
+def test_other_setting():
     with pytest.raises(ValidationError):
         SimpleSettings(apple='a', foobar=42)
 
 
-def test_env_with_aliass(env):
+def test_with_prefix(env):
     class Settings(BaseSettings):
-        apple: str = ...
+        apple: str
 
         class Config:
-            fields = {'apple': 'BOOM'}
+            env_prefix = 'foobar_'
 
-    env.set('BOOM', 'hello')
-    assert Settings().apple == 'hello'
+    with pytest.raises(ValidationError):
+        Settings()
+    env.set('foobar_apple', 'has_prefix')
+    s = Settings()
+    assert s.apple == 'has_prefix'
 
 
 class DateModel(BaseModel):
@@ -59,22 +58,18 @@ class ComplexSettings(BaseSettings):
     carrots: dict = {}
     date: DateModel = DateModel()
 
-    class Config:
-        env_prefix = 'APP_'
-        case_sensitive = True
-
 
 def test_list(env):
-    env.set('APP_APPLES', '["russet", "granny smith"]')
+    env.set('apples', '["russet", "granny smith"]')
     s = ComplexSettings()
     assert s.apples == ['russet', 'granny smith']
     assert s.date.pips is False
 
 
 def test_set_dict_model(env):
-    env.set('APP_BANANAS', '[1, 2, 3, 3]')
-    env.set('APP_CARROTS', '{"a": null, "b": 4}')
-    env.set('APP_DATE', '{"pips": true}')
+    env.set('bananas', '[1, 2, 3, 3]')
+    env.set('CARROTS', '{"a": null, "b": 4}')
+    env.set('daTE', '{"pips": true}')
     s = ComplexSettings()
     assert s.bananas == {1, 2, 3}
     assert s.carrots == {'a': None, 'b': 4}
@@ -82,8 +77,8 @@ def test_set_dict_model(env):
 
 
 def test_invalid_json(env):
-    env.set('APP_APPLES', '["russet", "granny smith",]')
-    with pytest.raises(SettingsError):
+    env.set('apples', '["russet", "granny smith",]')
+    with pytest.raises(SettingsError, match='error parsing JSON for "apples"'):
         ComplexSettings()
 
 
@@ -107,37 +102,84 @@ def test_non_class(env):
     assert s.foobar == 'xxx'
 
 
-def test_alias_matches_name(env):
+def test_env_str(env):
+    class Settings(BaseSettings):
+        apple: str = ...
+
+        class Config:
+            fields = {'apple': {'env': 'BOOM'}}
+
+    env.set('BOOM', 'hello')
+    assert Settings().apple == 'hello'
+
+
+def test_env_list(env):
     class Settings(BaseSettings):
         foobar: str
 
         class Config:
-            fields = {'foobar': 'foobar'}
+            fields = {'foobar': {'env': ['different1', 'different2']}}
 
-    env.set('foobar', 'xxx')
+    env.set('different1', 'value 1')
+    env.set('different2', 'value 2')
     s = Settings()
-    assert s.foobar == 'xxx'
+    assert s.foobar == 'value 1'
 
 
-def test_case_insensitive(env):
+def test_env_list_field(env):
     class Settings(BaseSettings):
-        foo: str
-        bAR: str
+        foobar: str = Field(..., env='foobar_env_name')
+
+    env.set('FOOBAR_ENV_NAME', 'env value')
+    s = Settings()
+    assert s.foobar == 'env value'
+
+
+def test_env_list_last(env):
+    class Settings(BaseSettings):
+        foobar: str
 
         class Config:
-            env_prefix = 'APP_'
-            case_sensitive = False
+            fields = {'foobar': {'env': ['different2']}}
 
-    env.set('apP_foO', 'foo')
-    env.set('app_bar', 'bar')
+    env.set('different1', 'value 1')
+    env.set('different2', 'value 2')
     s = Settings()
-    assert s.foo == 'foo'
-    assert s.bAR == 'bar'
+    assert s.foobar == 'value 2'
+
+
+def test_env_invalid(env):
+    with pytest.raises(TypeError, match=r'invalid field env: 123 \(int\); should be string, list or set'):
+
+        class Settings(BaseSettings):
+            foobar: str
+
+            class Config:
+                fields = {'foobar': {'env': 123}}
+
+
+def test_env_field(env):
+    with pytest.raises(TypeError, match=r'invalid field env: 123 \(int\); should be string, list or set'):
+
+        class Settings(BaseSettings):
+            foobar: str = Field(..., env=123)
+
+
+def test_aliases_no_effect(env):
+    class Settings(BaseSettings):
+        foobar: str = 'default value'
+
+        class Config:
+            fields = {'foobar': 'different'}
+
+    env.set('different', 'xxx')
+    s = Settings()
+    assert s.foobar == 'default value'
 
 
 def test_case_sensitive(monkeypatch):
     class Settings(BaseSettings):
-        foo: str = Field(..., alias='foo')
+        foo: str
 
         class Config:
             case_sensitive = True
@@ -165,7 +207,7 @@ def test_nested_dataclass(env):
     assert s.n.bar == 'bar value'
 
 
-def test_config_file_settings(env):
+def test_env_takes_precedence(env):
     class Settings(BaseSettings):
         foo: int
         bar: str


### PR DESCRIPTION
## Change Summary

* add `prepare_field` hook on `Config`
* use `env` not aliases to define which environment variable(s) settings respects

## Related issue number

#721

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
