### PR TITLE
Extend dataclass doc

### DIFF
--- a/changes/710-maddosaurus.rst
+++ b/changes/710-maddosaurus.rst
@@ -1,0 +1,1 @@
+Update documentation to specify the use of ``pydantic.dataclasses.dataclass`` and subclassing ``pydantic.BaseModel``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,6 +136,13 @@ Dataclasses work in python 3.6 using the `dataclasses backport package <https://
 
 (This script is complete, it should run "as is")
 
+.. note::
+
+   Keep in mind that ``pydantic.dataclasses.dataclass`` is a drop in replacement for ``dataclasses.dataclass``
+   with validation, not a repacement for ``pydantic.BaseModel``. There are cases where subclassing
+   ``pydantic.BaseModel`` is the better choice. For more information and disucssion see
+   `samuelcolvin/pydantic#6239 <https://github.com/samuelcolvin/pydantic/issues/710>`_.
+
 You can use all the standard pydantic field types and the resulting dataclass will be identical to the one
 created by the standard library ``dataclass`` decorator.
 


### PR DESCRIPTION
## Change Summary

Update documentation regarding the use of `dataclasses` vs subclassing `BaseModel`.  

After consulting the documentation, I ran into the same issue as SethMMorton and found the according issue. As other people might profit from the documentation update, I prepared a PR to introduce a note detailing the problem.

## Related issue number

#710 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
