### PR TITLE
Add Path to  ENCODERS_BY_TYPE

### DIFF
--- a/changes/849-stratosgear.rst
+++ b/changes/849-stratosgear.rst
@@ -1,0 +1,1 @@
+Add Path to ``ENCODERS_BY_TYPE`` for proper model serialization

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from pydantic.color import Color
 from pydantic.types import SecretBytes, SecretStr
 
-__all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
+__all__ = "pydantic_encoder", "custom_pydantic_encoder", "timedelta_isoformat"
 
 
 def isoformat(o: Union[datetime.date, datetime.time]) -> str:
@@ -38,6 +38,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     GeneratorType: list,
     bytes: lambda o: o.decode(),
     Decimal: float,
+    Path: str,
 }
 
 
@@ -75,4 +76,4 @@ def timedelta_isoformat(td: datetime.timedelta) -> str:
     """
     minutes, seconds = divmod(td.seconds, 60)
     hours, minutes = divmod(minutes, 60)
-    return f'P{td.days}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'
+    return f"P{td.days}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -19,45 +19,46 @@ from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr
 
 
 class MyEnum(Enum):
-    foo = 'bar'
-    snap = 'crackle'
+    foo = "bar"
+    snap = "crackle"
 
 
 @pytest.mark.parametrize(
-    'input,output',
+    "input,output",
     [
-        (UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8'), '"ebcdab58-6eb8-46fb-a190-d07a33e9eac8"'),
-        (IPv4Address('192.168.0.1'), '"192.168.0.1"'),
-        (Color('#000'), '"black"'),
+        (UUID("ebcdab58-6eb8-46fb-a190-d07a33e9eac8"), '"ebcdab58-6eb8-46fb-a190-d07a33e9eac8"'),
+        (IPv4Address("192.168.0.1"), '"192.168.0.1"'),
+        (Color("#000"), '"black"'),
         (Color((1, 12, 123)), '"#010c7b"'),
-        (SecretStr('abcd'), '"**********"'),
-        (SecretStr(''), '""'),
-        (SecretBytes(b'xyz'), '"**********"'),
-        (SecretBytes(b''), '""'),
-        (IPv6Address('::1:0:1'), '"::1:0:1"'),
-        (IPv4Interface('192.168.0.0/24'), '"192.168.0.0/24"'),
-        (IPv6Interface('2001:db00::/120'), '"2001:db00::/120"'),
-        (IPv4Network('192.168.0.0/24'), '"192.168.0.0/24"'),
-        (IPv6Network('2001:db00::/120'), '"2001:db00::/120"'),
+        (SecretStr("abcd"), '"**********"'),
+        (SecretStr(""), '""'),
+        (SecretBytes(b"xyz"), '"**********"'),
+        (SecretBytes(b""), '""'),
+        (IPv6Address("::1:0:1"), '"::1:0:1"'),
+        (IPv4Interface("192.168.0.0/24"), '"192.168.0.0/24"'),
+        (IPv6Interface("2001:db00::/120"), '"2001:db00::/120"'),
+        (IPv4Network("192.168.0.0/24"), '"192.168.0.0/24"'),
+        (IPv6Network("2001:db00::/120"), '"2001:db00::/120"'),
         (datetime.datetime(2032, 1, 1, 1, 1), '"2032-01-01T01:01:00"'),
         (datetime.datetime(2032, 1, 1, 1, 1, tzinfo=datetime.timezone.utc), '"2032-01-01T01:01:00+00:00"'),
         (datetime.datetime(2032, 1, 1), '"2032-01-01T00:00:00"'),
         (datetime.time(12, 34, 56), '"12:34:56"'),
-        (datetime.timedelta(days=12, seconds=34, microseconds=56), '1036834.000056'),
-        ({1, 2, 3}, '[1, 2, 3]'),
-        (frozenset([1, 2, 3]), '[1, 2, 3]'),
-        ((v for v in range(4)), '[0, 1, 2, 3]'),
-        (b'this is bytes', '"this is bytes"'),
-        (Decimal('12.34'), '12.34'),
-        (create_model('BarModel', a='b', c='d')(), '{"a": "b", "c": "d"}'),
+        (datetime.timedelta(days=12, seconds=34, microseconds=56), "1036834.000056"),
+        ({1, 2, 3}, "[1, 2, 3]"),
+        (frozenset([1, 2, 3]), "[1, 2, 3]"),
+        ((v for v in range(4)), "[0, 1, 2, 3]"),
+        (b"this is bytes", '"this is bytes"'),
+        (Decimal("12.34"), "12.34"),
+        (create_model("BarModel", a="b", c="d")(), '{"a": "b", "c": "d"}'),
         (MyEnum.foo, '"bar"'),
+        (Path("/tmp"), '"/tmp"'),
     ],
 )
 def test_encoding(input, output):
     assert output == json.dumps(input, default=pydantic_encoder)
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason='paths look different on windows')
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="paths look different on windows")
 def test_path_encoding(tmpdir):
     class PathModel(BaseModel):
         path: Path
@@ -65,11 +66,11 @@ def test_path_encoding(tmpdir):
         dir_path: DirectoryPath
 
     tmpdir = Path(tmpdir)
-    file_path = tmpdir / 'bar'
+    file_path = tmpdir / "bar"
     file_path.touch()
-    dir_path = tmpdir / 'baz'
+    dir_path = tmpdir / "baz"
     dir_path.mkdir()
-    model = PathModel(path=Path('/path/test/example/'), file_path=file_path, dir_path=dir_path)
+    model = PathModel(path=Path("/path/test/example/"), file_path=file_path, dir_path=dir_path)
     expected = '{{"path": "/path/test/example", "file_path": "{}", "dir_path": "{}"}}'.format(file_path, dir_path)
     assert json.dumps(model, default=pydantic_encoder) == expected
 
@@ -85,10 +86,10 @@ def test_model_encoding():
         c: Decimal
         d: ModelA
 
-    m = Model(a=10.2, b='foobar', c=10.2, d={'x': 123, 'y': '123'})
-    assert m.dict() == {'a': 10.2, 'b': b'foobar', 'c': Decimal('10.2'), 'd': {'x': 123, 'y': '123'}}
+    m = Model(a=10.2, b="foobar", c=10.2, d={"x": 123, "y": "123"})
+    assert m.dict() == {"a": 10.2, "b": b"foobar", "c": Decimal("10.2"), "d": {"x": 123, "y": "123"}}
     assert m.json() == '{"a": 10.2, "b": "foobar", "c": 10.2, "d": {"x": 123, "y": "123"}}'
-    assert m.json(exclude={'b'}) == '{"a": 10.2, "c": 10.2, "d": {"x": 123, "y": "123"}}'
+    assert m.json(exclude={"b"}) == '{"a": 10.2, "c": 10.2, "d": {"x": 123, "y": "123"}}'
 
 
 def test_invalid_model():
@@ -100,10 +101,10 @@ def test_invalid_model():
 
 
 @pytest.mark.parametrize(
-    'input,output',
+    "input,output",
     [
-        (datetime.timedelta(days=12, seconds=34, microseconds=56), 'P12DT0H0M34.000056S'),
-        (datetime.timedelta(days=1001, hours=1, minutes=2, seconds=3, microseconds=654_321), 'P1001DT1H2M3.654321S'),
+        (datetime.timedelta(days=12, seconds=34, microseconds=56), "P12DT0H0M34.000056S"),
+        (datetime.timedelta(days=1001, hours=1, minutes=2, seconds=3, microseconds=654_321), "P1001DT1H2M3.654321S"),
     ],
 )
 def test_iso_timedelta(input, output):
@@ -117,9 +118,9 @@ def test_custom_encoder():
         z: datetime.date
 
         class Config:
-            json_encoders = {datetime.timedelta: lambda v: f'{v.total_seconds():0.3f}s', Decimal: lambda v: 'a decimal'}
+            json_encoders = {datetime.timedelta: lambda v: f"{v.total_seconds():0.3f}s", Decimal: lambda v: "a decimal"}
 
-    assert Model(x=123, y=5, z='2032-06-01').json() == '{"x": "123.000s", "y": "a decimal", "z": "2032-06-01"}'
+    assert Model(x=123, y=5, z="2032-06-01").json() == '{"x": "123.000s", "y": "a decimal", "z": "2032-06-01"}'
 
 
 def test_custom_iso_timedelta():
@@ -139,7 +140,7 @@ def test_custom_encoder_arg():
 
     m = Model(x=123)
     assert m.json() == '{"x": 123.0}'
-    assert m.json(encoder=lambda v: '__default__') == '{"x": "__default__"}'
+    assert m.json(encoder=lambda v: "__default__") == '{"x": "__default__"}'
 
 
 def test_encode_dataclass():
@@ -148,7 +149,7 @@ def test_encode_dataclass():
         bar: int
         spam: str
 
-    f = Foo(bar=123, spam='apple pie')
+    f = Foo(bar=123, spam="apple pie")
     assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
 
 
@@ -158,7 +159,7 @@ def test_encode_pydantic_dataclass():
         bar: int
         spam: str
 
-    f = Foo(bar=123, spam='apple pie')
+    f = Foo(bar=123, spam="apple pie")
     assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
 
 
@@ -166,7 +167,7 @@ def test_encode_custom_root():
     class Model(BaseModel):
         __root__: List[str]
 
-    assert Model(__root__=['a', 'b']).json() == '["a", "b"]'
+    assert Model(__root__=["a", "b"]).json() == '["a", "b"]'
 
 
 def test_custom_decode_encode():
@@ -175,7 +176,7 @@ def test_custom_decode_encode():
     def custom_loads(s):
         nonlocal load_calls
         load_calls += 1
-        return json.loads(s.strip('$'))
+        return json.loads(s.strip("$"))
 
     def custom_dumps(s, default=None, **kwargs):
         nonlocal dump_calls
@@ -191,5 +192,5 @@ def test_custom_decode_encode():
             json_dumps = custom_dumps
 
     m = Model.parse_raw('${"a": 1, "b": "foo"}$$')
-    assert m.dict() == {'a': 1, 'b': 'foo'}
+    assert m.dict() == {"a": 1, "b": "foo"}
     assert m.json() == '{\n  "a": 1,\n  "b": "foo"\n}'


### PR DESCRIPTION
## Change Summary

Add the pathlib.Path type as an option in the ENCODERS_BY_TYPE.

It seems that pydantic is hardcoding the check for Path [here](https://github.com/samuelcolvin/pydantic/blob/master/pydantic/json.py#L51) and the examples of `json.dumps(t, default=pydantic_encoder)` succesfully encode a Pydantic model, but [Fastapi](https://github.com/tiangolo/fastapi) that is using it's own `jsonable_encoder` is using the ENCODERS_BY_TYPE structure to do a [similar serialization](https://github.com/tiangolo/fastapi/blob/master/fastapi/encoders.py#L94).

I consider this the appropriate place to clarify how pathlib.Path types should be handled.

## Related issue number

Sorry I have not created a separate issue! :(

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
