### PR TITLE
Add support for custom naming schemes for GenericModel subclasses

### DIFF
--- a/changes/859-dmontagu.md
+++ b/changes/859-dmontagu.md
@@ -1,0 +1,1 @@
+Add support for custom naming schemes for `GenericModel` subclasses.

--- a/docs/examples/generics-naming.py
+++ b/docs/examples/generics-naming.py
@@ -1,0 +1,17 @@
+from typing import Generic, TypeVar, Type, Any, Tuple
+
+from pydantic.generics import GenericModel
+
+DataT = TypeVar('DataT')
+
+class Response(GenericModel, Generic[DataT]):
+    data: DataT
+
+    @classmethod
+    def __concrete_name__(cls: Type[Any], params: Tuple[Type[Any], ...]) -> str:
+        return f'{params[0].__name__.title()}Response'
+
+print(Response[int](data=1))
+# IntResponse data=1
+print(Response[str](data='a'))
+# StrResponse data='a'

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -265,6 +265,13 @@ you would expect mypy to provide if you were to declare the type without using `
     Internally, pydantic uses `create_model` to generate a (cached) concrete `BaseModel` at runtime,
     so there is essentially zero overhead introduced by making use of `GenericModel`.
 
+If the name of the concrete subclasses is important, you can also override the default behavior:
+
+```py
+{!./examples/generics-naming.py!}
+```
+_(This script is complete, it should run "as is")_
+
 ## Dynamic model creation
 
 There are some occasions where the shape of a model is not known until runtime, for this *pydantic* provides

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -40,7 +40,7 @@ class GenericModel(BaseModel):
             k: resolve_type_hint(v, typevars_map) for k, v in instance_type_hints.items()
         }
 
-        model_name = concrete_name(cls, params)
+        model_name = cls.__concrete_name__(params)
         validators = gather_all_validators(cls)
         fields: Dict[str, Tuple[Type[Any], Any]] = {
             k: (v, cls.__fields__[k].field_info) for k, v in concrete_type_hints.items() if k in cls.__fields__
@@ -60,11 +60,14 @@ class GenericModel(BaseModel):
             _generic_types_cache[(cls, params[0])] = created_model
         return created_model
 
-
-def concrete_name(cls: Type[Any], params: Tuple[Type[Any], ...]) -> str:
-    param_names = [param.__name__ if hasattr(param, '__name__') else str(param) for param in params]
-    params_component = ', '.join(param_names)
-    return f'{cls.__name__}[{params_component}]'
+    @classmethod
+    def __concrete_name__(cls: Type[Any], params: Tuple[Type[Any], ...]) -> str:
+        """
+        This method can be overridden to achieve a custom naming scheme for GenericModels
+        """
+        param_names = [param.__name__ if hasattr(param, '__name__') else str(param) for param in params]
+        params_component = ', '.join(param_names)
+        return f'{cls.__name__}[{params_component}]'
 
 
 def resolve_type_hint(type_: Any, typevars_map: Dict[Any, Any]) -> Type[Any]:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,6 +1,6 @@
 import sys
 from enum import Enum
-from typing import Any, ClassVar, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 
 import pytest
 
@@ -421,3 +421,20 @@ def test_custom_schema():
 
     schema = MyModel[int].schema()
     assert schema['properties']['a'].get('description') == 'Custom'
+
+
+@skip_36
+def test_custom_generic_naming():
+    T = TypeVar('T')
+
+    class MyModel(GenericModel, Generic[T]):
+        value: Optional[T]
+
+        @classmethod
+        def __concrete_name__(cls: Type[Any], params: Tuple[Type[Any], ...]) -> str:
+            param_names = [param.__name__ if hasattr(param, '__name__') else str(param) for param in params]
+            title = param_names[0].title()
+            return f'Optional{title}Wrapper'
+
+    assert str(MyModel[int](value=1)) == 'OptionalIntWrapper value=1'
+    assert str(MyModel[str](value=None)) == 'OptionalStrWrapper value=None'


### PR DESCRIPTION
## Change Summary

Makes it easier to set a custom naming scheme for a GenericModel subclass.

## Related issue number

Closes #859 .

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
