### PR TITLE
Fix #867 by accepting and passing on **kwargs in ModelMetaclass.__new__

### DIFF
--- a/changes/867-retnikt.md
+++ b/changes/867-retnikt.md
@@ -1,0 +1,2 @@
+Add `**kwargs` to `pydantic.main.ModelMetaclass.__new__` so `__init_subclass__` can take custom parameters on extended 
+`BaseModel` classes

--- a/changes/867-retnikt.rst
+++ b/changes/867-retnikt.rst
@@ -1,4 +1,4 @@
-``pydantic.main.MetaModel.__new__`` should include ``**kwargs`` at the
+``pydantic.main.ModelMetaclass.__new__`` should include ``**kwargs`` at the
 end of the method definition and pass them on to the ``super`` call at
 the end in order to allow the special method ```__init_subclass__```_ to
 be defined with custom parameters on extended ``BaseModel`` classes.

--- a/changes/867-retnikt.rst
+++ b/changes/867-retnikt.rst
@@ -1,1 +1,0 @@
-Add ``**kwargs`` to ``pydantic.main.ModelMetaclass.__new__`` so ``__init_subclass__`` can take custom parameters on extended ``BaseModel`` classes

--- a/changes/867-retnikt.rst
+++ b/changes/867-retnikt.rst
@@ -1,4 +1,1 @@
-``pydantic.main.ModelMetaclass.__new__`` should include ``**kwargs`` at the
-end of the method definition and pass them on to the ``super`` call at
-the end in order to allow the special method ```__init_subclass__```_ to
-be defined with custom parameters on extended ``BaseModel`` classes.
+Add ``**kwargs`` to ``pydantic.main.ModelMetaclass.__new__`` so ``__init_subclass__`` can take custom parameters on extended ``BaseModel`` classes

--- a/changes/867-retnikt.rst
+++ b/changes/867-retnikt.rst
@@ -1,0 +1,4 @@
+``pydantic.main.MetaModel.__new__`` should include ``**kwargs`` at the
+end of the method definition and pass them on to the ``super`` call at
+the end in order to allow the special method ```__init_subclass__```_ to
+be defined with custom parameters on extended ``BaseModel`` classes.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -130,7 +130,7 @@ UNTOUCHED_TYPES = FunctionType, property, type, classmethod, staticmethod
 
 class ModelMetaclass(ABCMeta):
     @no_type_check  # noqa C901
-    def __new__(mcs, name, bases, namespace):
+    def __new__(mcs, name, bases, namespace, **kwargs):
         fields: Dict[str, ModelField] = {}
         config = BaseConfig
         validators: 'ValidatorListDict' = {}
@@ -220,7 +220,7 @@ class ModelMetaclass(ABCMeta):
             '__custom_root_type__': _custom_root_type,
             **{n: v for n, v in namespace.items() if n not in fields},
         }
-        return super().__new__(mcs, name, bases, new_namespace)
+        return super().__new__(mcs, name, bases, new_namespace, **kwargs)
 
 
 class BaseModel(metaclass=ModelMetaclass):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1001,3 +1001,19 @@ def test_model_iteration():
     assert m.dict() == {'c': 3, 'd': {'a': 1, 'b': 2}}
     assert list(m) == [('c', 3), ('d', Foo())]
     assert dict(m) == {'c': 3, 'd': Foo()}
+
+
+def test_custom_init_subclass_params():
+    class DerivedModel(BaseModel):
+        def __init_subclass__(cls, something):
+            cls.something = something
+
+    # if this raises a TypeError, then there is a regression of issue 867:
+    # pydantic.main.MetaModel.__new__ should include **kwargs at the end of the
+    # method definition and pass them on to the super call at the end in order
+    # to allow the special method __init_subclass__ to be defined with custom
+    # parameters on extended BaseModel classes.
+    class NewModel(DerivedModel, something=2):
+        something = 1
+
+    assert NewModel.something == 2


### PR DESCRIPTION
`pydantic.main.ModelMetaclass.__new__` should include `**kwargs` at the end of
the method definition and pass them on to the `super` call at the end in
order to allow the special method `__init_subclass__` to be defined with
custom parameters on extended `BaseModel` classes.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->

**NOTICE**: pydantic is currently pushing towards V1 release, 
see [issue 576](https://github.com/samuelcolvin/pydantic/issues/576). Changes not required to release version 1
may be be delayed until after version 1 is released. If your PR is a bugfix for v0.32, please base off and target the `v0.32.x` branch.

## Change Summary

`pydantic.main.ModelMetaclass.__new__` now includes `**kwargs` at the end of the method definition and passes them on to the `super` call at the end in order to allow the special method `__init_subclass__` to be defined with custom parameters on extended `BaseModel` classes.

## Related issue number

Fixes #867

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
