### PR TITLE
Automatically add no-cover to TYPE_CHECKING blocks

### DIFF
--- a/changes/874-dmontagu.md
+++ b/changes/874-dmontagu.md
@@ -1,0 +1,1 @@
+Add `if TYPE_CHECKING:` to the excluded lines for test coverage

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -29,7 +29,7 @@ class Validator:
         self.check_fields = check_fields
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .main import BaseConfig
     from .fields import ModelField
     from .types import ModelOrDc

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple, Union, cast
 from .errors import ColorError
 from .utils import almost_equal_floats
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .typing import CallableGenerator
 
 ColorTuple = Union[Tuple[int, int, int], Tuple[int, int, int, float]]

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -8,7 +8,7 @@ from .fields import Required
 from .main import create_model, validate_model
 from .typing import AnyType
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .main import BaseConfig, BaseModel  # noqa: F401
 
     class DataclassType:
@@ -105,7 +105,7 @@ def _process_class(
     return cls
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     # see https://github.com/python/mypy/issues/6239 for explanation of why we do this
     from dataclasses import dataclass as dataclass
 else:

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -1,7 +1,7 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Sequence, Tuple, Type, Union
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .main import BaseConfig  # noqa: F401
     from .types import ModelOrDc  # noqa: F401
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -35,7 +35,7 @@ except ImportError:
 Required: Any = Ellipsis
 NoneType = type(None)
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .class_validators import ValidatorsList  # noqa: F401
     from .error_wrappers import ErrorList
     from .main import BaseConfig, BaseModel  # noqa: F401

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -20,7 +20,7 @@ from .types import PyObject, StrBytes
 from .typing import AnyCallable, AnyType, ForwardRef, is_classvar, resolve_annotations, update_field_forward_refs
 from .utils import GetterDict, ValueItems, truncate, validate_field_name
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .class_validators import ValidatorListDict
     from .types import ModelOrDc
     from .typing import CallableGenerator, TupleGenerator, DictStrAny, DictAny, SetStr
@@ -224,7 +224,7 @@ class ModelMetaclass(ABCMeta):
 
 
 class BaseModel(metaclass=ModelMetaclass):
-    if TYPE_CHECKING:  # pragma: no cover
+    if TYPE_CHECKING:
         # populated by the metaclass, defined here to help IDEs only
         __fields__: Dict[str, ModelField] = {}
         __validators__: Dict[str, AnyCallable] = {}
@@ -241,7 +241,7 @@ class BaseModel(metaclass=ModelMetaclass):
 
     def __init__(__pydantic_self__, **data: Any) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
-        if TYPE_CHECKING:  # pragma: no cover
+        if TYPE_CHECKING:
             __pydantic_self__.__dict__: Dict[str, Any] = {}
             __pydantic_self__.__fields_set__: 'SetStr' = set()
         values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Set, Tuple, Ty
 from . import errors
 from .validators import constr_length_validator, str_validator
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .fields import ModelField
     from .main import BaseConfig  # noqa: F401
     from .typing import AnyCallable

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -40,7 +40,7 @@ from .types import (
 from .typing import Literal, is_callable_type, is_literal_type, is_new_type, literal_values, new_type_supertype
 from .utils import lenient_issubclass
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
 
 default_prefix = '#/definitions/'

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -73,7 +73,7 @@ OptionalInt = Optional[int]
 OptionalIntFloat = Union[OptionalInt, float]
 OptionalIntFloatDecimal = Union[OptionalIntFloat, Decimal]
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .dataclasses import DataclassType  # noqa: F401
     from .main import BaseModel, BaseConfig  # noqa: F401
     from .typing import CallableGenerator

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -52,7 +52,7 @@ except ImportError:
     Literal = None  # type: ignore
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .fields import ModelField
 
     TupleGenerator = Generator[Tuple[str, Any], None, None]

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -10,7 +10,7 @@ except ImportError:
     Literal = None  # type: ignore
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
     from .typing import SetIntStr, DictIntStrAny, IntStr  # noqa: F401
 
@@ -157,7 +157,7 @@ class ValueItems:
     __slots__ = ('_items', '_type')
 
     def __init__(self, value: Any, items: Union['SetIntStr', 'DictIntStrAny']) -> None:
-        if TYPE_CHECKING:  # pragma: no cover
+        if TYPE_CHECKING:
             self._items: Union['SetIntStr', 'DictIntStrAny']
             self._type: Type[Union[set, dict]]  # type: ignore
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -29,7 +29,7 @@ from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_ti
 from .typing import AnyCallable, AnyType, ForwardRef, display_as_type, get_class, is_callable_type, is_literal_type
 from .utils import almost_equal_floats, lenient_issubclass, sequence_like
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .fields import ModelField
     from .main import BaseConfig
     from .types import ConstrainedDecimal, ConstrainedFloat, ConstrainedInt

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ exclude_lines =
     pragma: no cover
     raise NotImplementedError
     raise NotImplemented
+    if TYPE_CHECKING:
 
 [isort]
 line_length=120


### PR DESCRIPTION
## Change Summary

Adds `if TYPE_CHECKING:` to the exclude_lines for coverage so that the `# pragma: no cover` can be removed everywhere it occurs next to an `if TYPE_CHECKING:` block.

Note: this is safe since code inside such blocks should *never* be executed except during static analysis.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
