### PR TITLE
fix subtle issue with settings env variables

### DIFF
--- a/changes/882-samuelcolvin.md
+++ b/changes/882-samuelcolvin.md
@@ -1,0 +1,1 @@
+Fix issue with `BaseSettings` inheritance and `alias` getting set to `None`

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -269,7 +269,7 @@ class ModelField:
         schema_from_config = config.get_field_info(self.name)
         if schema_from_config:
             self.field_info = cast(FieldInfo, self.field_info)
-            self.field_info.alias = self.field_info.alias or schema_from_config.get('alias')
+            self.field_info.alias = self.field_info.alias or schema_from_config.get('alias') or self.name
             self.alias = cast(str, self.field_info.alias)
 
     @property

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -304,3 +304,33 @@ def test_config_file_settings_nornir(env):
     assert s.a == 'config a'
     assert s.b == 'argument b'
     assert s.c == 'env setting c'
+
+
+def test_alias_set(env):
+    class Settings(BaseSettings):
+        foo: str = 'default foo'
+        bar: str = 'bar default'
+
+        class Config:
+            fields = {'foo': {'env': 'foo_env'}}
+
+    assert Settings.__fields__['bar'].name == 'bar'
+    assert Settings.__fields__['bar'].alias == 'bar'
+    assert Settings.__fields__['foo'].name == 'foo'
+    assert Settings.__fields__['foo'].alias == 'foo'
+
+    class SubSettings(Settings):
+        spam: str = 'spam default'
+
+    assert SubSettings.__fields__['bar'].name == 'bar'
+    assert SubSettings.__fields__['bar'].alias == 'bar'
+    assert SubSettings.__fields__['foo'].name == 'foo'
+    assert SubSettings.__fields__['foo'].alias == 'foo'
+
+    assert SubSettings().dict() == {'foo': 'default foo', 'bar': 'bar default', 'spam': 'spam default'}
+    env.set('foo_env', 'fff')
+    assert SubSettings().dict() == {'foo': 'fff', 'bar': 'bar default', 'spam': 'spam default'}
+    env.set('bar', 'bbb')
+    assert SubSettings().dict() == {'foo': 'fff', 'bar': 'bbb', 'spam': 'spam default'}
+    env.set('spam', 'sss')
+    assert SubSettings().dict() == {'foo': 'fff', 'bar': 'bbb', 'spam': 'sss'}


### PR DESCRIPTION
## Change Summary

Fix issue with `BaseSettings` inheritance and `alias` getting set to `None`

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
