### PR TITLE
deprecation warning for case_insensitive on BaseSettings config

### DIFF
--- a/changes/885-samuelcolvin.md
+++ b/changes/885-samuelcolvin.md
@@ -1,0 +1,1 @@
+deprecation warning for `case_insensitive` on `BaseSettings` config

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -118,6 +118,14 @@ def prepare_config(config: Type[BaseConfig], cls_name: str) -> None:
         )
         config.allow_population_by_field_name = config.allow_population_by_alias  # type: ignore
 
+    if hasattr(config, 'case_insensitive') and any('BaseSettings.Config' in c.__qualname__ for c in config.__mro__):
+        warnings.warn(
+            f'{cls_name}: "case_insensitive" is deprecated on BaseSettings config and replaced by '
+            f'"case_sensitive" (default False)',
+            DeprecationWarning,
+        )
+        config.case_sensitive = not config.case_insensitive  # type: ignore
+
 
 def is_valid_field(name: str) -> bool:
     if not name.startswith('_'):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -252,6 +252,22 @@ def test_case_sensitive(monkeypatch):
     assert exc_info.value.errors() == [{'loc': ('foo',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+def test_case_insensitive(monkeypatch):
+    class Settings1(BaseSettings):
+        foo: str
+
+    with pytest.warns(DeprecationWarning, match='Settings2: "case_insensitive" is deprecated on BaseSettings'):
+
+        class Settings2(BaseSettings):
+            foo: str
+
+            class Config:
+                case_insensitive = False
+
+    assert Settings1.__config__.case_sensitive is False
+    assert Settings2.__config__.case_sensitive is True
+
+
 def test_nested_dataclass(env):
     @dataclasses.dataclass
     class MyDataclass:


### PR DESCRIPTION
This is just adding a deprecation warning and use the value of `case_insensitive` which was removed on #721.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
