### PR TITLE
Fix formatting for datetime nested bullet points in docs/usage/types.md

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -190,37 +190,37 @@ types:
 
 * `datetime` fields can be:
 
-  * `datetime`, existing `datetime` object
-  * `int` or `float`, assumed as Unix time, i.e. seconds (if <= `2e10`) or milliseconds (if > `2e10`) since 1 January 1970
-  * `str`, following formats work:
+    * `datetime`, existing `datetime` object
+    * `int` or `float`, assumed as Unix time, i.e. seconds (if <= `2e10`) or milliseconds (if > `2e10`) since 1 January 1970
+    * `str`, following formats work:
 
-    * `YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z[±]HH[:]MM]]]`
-    * `int` or `float` as a string (assumed as Unix time)
+        * `YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z[±]HH[:]MM]]]`
+        * `int` or `float` as a string (assumed as Unix time)
 
 * `date` fields can be:
 
-  * `date`, existing `date` object
-  * `int` or `float`, see `datetime`
-  * `str`, following formats work:
-
-    * `YYYY-MM-DD`
+    * `date`, existing `date` object
     * `int` or `float`, see `datetime`
+    * `str`, following formats work:
+
+        * `YYYY-MM-DD`
+        * `int` or `float`, see `datetime`
 
 * `time` fields can be:
 
-  * `time`, existing `time` object
-  * `str`, following formats work:
+    * `time`, existing `time` object
+    * `str`, following formats work:
 
-    * `HH:MM[:SS[.ffffff]]`
+        * `HH:MM[:SS[.ffffff]]`
 
 * `timedelta` fields can be:
 
-  * `timedelta`, existing `timedelta` object
-  * `int` or `float`, assumed as seconds
-  * `str`, following formats work:
+    * `timedelta`, existing `timedelta` object
+    * `int` or `float`, assumed as seconds
+    * `str`, following formats work:
 
-    * `[-][DD ][HH:MM]SS[.ffffff]`
-    * `[±]P[DD]DT[HH]H[MM]M[SS]S` (ISO 8601 format for timedelta)
+        * `[-][DD ][HH:MM]SS[.ffffff]`
+        * `[±]P[DD]DT[HH]H[MM]M[SS]S` (ISO 8601 format for timedelta)
 
 ```py
 {!./examples/datetime_example.py!}


### PR DESCRIPTION
## Change Summary

The formatting of the nested bullet points is wrong in the datetime section of the Field Types page of the docs, resulting in un-nested bullet points. Indentation is fixed so it is clearer

## Related issue number

N/A, since it's a trivial change

## Checklist

* [ ] Unit tests for the changes exist (N/A)
* [ ] Tests pass on CI and coverage remains at 100% (N/A)
* [ ] Documentation reflects the changes where applicable (N/A)
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md] (https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details) (do I need to do this, it took me less than 30 seconds to fix)
