### PR TITLE
Merge init_kwargs with env variables recursively to handle nested values

### DIFF
--- a/changes/888-idmitrievsky.md
+++ b/changes/888-idmitrievsky.md
@@ -1,0 +1,2 @@
+Merge environment variables and in-code values recursively, as long as they create a valid object
+when merged together, to allow splitting init arguments.

--- a/changes/888-idmitrievsky.md
+++ b/changes/888-idmitrievsky.md
@@ -1,2 +1,2 @@
-Merge environment variables and in-code values recursively, as long as they create a valid object
+For `BaseSettings` merge environment variables and in-code values recursively, as long as they create a valid object
 when merged together, to allow splitting init arguments.

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional
 from .fields import ModelField
 from .main import BaseModel, Extra
 from .typing import display_as_type
+from .utils import deep_update
 
 
 class SettingsError(ValueError):
@@ -24,7 +25,7 @@ class BaseSettings(BaseModel):
         super().__init__(**__pydantic_self__._build_values(values))
 
     def _build_values(self, init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        return {**self._build_environ(), **init_kwargs}
+        return deep_update(self._build_environ(), init_kwargs)
 
     def _build_environ(self) -> Dict[str, Optional[str]]:
         """

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -97,6 +97,13 @@ def in_ipython() -> bool:
     else:  # pragma: no cover
         return True
 
+def deep_update(mapping, updating_mapping):
+    for k, v in updating_mapping.items():
+        if (k in mapping) and isinstance(mapping[k], dict) and isinstance(v, dict):
+            deep_update(mapping[k], v)
+        else:
+            mapping[k] = v
+    return mapping
 
 def almost_equal_floats(value_1: float, value_2: float, *, delta: float = 1e-8) -> bool:
     """

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -13,6 +13,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
     no_type_check,
 )
@@ -24,10 +25,11 @@ try:
 except ImportError:
     Literal = None  # type: ignore
 
-
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
     from .typing import SetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
+
+KeyType = TypeVar('KeyType')
 
 
 def import_string(dotted_path: str) -> Any:
@@ -99,13 +101,14 @@ def in_ipython() -> bool:
         return True
 
 
-def deep_update(mapping: Dict[str, Any], updating_mapping: Dict[str, Any]) -> Dict[str, Any]:
+def deep_update(mapping: Dict[KeyType, Any], updating_mapping: Dict[KeyType, Any]) -> Dict[KeyType, Any]:
+    updated_mapping = mapping.copy()
     for k, v in updating_mapping.items():
-        if (k in mapping) and isinstance(mapping[k], dict) and isinstance(v, dict):
-            deep_update(mapping[k], v)
+        if k in mapping and isinstance(mapping[k], dict) and isinstance(v, dict):
+            updated_mapping[k] = deep_update(mapping[k], v)
         else:
-            mapping[k] = v
-    return mapping
+            updated_mapping[k] = v
+    return updated_mapping
 
 
 def almost_equal_floats(value_1: float, value_2: float, *, delta: float = 1e-8) -> bool:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Generator,
     Iterator,
     List,
@@ -97,13 +98,15 @@ def in_ipython() -> bool:
     else:  # pragma: no cover
         return True
 
-def deep_update(mapping, updating_mapping):
+
+def deep_update(mapping: Dict[str, Any], updating_mapping: Dict[str, Any]) -> Dict[str, Any]:
     for k, v in updating_mapping.items():
         if (k in mapping) and isinstance(mapping[k], dict) and isinstance(v, dict):
             deep_update(mapping[k], v)
         else:
             mapping[k] = v
     return mapping
+
 
 def almost_equal_floats(value_1: float, value_2: float, *, delta: float = 1e-8) -> bool:
     """

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Set
+from typing import Dict, List, Set
 
 import pytest
 
@@ -46,6 +46,38 @@ def test_with_prefix(env):
     env.set('foobar_apple', 'has_prefix')
     s = Settings()
     assert s.apple == 'has_prefix'
+
+
+def test_nested_env_with_basemodel(env):
+    class TopValue(BaseModel):
+        apple: str
+        banana: str
+
+    class Settings(BaseSettings):
+        top: TopValue
+
+        class Config:
+            env_prefix = 'APP_'
+
+    with pytest.raises(ValidationError):
+        Settings()
+    env.set('APP_top', '{"banana": "secret_value"}')
+    s = Settings(top={'apple': 'value'})
+    assert s.top.banana == 'secret_value'
+
+
+def test_nested_env_with_dict(env):
+    class Settings(BaseSettings):
+        top: Dict[str, str]
+
+        class Config:
+            env_prefix = 'APP_'
+
+    with pytest.raises(ValidationError):
+        Settings()
+    env.set('APP_top', '{"banana": "secret_value"}')
+    s = Settings(top={'apple': 'value'})
+    assert s.top['banana'] == 'secret_value'
 
 
 class DateModel(BaseModel):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -56,28 +56,22 @@ def test_nested_env_with_basemodel(env):
     class Settings(BaseSettings):
         top: TopValue
 
-        class Config:
-            env_prefix = 'APP_'
-
     with pytest.raises(ValidationError):
         Settings()
-    env.set('APP_top', '{"banana": "secret_value"}')
+    env.set('top', '{"banana": "secret_value"}')
     s = Settings(top={'apple': 'value'})
-    assert s.top.banana == 'secret_value'
+    assert s.top == {'apple': 'value', 'banana': 'secret_value'}
 
 
 def test_nested_env_with_dict(env):
     class Settings(BaseSettings):
         top: Dict[str, str]
 
-        class Config:
-            env_prefix = 'APP_'
-
     with pytest.raises(ValidationError):
         Settings()
-    env.set('APP_top', '{"banana": "secret_value"}')
+    env.set('top', '{"banana": "secret_value"}')
     s = Settings(top={'apple': 'value'})
-    assert s.top['banana'] == 'secret_value'
+    assert s.top == {'apple': 'value', 'banana': 'secret_value'}
 
 
 class DateModel(BaseModel):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -224,16 +224,41 @@ def test_devtools_output_validation_error():
     )
 
 
-def test_deep_update_extra_keys():
-    mapping = {'key': {'inner_key': 0}}
-    assert deep_update(mapping, {'other_key': 1}) == {'key': {'inner_key': 0}, 'other_key': 1}
+@pytest.mark.parametrize(
+    'mapping, updating_mapping, expected_mapping, msg',
+    [
+        (
+            {'key': {'inner_key': 0}},
+            {'other_key': 1},
+            {'key': {'inner_key': 0}, 'other_key': 1},
+            'extra keys are inserted',
+        ),
+        (
+            {'key': {'inner_key': 0}, 'other_key': 1},
+            {'key': [1, 2, 3]},
+            {'key': [1, 2, 3], 'other_key': 1},
+            'values that can not be merged are updated',
+        ),
+        (
+            {'key': {'inner_key': 0}},
+            {'key': {'other_key': 1}},
+            {'key': {'inner_key': 0, 'other_key': 1}},
+            'values that have corresponding keys are merged',
+        ),
+        (
+            {'key': {'inner_key': {'deep_key': 0}}},
+            {'key': {'inner_key': {'other_deep_key': 1}}},
+            {'key': {'inner_key': {'deep_key': 0, 'other_deep_key': 1}}},
+            'deeply nested values that have corresponding keys are merged',
+        ),
+    ],
+)
+def test_deep_update(mapping, updating_mapping, expected_mapping, msg):
+    assert deep_update(mapping, updating_mapping) == expected_mapping, msg
 
 
-def test_deep_update_overwrites_keys():
-    mapping = {'key': {'inner_key': 0}, 'other_key': 1}
-    assert deep_update(mapping, {'key': [1, 2, 3]}) == {'key': [1, 2, 3], 'other_key': 1}
-
-
-def test_deep_update_merges_keys():
-    mapping = {'key': {'inner_key': 0}}
-    assert deep_update(mapping, {'key': {'other_key': 1}}) == {'key': {'inner_key': 0, 'other_key': 1}}
+def test_deep_update_is_not_mutating():
+    mapping = {'key': {'inner_key': {'deep_key': 1}}}
+    updated_mapping = deep_update(mapping, {'key': {'inner_key': {'other_deep_key': 1}}})
+    assert updated_mapping == {'key': {'inner_key': {'deep_key': 1, 'other_deep_key': 1}}}
+    assert mapping == {'key': {'inner_key': {'deep_key': 1}}}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import BaseModel
 from pydantic.color import Color
 from pydantic.typing import display_as_type, is_new_type, new_type_supertype
-from pydantic.utils import ValueItems, import_string, lenient_issubclass, truncate
+from pydantic.utils import ValueItems, deep_update, import_string, lenient_issubclass, truncate
 
 try:
     import devtools
@@ -222,3 +222,18 @@ def test_devtools_output_validation_error():
         '    ],\n'
         ')'
     )
+
+
+def test_deep_update_extra_keys():
+    mapping = {"key": {"inner_key": 0}}
+    assert deep_update(mapping, {"other_key": 1}) == {"key": {"inner_key": 0}, "other_key": 1}
+
+
+def test_deep_update_overwrites_keys():
+    mapping = {"key": {"inner_key": 0}, "other_key": 1}
+    assert deep_update(mapping, {"key": [1, 2, 3]}) == {"key": [1, 2, 3], "other_key": 1}
+
+
+def test_deep_update_merges_keys():
+    mapping = {"key": {"inner_key": 0}}
+    assert deep_update(mapping, {"key": {"other_key": 1}}) == {"key": {"inner_key": 0, "other_key": 1}}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,15 +225,15 @@ def test_devtools_output_validation_error():
 
 
 def test_deep_update_extra_keys():
-    mapping = {"key": {"inner_key": 0}}
-    assert deep_update(mapping, {"other_key": 1}) == {"key": {"inner_key": 0}, "other_key": 1}
+    mapping = {'key': {'inner_key': 0}}
+    assert deep_update(mapping, {'other_key': 1}) == {'key': {'inner_key': 0}, 'other_key': 1}
 
 
 def test_deep_update_overwrites_keys():
-    mapping = {"key": {"inner_key": 0}, "other_key": 1}
-    assert deep_update(mapping, {"key": [1, 2, 3]}) == {"key": [1, 2, 3], "other_key": 1}
+    mapping = {'key': {'inner_key': 0}, 'other_key': 1}
+    assert deep_update(mapping, {'key': [1, 2, 3]}) == {'key': [1, 2, 3], 'other_key': 1}
 
 
 def test_deep_update_merges_keys():
-    mapping = {"key": {"inner_key": 0}}
-    assert deep_update(mapping, {"key": {"other_key": 1}}) == {"key": {"inner_key": 0, "other_key": 1}}
+    mapping = {'key': {'inner_key': 0}}
+    assert deep_update(mapping, {'key': {'other_key': 1}}) == {'key': {'inner_key': 0, 'other_key': 1}}


### PR DESCRIPTION
## Change Summary

This PR implements `deep_update` function that works as standard
`update` method on dicts, but also recursively updates all the nested
dict values. It allows splitting init arguments between environment
variables and in-code values, as long as they create a valid object
when merged together.

## Related issue number

Closes #888.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
