### PR TITLE
Add example for construct function

### DIFF
--- a/changes/907-ashears.md
+++ b/changes/907-ashears.md
@@ -1,0 +1,1 @@
+Add example for construct function

--- a/docs/examples/ex_construct.py
+++ b/docs/examples/ex_construct.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, ValidationError
+
+class Model(BaseModel):
+    a: int
+
+valid_data = dict(a=5)
+invalid_data = dict(a="dog")
+
+# Validate the model at instantiation
+m = Model(**valid_data)
+print(m)
+try:
+    Model(**invalid_data)
+except ValidationError as e:
+    print(e)
+
+# Instantiate the model without validation
+c = Model.construct(values=valid_data, fields_set=None)
+print(c)
+c = Model.construct(values=invalid_data, fields_set=None)
+print(c)

--- a/docs/examples/ex_construct.py
+++ b/docs/examples/ex_construct.py
@@ -3,19 +3,5 @@ from pydantic import BaseModel, ValidationError
 class Model(BaseModel):
     a: int
 
-valid_data = dict(a=5)
-invalid_data = dict(a="dog")
-
-# Validate the model at instantiation
-m = Model(**valid_data)
-print(m)
-try:
-    Model(**invalid_data)
-except ValidationError as e:
-    print(e)
-
-# Instantiate the model without validation
-c = Model.construct(values=valid_data, fields_set=None)
-print(c)
-c = Model.construct(values=invalid_data, fields_set=None)
+c = Model.construct(a='dog')
 print(c)

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -84,17 +84,6 @@ as an optional alternative which implements ISO 8601 time diff encoding.
 See [below](#custom-json-deserialisation) for details on how to use other libraries for more performant JSON encoding
 and decoding.
 
-## `model.construct()`
-
-Using the construct function, it is possible to instantiate a model without validation.
-
-Example:
-
-```py
-{!.tmp_examples/ex_construct.py!}
-```
-_(This script is complete, it should run "as is")_
-
 ## `pickle.dumps(model)`
 
 Using the same plumbing as `copy()`, *pydantic* models support efficient pickling and unpickling.

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -86,7 +86,7 @@ and decoding.
 
 ## `model.construct()`
 
-Using the construct function, it is possible to instatiate a model without validation.
+Using the construct function, it is possible to instantiate a model without validation.
 
 Example:
 

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -84,6 +84,17 @@ as an optional alternative which implements ISO 8601 time diff encoding.
 See [below](#custom-json-deserialisation) for details on how to use other libraries for more performant JSON encoding
 and decoding.
 
+## `model.construct()`
+
+Using the construct function, it is possible to instatiate a model without validation.
+
+Example:
+
+```py
+{!.tmp_examples/ex_construct.py!}
+```
+_(This script is complete, it should run "as is")_
+
 ## `pickle.dumps(model)`
 
 Using the same plumbing as `copy()`, *pydantic* models support efficient pickling and unpickling.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -237,7 +237,7 @@ _(This script is complete, it should run "as is")_
 *Pydantic* also allows the ability to turn off model validation:
 
 ```py
-{!.tmp_examples/parse.py!}
+{!.tmp_examples/ex_construct.py!}
 ```
 _(This script is complete, it should run "as is")_
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -234,6 +234,17 @@ _(This script is complete, it should run "as is")_
     Because it can result in arbitrary code execution, as a security measure, you need
     to explicitly pass `allow_pickle` to the parsing function in order to load `pickle` data.
 
+*Pydantic* also allows the ability to turn off model validation:
+
+```py
+{!.tmp_examples/parse.py!}
+```
+_(This script is complete, it should run "as is")_
+
+!!! warning
+    Not validating the models can allow for errors. The user must ensure that the data is valid at the time
+    that it is passed into the model.
+
 ## Generic Models
 
 !!! note


### PR DESCRIPTION
## Change Summary
Added examples for the construct function, as it was mentioned in https://github.com/samuelcolvin/pydantic/pull/898 that this was needed.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
