### PR TITLE
update docs for bool to match code

### DIFF
--- a/changes/904-trim21.md
+++ b/changes/904-trim21.md
@@ -1,0 +1,2 @@
+**Breaking Change:** Change the precedence of aliases so child model aliases override parent aliases, 
+including using `alias_generator`

--- a/changes/904-trim21.md
+++ b/changes/904-trim21.md
@@ -1,2 +1,0 @@
-**Breaking Change:** Change the precedence of aliases so child model aliases override parent aliases, 
-including using `alias_generator`

--- a/changes/911-trim21.md
+++ b/changes/911-trim21.md
@@ -1,0 +1,1 @@
+update docs for bool missing valid value.

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -239,7 +239,7 @@ A standard `bool` field will raise a `ValidationError` if the value is not one o
 * A valid boolean (i.e. `True` or `False`),
 * The integers `0` or `1`,
 * a `str` which when converted to lower case is one of
-  `'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'`
+  `'0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'`
 * a `bytes` which is valid (per the previous rule) when decoded to `str`
 
 !!! note


### PR DESCRIPTION
# Change Summary
Update docs for `usage/types/#booleans`
<!-- Please give a short summary of the changes. -->

> a str which when converted to lower case is one of 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'

Missing value `'0'` in code 

https://github.com/samuelcolvin/pydantic/blob/ed7b216e5fe436756ff61e3a2dfed63aa8836464/pydantic/validators.py#L77

## Related issue number

No

## Checklist

* <del>[ ] Unit tests for the changes exist</del> not changing any code.
* <del>[ ] Tests pass on CI and coverage remains at 100%</del> not changing any code.
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
