### PR TITLE
Rename skip-defaults, and add ability to exclude actual defaults

### DIFF
--- a/changes/915-dmontagu.md
+++ b/changes/915-dmontagu.md
@@ -1,0 +1,1 @@
+**Breaking change:** Rename `skip_defaults` to `exclude_unset`, and add ability to exclude actual defaults 

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -10,7 +10,7 @@ Arguments:
 * `include`: fields to include in the returned dictionary; see [below](#advanced-include-exclude)
 * `exclude`: fields to exclude from the returned dictionary; see [below](#advanced-include-exclude)
 * `by_alias`: whether field aliases should be used as keys in the returned dictionary; default `False`
-* `skip_defaults`: whether fields which were not explicitly set when creating the model should
+* `exclude_unset`: whether fields which were not explicitly set when creating the model should
   be excluded from the returned dictionary; default `False`
 
 Example:
@@ -65,7 +65,7 @@ Arguments:
 * `include`: fields to include in the returned dictionary; see [below](#advanced-include-exclude)
 * `exclude`: fields to exclude from the returned dictionary; see [below](#advanced-include-exclude)
 * `by_alias`: whether field aliases should be used as keys in the returned dictionary; default `False`
-* `skip_defaults`: whether fields which were not set when creating the model and have their default values should
+* `exclude_unset`: whether fields which were not set when creating the model and have their default values should
   be excluded from the returned dictionary; default `False`
 * `encoder`: a custom encoder function passed to the `default` argument of `json.dumps()`; defaults to a custom
   encoder designed to take care of all common types

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -12,6 +12,9 @@ Arguments:
 * `by_alias`: whether field aliases should be used as keys in the returned dictionary; default `False`
 * `exclude_unset`: whether fields which were not explicitly set when creating the model should
   be excluded from the returned dictionary; default `False`
+  * Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
+* `exclude_defaults`: whether fields which are equal to their default values (whether set or otherwise) should
+  be excluded from the returned dictionary; default `False`
 
 Example:
 
@@ -66,6 +69,9 @@ Arguments:
 * `exclude`: fields to exclude from the returned dictionary; see [below](#advanced-include-exclude)
 * `by_alias`: whether field aliases should be used as keys in the returned dictionary; default `False`
 * `exclude_unset`: whether fields which were not set when creating the model and have their default values should
+  be excluded from the returned dictionary; default `False`
+  * Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
+* `exclude_defaults`: whether fields which are equal to their default values (whether set or otherwise) should
   be excluded from the returned dictionary; default `False`
 * `encoder`: a custom encoder function passed to the `default` argument of `json.dumps()`; defaults to a custom
   encoder designed to take care of all common types

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -11,8 +11,8 @@ Arguments:
 * `exclude`: fields to exclude from the returned dictionary; see [below](#advanced-include-exclude)
 * `by_alias`: whether field aliases should be used as keys in the returned dictionary; default `False`
 * `exclude_unset`: whether fields which were not explicitly set when creating the model should
-  be excluded from the returned dictionary; default `False`
-  * Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
+  be excluded from the returned dictionary; default `False`.
+  Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
 * `exclude_defaults`: whether fields which are equal to their default values (whether set or otherwise) should
   be excluded from the returned dictionary; default `False`
 
@@ -69,8 +69,8 @@ Arguments:
 * `exclude`: fields to exclude from the returned dictionary; see [below](#advanced-include-exclude)
 * `by_alias`: whether field aliases should be used as keys in the returned dictionary; default `False`
 * `exclude_unset`: whether fields which were not set when creating the model and have their default values should
-  be excluded from the returned dictionary; default `False`
-  * Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
+  be excluded from the returned dictionary; default `False`.
+  Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
 * `exclude_defaults`: whether fields which are equal to their default values (whether set or otherwise) should
   be excluded from the returned dictionary; default `False`
 * `encoder`: a custom encoder function passed to the `default` argument of `json.dumps()`; defaults to a custom

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -231,7 +231,7 @@ class ModelMetaclass(ABCMeta):
         new_namespace = {
             '__config__': config,
             '__fields__': fields,
-            '__defaults__': {n: f.default for n, f in fields.items() if not f.required},
+            '__field_defaults__': {n: f.default for n, f in fields.items() if not f.required},
             '__validators__': vg.validators,
             '__pre_root_validators__': pre_root_validators + pre_rv_new,
             '__post_root_validators__': post_root_validators + post_rv_new,
@@ -253,7 +253,7 @@ class BaseModel(metaclass=ModelMetaclass):
     if TYPE_CHECKING:
         # populated by the metaclass, defined here to help IDEs only
         __fields__: Dict[str, ModelField] = {}
-        __defaults__: Dict[str, Any] = {}
+        __field_defaults__: Dict[str, Any] = {}
         __validators__: Dict[str, AnyCallable] = {}
         __pre_root_validators__: List[AnyCallable]
         __post_root_validators__: List[AnyCallable]
@@ -314,7 +314,7 @@ class BaseModel(metaclass=ModelMetaclass):
         """
         if skip_defaults is not None:
             warnings.warn(
-                f'{type(self).__name__}.dict: "skip_defaults" is deprecated and replaced by "exclude_unset"',
+                f'{self.__class__.__name__}.dict(): "skip_defaults" is deprecated and replaced by "exclude_unset"',
                 DeprecationWarning,
             )
             exclude_unset = skip_defaults
@@ -360,7 +360,7 @@ class BaseModel(metaclass=ModelMetaclass):
         """
         if skip_defaults is not None:
             warnings.warn(
-                f'{type(self).__name__}.dict: "skip_defaults" is deprecated and replaced by "exclude_unset"',
+                f'{self.__class__.__name__}.dict(): "skip_defaults" is deprecated and replaced by "exclude_unset"',
                 DeprecationWarning,
             )
             exclude_unset = skip_defaults
@@ -628,7 +628,7 @@ class BaseModel(metaclass=ModelMetaclass):
         if exclude_defaults:
             if allowed_keys is None:
                 allowed_keys = set(self.__fields__)
-            for k, v in self.__defaults__.items():
+            for k, v in self.__field_defaults__.items():
                 if self.__dict__[k] == v:
                     allowed_keys.discard(k)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -360,7 +360,7 @@ class BaseModel(metaclass=ModelMetaclass):
         """
         if skip_defaults is not None:
             warnings.warn(
-                f'{self.__class__.__name__}.dict(): "skip_defaults" is deprecated and replaced by "exclude_unset"',
+                f'{self.__class__.__name__}.json(): "skip_defaults" is deprecated and replaced by "exclude_unset"',
                 DeprecationWarning,
             )
             exclude_unset = skip_defaults

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -181,8 +181,8 @@ def test_copy_set_fields():
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy()
 
-    assert m.dict(skip_defaults=True) == {'a': 24.0, 'd': {'a': 12}}
-    assert m.dict(skip_defaults=True) == m2.dict(skip_defaults=True)
+    assert m.dict(exclude_unset=True) == {'a': 24.0, 'd': {'a': 12}}
+    assert m.dict(exclude_unset=True) == m2.dict(exclude_unset=True)
 
 
 def test_simple_pickle():
@@ -227,9 +227,9 @@ def test_immutable_copy():
 
 def test_pickle_fields_set():
     m = Model(a=24)
-    assert m.dict(skip_defaults=True) == {'a': 24}
+    assert m.dict(exclude_unset=True) == {'a': 24}
     m2 = pickle.loads(pickle.dumps(m))
-    assert m2.dict(skip_defaults=True) == {'a': 24}
+    assert m2.dict(exclude_unset=True) == {'a': 24}
 
 
 def test_copy_update_exclude():
@@ -246,5 +246,5 @@ def test_copy_update_exclude():
     assert m.copy(exclude={'c'}).dict() == {'d': {'a': 'ax', 'b': 'bx'}}
     assert m.copy(exclude={'c'}, update={'c': 42}).dict() == {'c': 42, 'd': {'a': 'ax', 'b': 'bx'}}
 
-    assert m._calculate_keys(exclude={'x'}, include=None, skip_defaults=False) == {'c', 'd'}
-    assert m._calculate_keys(exclude={'x'}, include=None, skip_defaults=False, update={'c': 42}) == {'d'}
+    assert m._calculate_keys(exclude={'x'}, include=None, exclude_unset=False) == {'c', 'd'}
+    assert m._calculate_keys(exclude={'x'}, include=None, exclude_unset=False, update={'c': 42}) == {'d'}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -383,16 +383,16 @@ def test_include_exclude_default():
     m = Model(a=1, b=2)
     assert m.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
     assert m.__fields_set__ == {'a', 'b'}
-    assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+    assert m.dict(exclude_unset=True) == {'a': 1, 'b': 2}
 
-    assert m.dict(include={'a'}, skip_defaults=True) == {'a': 1}
-    assert m.dict(include={'c'}, skip_defaults=True) == {}
+    assert m.dict(include={'a'}, exclude_unset=True) == {'a': 1}
+    assert m.dict(include={'c'}, exclude_unset=True) == {}
 
-    assert m.dict(exclude={'a'}, skip_defaults=True) == {'b': 2}
-    assert m.dict(exclude={'c'}, skip_defaults=True) == {'a': 1, 'b': 2}
+    assert m.dict(exclude={'a'}, exclude_unset=True) == {'b': 2}
+    assert m.dict(exclude={'c'}, exclude_unset=True) == {'a': 1, 'b': 2}
 
-    assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, skip_defaults=True) == {'a': 1}
-    assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, skip_defaults=True) == {'b': 2}
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, exclude_unset=True) == {'a': 1}
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, exclude_unset=True) == {'b': 2}
 
 
 def test_advanced_exclude():
@@ -474,12 +474,12 @@ def test_field_set_ignore_extra():
     m = Model(a=1, b=2)
     assert m.dict() == {'a': 1, 'b': 2, 'c': 3}
     assert m.__fields_set__ == {'a', 'b'}
-    assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+    assert m.dict(exclude_unset=True) == {'a': 1, 'b': 2}
 
     m2 = Model(a=1, b=2, d=4)
     assert m2.dict() == {'a': 1, 'b': 2, 'c': 3}
     assert m2.__fields_set__ == {'a', 'b'}
-    assert m2.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+    assert m2.dict(exclude_unset=True) == {'a': 1, 'b': 2}
 
 
 def test_field_set_allow_extra():
@@ -494,12 +494,12 @@ def test_field_set_allow_extra():
     m = Model(a=1, b=2)
     assert m.dict() == {'a': 1, 'b': 2, 'c': 3}
     assert m.__fields_set__ == {'a', 'b'}
-    assert m.dict(skip_defaults=True) == {'a': 1, 'b': 2}
+    assert m.dict(exclude_unset=True) == {'a': 1, 'b': 2}
 
     m2 = Model(a=1, b=2, d=4)
     assert m2.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
     assert m2.__fields_set__ == {'a', 'b', 'd'}
-    assert m2.dict(skip_defaults=True) == {'a': 1, 'b': 2, 'd': 4}
+    assert m2.dict(exclude_unset=True) == {'a': 1, 'b': 2, 'd': 4}
 
 
 def test_field_set_field_name():
@@ -509,7 +509,7 @@ def test_field_set_field_name():
         b: int = 3
 
     assert Model(a=1, field_set=2).dict() == {'a': 1, 'field_set': 2, 'b': 3}
-    assert Model(a=1, field_set=2).dict(skip_defaults=True) == {'a': 1, 'field_set': 2}
+    assert Model(a=1, field_set=2).dict(exclude_unset=True) == {'a': 1, 'field_set': 2}
     assert Model.construct(dict(a=1, field_set=3), {'a', 'field_set'}).dict() == {'a': 1, 'field_set': 3}
 
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -373,26 +373,68 @@ def test_success_values_include():
     assert m.dict(include={'a', 'b'}, exclude={'a'}) == {'b': 2}
 
 
-def test_include_exclude_default():
+def test_include_exclude_unset():
     class Model(BaseModel):
         a: int
         b: int
         c: int = 3
         d: int = 4
+        e: int = 5
+        f: int = 6
 
-    m = Model(a=1, b=2)
-    assert m.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
-    assert m.__fields_set__ == {'a', 'b'}
-    assert m.dict(exclude_unset=True) == {'a': 1, 'b': 2}
+    m = Model(a=1, b=2, e=5, f=7)
+    assert m.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 7}
+    assert m.__fields_set__ == {'a', 'b', 'e', 'f'}
+    assert m.dict(exclude_unset=True) == {'a': 1, 'b': 2, 'e': 5, 'f': 7}
 
     assert m.dict(include={'a'}, exclude_unset=True) == {'a': 1}
     assert m.dict(include={'c'}, exclude_unset=True) == {}
 
-    assert m.dict(exclude={'a'}, exclude_unset=True) == {'b': 2}
-    assert m.dict(exclude={'c'}, exclude_unset=True) == {'a': 1, 'b': 2}
+    assert m.dict(exclude={'a'}, exclude_unset=True) == {'b': 2, 'e': 5, 'f': 7}
+    assert m.dict(exclude={'c'}, exclude_unset=True) == {'a': 1, 'b': 2, 'e': 5, 'f': 7}
 
     assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, exclude_unset=True) == {'a': 1}
     assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, exclude_unset=True) == {'b': 2}
+
+
+def test_include_exclude_defaults():
+    class Model(BaseModel):
+        a: int
+        b: int
+        c: int = 3
+        d: int = 4
+        e: int = 5
+        f: int = 6
+
+    m = Model(a=1, b=2, e=5, f=7)
+    assert m.dict() == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 7}
+    assert m.__fields_set__ == {'a', 'b', 'e', 'f'}
+    assert m.dict(exclude_defaults=True) == {'a': 1, 'b': 2, 'f': 7}
+
+    assert m.dict(include={'a'}, exclude_defaults=True) == {'a': 1}
+    assert m.dict(include={'c'}, exclude_defaults=True) == {}
+
+    assert m.dict(exclude={'a'}, exclude_defaults=True) == {'b': 2, 'f': 7}
+    assert m.dict(exclude={'c'}, exclude_defaults=True) == {'a': 1, 'b': 2, 'f': 7}
+
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, exclude_defaults=True) == {'a': 1}
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, exclude_defaults=True) == {'b': 2}
+
+
+def test_skip_defaults_deprecated():
+    class Model(BaseModel):
+        x: int
+
+    m = Model(x=1)
+    match = r'Model.dict\(\): "skip_defaults" is deprecated and replaced by "exclude_unset"'
+    with pytest.warns(DeprecationWarning, match=match):
+        assert m.dict(skip_defaults=True)
+    with pytest.warns(DeprecationWarning, match=match):
+        assert m.dict(skip_defaults=False)
+    with pytest.warns(DeprecationWarning, match=match):
+        assert m.json(skip_defaults=True)
+    with pytest.warns(DeprecationWarning, match=match):
+        assert m.json(skip_defaults=False)
 
 
 def test_advanced_exclude():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -431,6 +431,8 @@ def test_skip_defaults_deprecated():
         assert m.dict(skip_defaults=True)
     with pytest.warns(DeprecationWarning, match=match):
         assert m.dict(skip_defaults=False)
+
+    match = r'Model.json\(\): "skip_defaults" is deprecated and replaced by "exclude_unset"'
     with pytest.warns(DeprecationWarning, match=match):
         assert m.json(skip_defaults=True)
     with pytest.warns(DeprecationWarning, match=match):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -729,19 +729,19 @@ def test_fields_set():
     assert m.__fields_set__ == {'a', 'b'}
 
 
-def test_skip_defaults_dict():
+def test_exclude_unset_dict():
     class MyModel(BaseModel):
         a: int
         b: int = 2
 
     m = MyModel(a=5)
-    assert m.dict(skip_defaults=True) == {'a': 5}
+    assert m.dict(exclude_unset=True) == {'a': 5}
 
     m = MyModel(a=5, b=3)
-    assert m.dict(skip_defaults=True) == {'a': 5, 'b': 3}
+    assert m.dict(exclude_unset=True) == {'a': 5, 'b': 3}
 
 
-def test_skip_defaults_recursive():
+def test_exclude_unset_recursive():
     class ModelA(BaseModel):
         a: int
         b: int = 1
@@ -753,11 +753,11 @@ def test_skip_defaults_recursive():
 
     m = ModelB(c=5, e={'a': 0})
     assert m.dict() == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
-    assert m.dict(skip_defaults=True) == {'c': 5, 'e': {'a': 0}}
+    assert m.dict(exclude_unset=True) == {'c': 5, 'e': {'a': 0}}
     assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
 
 
-def test_dict_skip_defaults_populated_by_alias():
+def test_dict_exclude_unset_populated_by_alias():
     class MyModel(BaseModel):
         a: str = Field('default', alias='alias_a')
         b: str = Field('default', alias='alias_b')
@@ -767,11 +767,11 @@ def test_dict_skip_defaults_populated_by_alias():
 
     m = MyModel(alias_a='a')
 
-    assert m.dict(skip_defaults=True) == {'a': 'a'}
-    assert m.dict(skip_defaults=True, by_alias=True) == {'alias_a': 'a'}
+    assert m.dict(exclude_unset=True) == {'a': 'a'}
+    assert m.dict(exclude_unset=True, by_alias=True) == {'alias_a': 'a'}
 
 
-def test_dict_skip_defaults_populated_by_alias_with_extra():
+def test_dict_exclude_unset_populated_by_alias_with_extra():
     class MyModel(BaseModel):
         a: str = Field('default', alias='alias_a')
         b: str = Field('default', alias='alias_b')
@@ -781,8 +781,8 @@ def test_dict_skip_defaults_populated_by_alias_with_extra():
 
     m = MyModel(alias_a='a', c='c')
 
-    assert m.dict(skip_defaults=True) == {'a': 'a', 'c': 'c'}
-    assert m.dict(skip_defaults=True, by_alias=True) == {'alias_a': 'a', 'c': 'c'}
+    assert m.dict(exclude_unset=True) == {'a': 'a', 'c': 'c'}
+    assert m.dict(exclude_unset=True, by_alias=True) == {'alias_a': 'a', 'c': 'c'}
 
 
 def test_dir_fields():

--- a/tests/test_orm_mode.py
+++ b/tests/test_orm_mode.py
@@ -122,7 +122,7 @@ def test_object_with_getattr():
     model = Model.from_orm(foo)
     assert model.foo == 'Foo'
     assert model.bar == 1
-    assert model.dict(skip_defaults=True) == {'foo': 'Foo'}
+    assert model.dict(exclude_unset=True) == {'foo': 'Foo'}
     with pytest.raises(ValidationError):
         ModelInvalid.from_orm(foo)
 


### PR DESCRIPTION
## Change Summary

Rename `skip_defaults` to `exclude_unset`, and add `exclude_defaults` argument.

Still need to add tests and docs, but I wanted to get some feedback on the approach first.

## Related issue number

fix #523

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
