### PR TITLE
allow abstract sets in include and exclude arguments

### DIFF
--- a/changes/921-samuelcolvin.md
+++ b/changes/921-samuelcolvin.md
@@ -1,0 +1,1 @@
+Allow abstracts sets (eg. dict keys) in the `include` and `exclude` arguments of `dict()`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from .class_validators import ValidatorListDict
     from .types import ModelOrDc
     from .typing import CallableGenerator, TupleGenerator, DictStrAny, DictAny, SetStr
-    from .typing import SetIntStr, DictIntStrAny, ReprArgs  # noqa: F401
+    from .typing import AbstractSetIntStr, SetIntStr, DictIntStrAny, ReprArgs  # noqa: F401
 
     ConfigType = Type['BaseConfig']
     Model = TypeVar('Model', bound='BaseModel')
@@ -427,8 +427,8 @@ class BaseModel(metaclass=ModelMetaclass):
     def copy(
         self: 'Model',
         *,
-        include: Union['SetIntStr', 'DictIntStrAny'] = None,
-        exclude: Union['SetIntStr', 'DictIntStrAny'] = None,
+        include: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
+        exclude: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
         update: 'DictStrAny' = None,
         deep: bool = False,
     ) -> 'Model':
@@ -582,8 +582,8 @@ class BaseModel(metaclass=ModelMetaclass):
         to_dict: bool = False,
         by_alias: bool = False,
         allowed_keys: Optional['SetStr'] = None,
-        include: Union['SetIntStr', 'DictIntStrAny'] = None,
-        exclude: Union['SetIntStr', 'DictIntStrAny'] = None,
+        include: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
+        exclude: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
         skip_defaults: bool = False,
     ) -> 'TupleGenerator':
 
@@ -603,8 +603,8 @@ class BaseModel(metaclass=ModelMetaclass):
 
     def _calculate_keys(
         self,
-        include: Optional[Union['SetIntStr', 'DictIntStrAny']],
-        exclude: Optional[Union['SetIntStr', 'DictIntStrAny']],
+        include: Optional[Union['AbstractSetIntStr', 'DictIntStrAny']],
+        exclude: Optional[Union['AbstractSetIntStr', 'DictIntStrAny']],
         skip_defaults: bool,
         update: Optional['DictStrAny'] = None,
     ) -> Optional['SetStr']:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from .class_validators import ValidatorListDict
     from .types import ModelOrDc
     from .typing import CallableGenerator, TupleGenerator, DictStrAny, DictAny, SetStr
-    from .typing import AbstractSetIntStr, SetIntStr, DictIntStrAny, ReprArgs  # noqa: F401
+    from .typing import AbstractSetIntStr, DictIntStrAny, ReprArgs  # noqa: F401
 
     ConfigType = Type['BaseConfig']
     Model = TypeVar('Model', bound='BaseModel')
@@ -300,8 +300,8 @@ class BaseModel(metaclass=ModelMetaclass):
     def dict(
         self,
         *,
-        include: Union['SetIntStr', 'DictIntStrAny'] = None,
-        exclude: Union['SetIntStr', 'DictIntStrAny'] = None,
+        include: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
+        exclude: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
         by_alias: bool = False,
         skip_defaults: bool = False,
     ) -> 'DictStrAny':
@@ -333,8 +333,8 @@ class BaseModel(metaclass=ModelMetaclass):
     def json(
         self,
         *,
-        include: Union['SetIntStr', 'DictIntStrAny'] = None,
-        exclude: Union['SetIntStr', 'DictIntStrAny'] = None,
+        include: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
+        exclude: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
         by_alias: bool = False,
         skip_defaults: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
@@ -514,8 +514,8 @@ class BaseModel(metaclass=ModelMetaclass):
         v: Any,
         to_dict: bool,
         by_alias: bool,
-        include: Optional[Union['SetIntStr', 'DictIntStrAny']],
-        exclude: Optional[Union['SetIntStr', 'DictIntStrAny']],
+        include: Optional[Union['AbstractSetIntStr', 'DictIntStrAny']],
+        exclude: Optional[Union['AbstractSetIntStr', 'DictIntStrAny']],
         skip_defaults: bool,
     ) -> Any:
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -2,6 +2,7 @@ import sys
 from enum import Enum
 from typing import (  # type: ignore
     TYPE_CHECKING,
+    AbstractSet,
     Any,
     ClassVar,
     Dict,
@@ -63,6 +64,7 @@ if TYPE_CHECKING:
     ListStr = List[str]
     IntStr = Union[int, str]
     SetIntStr = Set[IntStr]
+    AbstractSetIntStr = AbstractSet[IntStr]
     DictIntStrAny = Dict[IntStr, Any]
     CallableGenerator = Generator[AnyCallable, None, None]
     ReprArgs = Sequence[Tuple[Optional[str], Any]]
@@ -93,6 +95,8 @@ __all__ = (
     'DictIntStrAny',
     'CallableGenerator',
     'ReprArgs',
+    'AbstractSetIntStr',
+    'CallableGenerator',
 )
 
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -63,7 +63,6 @@ if TYPE_CHECKING:
     SetStr = Set[str]
     ListStr = List[str]
     IntStr = Union[int, str]
-    SetIntStr = Set[IntStr]
     AbstractSetIntStr = AbstractSet[IntStr]
     DictIntStrAny = Dict[IntStr, Any]
     CallableGenerator = Generator[AnyCallable, None, None]
@@ -91,11 +90,10 @@ __all__ = (
     'SetStr',
     'ListStr',
     'IntStr',
-    'SetIntStr',
+    'AbstractSetIntStr',
     'DictIntStrAny',
     'CallableGenerator',
     'ReprArgs',
-    'AbstractSetIntStr',
     'CallableGenerator',
 )
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -3,6 +3,7 @@ import warnings
 from importlib import import_module
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -27,7 +28,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
-    from .typing import SetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
+    from .typing import AbstractSetIntStr, SetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
 
 KeyType = TypeVar('KeyType')
 
@@ -247,15 +248,15 @@ class ValueItems(Representation):
 
     __slots__ = ('_items', '_type')
 
-    def __init__(self, value: Any, items: Union['SetIntStr', 'DictIntStrAny']) -> None:
+    def __init__(self, value: Any, items: Union['AbstractSetIntStr', 'DictIntStrAny']) -> None:
         if TYPE_CHECKING:
-            self._items: Union['SetIntStr', 'DictIntStrAny']
+            self._items: Union['AbstractSetIntStr', 'DictIntStrAny']
             self._type: Type[Union[set, dict]]  # type: ignore
 
         # For further type checks speed-up
         if isinstance(items, dict):
             self._type = dict
-        elif isinstance(items, set):
+        elif isinstance(items, AbstractSet):
             self._type = set
         else:
             raise TypeError(f'Unexpected type of exclude value {type(items)}')

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -28,7 +28,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
-    from .typing import AbstractSetIntStr, SetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
+    from .typing import AbstractSetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
 
 KeyType = TypeVar('KeyType')
 
@@ -289,7 +289,7 @@ class ValueItems(Representation):
         return item in self._items
 
     @no_type_check
-    def for_element(self, e: 'IntStr') -> Optional[Union['SetIntStr', 'DictIntStrAny']]:
+    def for_element(self, e: 'IntStr') -> Optional[Union['AbstractSetIntStr', 'DictIntStrAny']]:
         """
         :param e: key or index of element on value
         :return: raw values for elemet if self._items is dict and contain needed element
@@ -302,8 +302,8 @@ class ValueItems(Representation):
 
     @no_type_check
     def _normalize_indexes(
-        self, items: Union['SetIntStr', 'DictIntStrAny'], v_length: int
-    ) -> Union['SetIntStr', 'DictIntStrAny']:
+        self, items: Union['AbstractSetIntStr', 'DictIntStrAny'], v_length: int
+    ) -> Union['AbstractSetIntStr', 'DictIntStrAny']:
         """
         :param items: dict or set of indexes which will be normalized
         :param v_length: length of sequence indexes of which will be

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -394,6 +394,10 @@ def test_include_exclude_default():
     assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, skip_defaults=True) == {'a': 1}
     assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, skip_defaults=True) == {'b': 2}
 
+    # abstract set
+    assert m.dict(include={'a': 1}.keys(), skip_defaults=True) == {'a': 1}
+    assert m.dict(exclude={'a': 1}.keys(), skip_defaults=True) == {'b': 2}
+
 
 def test_advanced_exclude():
     class SubSubModel(BaseModel):


### PR DESCRIPTION
## Change Summary

Ease the process of migrating to pydantic v1 by allowing abstracts sets (eg. dict keys) in the `include` and `exclude` arguments to `dict()`.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
