### PR TITLE
Mention python 3.8 in docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,7 @@ To make contributing as easy and fast as possible, you'll want to run tests and 
 *pydantic* has few dependencies, doesn't require compiling and tests don't need access to databases, etc.
 Because of this, setting up and running the tests should be very simple.
 
-You'll need to have **python 3.6** or **3.7**, **virtualenv**, **git**, and **make** installed.
+You'll need to have **python 3.6**, **3.7**, or **3.8**, **virtualenv**, **git**, and **make** installed.
 
 ```bash
 # 1. clone your fork and cd into the repo directory

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,8 +4,8 @@ Installation is as simple as:
 pip install pydantic
 ```
 
-*pydantic* has no required dependencies except python 3.6 or 3.7 (and the dataclasses package in python 3.6).
-If you've got python 3.6 and `pip` installed, you're good to go.
+*pydantic* has no required dependencies except python 3.6, 3.7, or 3.8 (and the dataclasses package in python 3.6).
+If you've got python 3.6+ and `pip` installed, you're good to go.
 
 Pydantic is also available on [conda](https://www.anaconda.com) under the [conda-forge](https://conda-forge.org)
 channel:
@@ -15,7 +15,7 @@ conda install pydantic -c conda-forge
 ```
 
 *pydantic* can optionally be compiled with [cython](https://cython.org/) which should give a 30-50% performance
-improvement. `manylinux` binaries exist for python 3.6 and 3.7, so if you're installing from PyPI on linux, you
+improvement. `manylinux` binaries exist for python 3.6, 3.7, and 3.8, so if you're installing from PyPI on linux, you
 should get a compiled version of *pydantic* with no extra work. If you're installing manually, install `cython`
 before installing *pydantic* and compilation should happen automatically. Compilation with cython
 [is not tested](https://github.com/samuelcolvin/pydantic/issues/555) on windows or mac.


### PR DESCRIPTION
Since Python 3.8 is now a thing, I thought I would update the docs to reflect that. This is a trivial change so I didn't open an issue.

## Checklist

* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
