### PR TITLE
Fix generic typehint for pycharm

### DIFF
--- a/changes/936-dmontagu.md
+++ b/changes/936-dmontagu.md
@@ -1,0 +1,1 @@
+Change return type typehint for `GenericModel.__class_getitem__` to prevent PyCharm warnings

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -17,7 +17,7 @@ class GenericModel(BaseModel):
         else:
             raise TypeError(f'Type {cls.__name__} cannot be used without generic parameters, e.g. {cls.__name__}[T]')
 
-    # Setting the return type as Type[Any] instead of Type[BaseModel] prevents PyCharm errors
+    # Setting the return type as Type[Any] instead of Type[BaseModel] prevents PyCharm warnings
     def __class_getitem__(cls: Type[GenericModelT], params: Union[Type[Any], Tuple[Type[Any], ...]]) -> Type[Any]:
         cached = _generic_types_cache.get((cls, params))
         if cached is not None:

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -17,7 +17,8 @@ class GenericModel(BaseModel):
         else:
             raise TypeError(f'Type {cls.__name__} cannot be used without generic parameters, e.g. {cls.__name__}[T]')
 
-    def __class_getitem__(cls: Type[GenericModelT], params: Union[Type[Any], Tuple[Type[Any], ...]]) -> Type[BaseModel]:
+    # Setting the return type as Type[Any] instead of Type[BaseModel] prevents PyCharm errors
+    def __class_getitem__(cls: Type[GenericModelT], params: Union[Type[Any], Tuple[Type[Any], ...]]) -> Type[Any]:
         cached = _generic_types_cache.get((cls, params))
         if cached is not None:
             return cached


### PR DESCRIPTION
## Change Summary

Modifies a type hint to prevent pycharm from raising warnings.

I believe this was caused by pycharm recently starting to incorporate the return type of `__class_getitem__` into its type-checking logic.

## Related issue number

https://github.com/tiangolo/fastapi/issues/653

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
