### PR TITLE
Add better support for validator reuse

### DIFF
--- a/changes/940-dmontagu.md
+++ b/changes/940-dmontagu.md
@@ -1,0 +1,1 @@
+Add better support for reusable validators

--- a/changes/940-dmontagu.md
+++ b/changes/940-dmontagu.md
@@ -1,1 +1,1 @@
-Add better support for reusable validators
+Add `allow_reuse` argument to validators, thus allowing validator reuse

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -123,10 +123,10 @@ def _check_validator_name(f: AnyCallable, allow_reuse: bool) -> None:
     """
     if in_ipython():  # pragma: no cover
         return
-    if not allow_reuse and '.' in f.__qualname__:
+    if not allow_reuse:
         ref = f.__module__ + '.' + f.__qualname__
         if ref in _FUNCS:
-            raise ConfigError(f'duplicate validator function "{ref}"')
+            raise ConfigError(f'duplicate validator function "{ref}"; if this is intended, set `allow_reuse=True`')
         _FUNCS.add(ref)
 
 

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -121,7 +121,7 @@ def _check_validator_name(f: AnyCallable, allow_reuse: bool) -> None:
     does not check for duplicated names in functions defined at the module-global level
     since such validators are likely intended for reuse
     """
-    if in_ipython():  # pragma: no branch
+    if in_ipython():  # pragma: no cover
         return
     if not allow_reuse and '.' in f.__qualname__:
         ref = f.__module__ + '.' + f.__qualname__

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -51,6 +51,7 @@ def validator(
     always: bool = False,
     check_fields: bool = True,
     whole: bool = None,
+    allow_reuse: bool = False,
 ) -> Callable[[AnyCallable], classmethod]:
     """
     Decorate methods on the class indicating that they should be used to validate fields
@@ -60,6 +61,7 @@ def validator(
       whole object
     :param always: whether this method and other validators should be called even if the value is missing
     :param check_fields: whether to check that the fields actually exist on the model
+    :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
     """
     if not fields:
         raise ConfigError('validator with no fields specified')
@@ -78,7 +80,8 @@ def validator(
         each_item = not whole
 
     def dec(f: AnyCallable) -> classmethod:
-        _check_validator_name(f)
+        f = f.__func__ if isinstance(f, classmethod) else f
+        _check_validator_name(f, allow_reuse)
         f_cls = classmethod(f)
         setattr(
             f_cls,
@@ -91,16 +94,18 @@ def validator(
 
 
 def root_validator(
-    _func: Optional[AnyCallable] = None, *, pre: bool = False
+    _func: Optional[AnyCallable] = None, *, pre: bool = False, allow_reuse: bool = False
 ) -> Union[classmethod, Callable[[AnyCallable], classmethod]]:
     if _func:
-        _check_validator_name(_func)
+        _func = _func.__func__ if isinstance(_func, classmethod) else _func
+        _check_validator_name(_func, allow_reuse)
         f_cls = classmethod(_func)
         setattr(f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=_func, pre=pre))
         return f_cls
 
     def dec(f: AnyCallable) -> classmethod:
-        _check_validator_name(f)
+        f = f.__func__ if isinstance(f, classmethod) else f
+        _check_validator_name(f, allow_reuse)
         f_cls = classmethod(f)
         setattr(f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=f, pre=pre))
         return f_cls
@@ -108,12 +113,17 @@ def root_validator(
     return dec
 
 
-def _check_validator_name(f: AnyCallable) -> None:
+def _check_validator_name(f: AnyCallable, allow_reuse: bool) -> None:
     """
     avoid validators with duplicated names since without this, validators can be overwritten silently
     which generally isn't the intended behaviour, don't run in ipython - see #312
+
+    does not check for duplicated names in functions defined at the module-global level
+    since such validators are likely intended for reuse
     """
-    if not in_ipython():  # pragma: no branch
+    if in_ipython():  # pragma: no branch
+        return
+    if not allow_reuse and '.' in f.__qualname__:
         ref = f.__module__ + '.' + f.__qualname__
         if ref in _FUNCS:
             raise ConfigError(f'duplicate validator function "{ref}"')

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -80,9 +80,9 @@ def validator(
         each_item = not whole
 
     def dec(f: AnyCallable) -> classmethod:
-        f = f.__func__ if isinstance(f, classmethod) else f
+        f_cls = classmethod(f) if not isinstance(f, classmethod) else f
+        f = f_cls.__func__
         _check_validator_name(f, allow_reuse)
-        f_cls = classmethod(f)
         setattr(
             f_cls,
             VALIDATOR_CONFIG_KEY,
@@ -97,16 +97,16 @@ def root_validator(
     _func: Optional[AnyCallable] = None, *, pre: bool = False, allow_reuse: bool = False
 ) -> Union[classmethod, Callable[[AnyCallable], classmethod]]:
     if _func:
-        _func = _func.__func__ if isinstance(_func, classmethod) else _func
+        f_cls = classmethod(_func) if not isinstance(_func, classmethod) else _func
+        _func = f_cls.__func__
         _check_validator_name(_func, allow_reuse)
-        f_cls = classmethod(_func)
         setattr(f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=_func, pre=pre))
         return f_cls
 
     def dec(f: AnyCallable) -> classmethod:
-        f = f.__func__ if isinstance(f, classmethod) else f
+        f_cls = classmethod(f) if not isinstance(f, classmethod) else f
+        f = f_cls.__func__
         _check_validator_name(f, allow_reuse)
-        f_cls = classmethod(f)
         setattr(f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=f, pre=pre))
         return f_cls
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -933,13 +933,13 @@ def declare_with_reused_validators(include_root, allow_1, allow_2, allow_3):
         def duplicate_name(cls, v):
             return v
 
-        @validator('b', allow_reuse=allow_2)  # noqa
-        def duplicate_name(cls, v):  # noqa
+        @validator('b', allow_reuse=allow_2)  # noqa F811
+        def duplicate_name(cls, v):
             return v
 
         if include_root:
 
-            @root_validator(allow_reuse=allow_3)
+            @root_validator(allow_reuse=allow_3)  # noqa F811
             def duplicate_name(cls, values):
                 return values
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -934,13 +934,13 @@ def declare_with_reused_validators(include_root, allow_1, allow_2, allow_3):
             return v
 
         @validator('b', allow_reuse=allow_2)  # noqa F811
-        def duplicate_name(cls, v):
+        def duplicate_name(cls, v):  # noqa F811
             return v
 
         if include_root:
 
             @root_validator(allow_reuse=allow_3)  # noqa F811
-            def duplicate_name(cls, values):
+            def duplicate_name(cls, values):  # noqa F811
                 return values
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -236,7 +236,9 @@ def test_duplicates():
                 return v
 
     assert str(exc_info.value) == (
-        'duplicate validator function ' '"tests.test_validators.test_duplicates.<locals>.Model.duplicate_name"'
+        'duplicate validator function '
+        '"tests.test_validators.test_duplicates.<locals>.Model.duplicate_name"; '
+        'if this is intended, set `allow_reuse=True`'
     )
 
 
@@ -918,8 +920,8 @@ def test_reuse_global_validators():
         x: int
         y: int
 
-        double_x = validator('x')(reusable_validator)
-        double_y = validator('y')(reusable_validator)
+        double_x = validator('x', allow_reuse=True)(reusable_validator)
+        double_y = validator('y', allow_reuse=True)(reusable_validator)
 
     assert dict(Model(x=1, y=1)) == {'x': 2, 'y': 2}
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from itertools import product
 from typing import Dict, List, Optional, Tuple
 
 import pytest
@@ -756,7 +757,7 @@ def test_root_validator():
             return v * 2
 
         @root_validator
-        def root_validator(cls, values):
+        def example_root_validator(cls, values):
             root_val_values.append(values)
             if 'snap' in values.get('b', ''):
                 raise ValueError('foobar')
@@ -906,3 +907,99 @@ def test_root_validator_inheritance():
     assert len(Child.__pre_root_validators__) == 0
     assert Child(a=123).dict() == {'extra2': 2, 'extra1': 1, 'a': 123}
     assert calls == ["parent validator: {'a': 123}", "child validator: {'extra1': 1, 'a': 123}"]
+
+
+def reusable_validator(num):
+    return num * 2
+
+
+def test_reuse_global_validators():
+    class Model(BaseModel):
+        x: int
+        y: int
+
+        double_x = validator('x')(reusable_validator)
+        double_y = validator('y')(reusable_validator)
+
+    assert dict(Model(x=1, y=1)) == {'x': 2, 'y': 2}
+
+
+def declare_with_reused_validators(include_root, allow_1, allow_2, allow_3):
+    class Model(BaseModel):
+        a: str
+        b: str
+
+        @validator('a', allow_reuse=allow_1)
+        def duplicate_name(cls, v):
+            return v
+
+        @validator('b', allow_reuse=allow_2)  # noqa
+        def duplicate_name(cls, v):  # noqa
+            return v
+
+        if include_root:
+
+            @root_validator(allow_reuse=allow_3)
+            def duplicate_name(cls, values):
+                return values
+
+
+@pytest.fixture
+def reset_tracked_validators():
+    from pydantic.class_validators import _FUNCS
+
+    original_tracked_validators = set(_FUNCS)
+    yield
+    _FUNCS.clear()
+    _FUNCS.update(original_tracked_validators)
+
+
+@pytest.mark.parametrize('include_root,allow_1,allow_2,allow_3', product(*[[True, False]] * 4))
+def test_allow_reuse(include_root, allow_1, allow_2, allow_3, reset_tracked_validators):
+    duplication_count = int(not allow_1) + int(not allow_2) + int(include_root and not allow_3)
+    if duplication_count > 1:
+        with pytest.raises(ConfigError) as exc_info:
+            declare_with_reused_validators(include_root, allow_1, allow_2, allow_3)
+        assert str(exc_info.value).startswith('duplicate validator function')
+    else:
+        declare_with_reused_validators(include_root, allow_1, allow_2, allow_3)
+
+
+@pytest.mark.parametrize('validator_classmethod,root_validator_classmethod', product(*[[True, False]] * 2))
+def test_root_validator_classmethod(validator_classmethod, root_validator_classmethod, reset_tracked_validators):
+    root_val_values = []
+
+    class Model(BaseModel):
+        a: int = 1
+        b: str
+
+        def repeat_b(cls, v):
+            return v * 2
+
+        if validator_classmethod:
+            repeat_b = classmethod(repeat_b)
+        repeat_b = validator('b')(repeat_b)
+
+        def example_root_validator(cls, values):
+            root_val_values.append(values)
+            if 'snap' in values.get('b', ''):
+                raise ValueError('foobar')
+            return dict(values, b='changed')
+
+        if root_validator_classmethod:
+            example_root_validator = classmethod(example_root_validator)
+        example_root_validator = root_validator(example_root_validator)
+
+    assert Model(a='123', b='bar').dict() == {'a': 123, 'b': 'changed'}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(b='snap dragon')
+    assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'foobar', 'type': 'value_error'}]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='broken', b='bar')
+    assert exc_info.value.errors() == [
+        {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+    ]
+
+    assert root_val_values == [{'a': 123, 'b': 'barbar'}, {'a': 1, 'b': 'snap dragonsnap dragon'}, {'b': 'barbar'}]


### PR DESCRIPTION
## Change Summary

Adds a few things:
* Add `allow_reuse` argument to `validator` and `root_validator` indicating that the validator should not be tracked for accidental name collisions.
* Always allow reuse of validators defined at the module level, since those are not likely to be accidents
* Support directly passing classmethods to `root_validator` and `validator` so that you can declare a reused validator/root validator as a classmethod prior to passing it to the decorators.

(I still need to add documentation.)

## Related issue number

fix #940

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
