### PR TITLE
Add TemplateStr type

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -304,6 +304,14 @@ class StrRegexError(PydanticValueError):
         super().__init__(pattern=pattern)
 
 
+class TemplateStrError(PydanticValueError):
+    code = 'str.template'
+    msg_template = 'invalid template string, expected keys: {expected_keys}, actual keys: {actual_keys}'
+
+    def __init__(self, expected_keys, actual_keys):
+        super().__init__(expected_keys=expected_keys, actual_keys=actual_keys)
+
+
 class _NumberBoundError(PydanticValueError):
     def __init__(self, *, limit_value: Union[int, float, Decimal]) -> None:
         super().__init__(limit_value=limit_value)

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Set, Union
+from typing import Any, List, Set, Union
 
 from .typing import AnyType, display_as_type
 
@@ -308,7 +308,9 @@ class TemplateStrError(PydanticValueError):
     code = 'str.template'
     msg_template = 'invalid template string, expected keys: {expected_keys}, actual keys: {actual_keys}'
 
-    def __init__(self, expected_keys, actual_keys):
+    def __init__(
+        self, expected_keys: Union[int, Set[str], List[str]], actual_keys: Union[int, Set[str], List[str]]
+    ) -> None:
         super().__init__(expected_keys=expected_keys, actual_keys=actual_keys)
 
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -210,15 +210,14 @@ class StrictStr(ConstrainedStr):
 
 class TemplateStrMeta(type):
     # can't use __class_getattr__ since it doesnt work on python 3.6
-    def __getitem__(cls, keys: Union[str, int, Tuple[str, ...]]):
+    def __getitem__(cls, keys: Union[str, int, Tuple[str, ...]]) -> Type['TemplateStr']:
         if isinstance(keys, int):
             # no named keys, check their quantity
-            name = f"{cls.__name__}[{keys}]"
+            name = f'{cls.__name__}[{keys}]'
             namespace = dict(__quantity__=keys)
         else:
-            keys = set(keys) if isinstance(keys, tuple) else {keys}
             name = f'{cls.__name__}[{", ".join(map(repr, keys))}]'
-            namespace = dict(__keys__=keys)
+            namespace = dict(__keys__=set(keys) if isinstance(keys, tuple) else {keys})  # type: ignore
 
         return new_class(name=name, bases=(cls,), exec_body=lambda ns: ns.update(namespace))
 
@@ -235,7 +234,7 @@ class TemplateStr(str, metaclass=TemplateStrMeta):
             yield cls.validate_quantity
 
     @classmethod
-    def validate_keys(cls, v) -> str:
+    def validate_keys(cls, v: Any) -> str:
         v = str(v)
         found_keys = {
             field_name + ('!' + conversion if conversion else '') + (':' + format_spec if format_spec else '')
@@ -248,7 +247,7 @@ class TemplateStr(str, metaclass=TemplateStrMeta):
         return v
 
     @classmethod
-    def validate_quantity(cls, v):
+    def validate_quantity(cls, v: Any) -> str:
         v = str(v)
         expected_quantity = cls.__quantity__
         found_keys = [
@@ -264,7 +263,6 @@ class TemplateStr(str, metaclass=TemplateStrMeta):
 
 
 if TYPE_CHECKING:
-    TemplateStr = str
     StrictBool = bool
 else:
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import uuid
 from collections import OrderedDict
@@ -34,6 +35,7 @@ from pydantic import (
     StrictFloat,
     StrictInt,
     StrictStr,
+    TemplateStr,
     ValidationError,
     conbytes,
     condecimal,
@@ -944,6 +946,47 @@ def test_strict_str():
 
     with pytest.raises(ValidationError):
         Model(v=b'foobar')
+
+
+@pytest.mark.parametrize(
+    'tmpl_str,keys',
+    (
+        ('f{key}b', 'key'),
+        ('f{key!r}{k}b', ('key!r', 'k')),
+        ('foo{key.__class__!r:20}{key}bar{key}', ('key.__class__!r:20', 'key')),
+    ),
+)
+def test_template_str_keys(tmpl_str, keys):
+    class Model(BaseModel):
+        v: TemplateStr[keys]
+
+    m = Model(v=tmpl_str)
+    assert m.v == tmpl_str
+
+
+@pytest.mark.parametrize('tmpl_str', ('{}', 'f{key!r}{k}b', 'foo{key.__class__!r:20}{key}bar{key}', '{k}{key}', 'foo'))
+def test_template_str_wrong_keys(tmpl_str):
+    class Model(BaseModel):
+        v: TemplateStr['key']
+
+    with pytest.raises(ValidationError, match='invalid template string'):
+        Model(v=tmpl_str)
+
+
+def test_template_str_quantity():
+    class Model(BaseModel):
+        a: TemplateStr[1]
+        b: TemplateStr[5] = None
+
+    m = Model(a='foo{}bar', b='A{}-{}-{}-{}-{}!')
+    assert m.a == 'foo{}bar'
+    assert m.b == 'A{}-{}-{}-{}-{}!'
+
+    with pytest.raises(ValidationError, match='expected keys: 1, actual keys: 2'):
+        m = Model(a='{}{}')
+
+    with pytest.raises(ValidationError, match=re.escape("expected keys: ['{}'], actual keys: [':20']")):
+        m = Model(a='{:20}')
 
 
 def test_strict_bool():


### PR DESCRIPTION
## Change Summary
Add TemplateStr type to validate template strings that can be formatted
Validates that all specified keys present in given string and checks that they are exactly same format, as specified

```py
from pydantic import BaseModel, ValidationError, TemplateStr


class Templates(BaseModel):
    a: TemplateStr['foo']
    b: TemplateStr['foo[4]']
    c: TemplateStr['foo.__class__.__name__!r:15']
    d: TemplateStr[3]


t = Templates(
    a='Only {foo}',
    b='Only fifth char: {foo[4]}',
    c='{foo.__class__.__name__!r:15} <- our class name',
    d='3 positional items: {}, {}, {}',
)
print(
    t.a.format(foo='bar!'),
    t.b.format(foo='123456789'),
    t.c.format(foo=t),
    t.d.format('foo', 'bar', 'baz'),
    '\n',
    sep = '\n'
)

try:
    Templates(
        a='Not only foo {foo!r}:',
        b='Not fifth char: {foo[10]}',
        c='We did not allow that: {foo.__dict__}',
        d='4 positional items?! {}{}{}{}'
    )
except ValidationError as e:
    print(e)

'''
Only bar!
Only fifth char: 5
'Templates'     <- our class name
3 positional items: foo, bar, baz
'''


4 validation errors for Templates
a
  invalid template string, expected keys: {'foo'}, actual keys: {'foo!r'} (type=value_error.str.template; expected_keys={'foo'}; actual_keys={'foo!r'})
b
  invalid template string, expected keys: {'foo[4]'}, actual keys: {'foo[10]'} (type=value_error.str.template; expected_keys={'foo[4]'}; actual_keys={'foo[10]'})
c
  invalid template string, expected keys: {'foo.__class__.__name__!r:15'}, actual keys: {'foo.__dict__'} (type=value_error.str.template; expected_keys={'foo.__class__.__name__!r:15'}; actual_keys={'foo.__dict__'})
d
  invalid template string, expected keys: 3, actual keys: 4 (type=value_error.str.template; expected_keys=3; actual_keys=4)
```


## Related issue number
Closes #938 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
