### PR TITLE
Fixed PositiveFloat and PositiveInt description

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -398,7 +398,7 @@ _(This script is complete, it should run "as is")_
   see [Constrained Types](#constrained-types)
 
 `NegativeInt`
-: allows a int which is negative; uses standard `int` parsing then checks the value is less than 0;
+: allows an int which is negative; uses standard `int` parsing then checks the value is less than 0;
   see [Constrained Types](#constrained-types)
 
 `PositiveFloat`
@@ -406,7 +406,7 @@ _(This script is complete, it should run "as is")_
   see [Constrained Types](#constrained-types)
 
 `PositiveInt`
-: allows a int which is positive; uses standard `int` parsing then checks the value is greater than 0;
+: allows an int which is positive; uses standard `int` parsing then checks the value is greater than 0;
   see [Constrained Types](#constrained-types)
 
 `conbytes`

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -402,11 +402,11 @@ _(This script is complete, it should run "as is")_
   see [Constrained Types](#constrained-types)
 
 `PositiveFloat`
-: allows a float which is negative; uses standard `float` parsing then checks the value is greater than 0;
+: allows a float which is positive; uses standard `float` parsing then checks the value is greater than 0;
   see [Constrained Types](#constrained-types)
 
 `PositiveInt`
-: allows a int which is negative; uses standard `int` parsing then checks the value is greater than 0;
+: allows a int which is positive; uses standard `int` parsing then checks the value is greater than 0;
   see [Constrained Types](#constrained-types)
 
 `conbytes`


### PR DESCRIPTION
changed "negative" word to "positive"

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
