### PR TITLE
Add support for mapping types as custom root

### DIFF
--- a/changes/958-dmontagu.md
+++ b/changes/958-dmontagu.md
@@ -1,0 +1,1 @@
+Add support for mapping types for custom root models 

--- a/docs/examples/models_custom_root_field_parse_obj.py
+++ b/docs/examples/models_custom_root_field_parse_obj.py
@@ -1,0 +1,17 @@
+from typing import List, Dict
+from pydantic import BaseModel, ValidationError
+
+class Pets(BaseModel):
+    __root__: List[str]
+
+print(Pets.parse_obj(['dog', 'cat']))
+print(Pets.parse_obj({'__root__': ['dog', 'cat']}))  # not recommended
+
+class PetsByName(BaseModel):
+    __root__: Dict[str, str]
+
+print(PetsByName.parse_obj({'Otis': 'dog', 'Milo': 'cat'}))
+try:
+    PetsByName.parse_obj({'__root__': {'Otis': 'dog', 'Milo': 'cat'}})
+except ValidationError as e:
+    print(e)

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -325,7 +325,7 @@ extending a base model with extra fields.
 ## Custom Root Types
 
 Pydantic models can be defined with a custom root type by declaring the `__root__` field.
-The root type can be of any type: list, float, int, etc.
+The root type can be of any type: dict, list, float, int, etc.
 
 The root type is defined via the type hint on the `__root__` field.
 The root value can be passed to model `__init__` via the `__root__` keyword argument or as

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -334,6 +334,25 @@ the first and only argument to `parse_obj`.
 {!.tmp_examples/models_custom_root_field.py!}
 ```
 
+If you call the `parse_obj` method for a model with a custom root type with a *dict* as the first argument,
+the following logic is used:
+
+* If the custom root type is a mapping type (eg., `Dict` or `Mapping`),
+  the argument itself is always validated against the custom root type.
+* For other custom root types, if the dict has precisely one key with the value `__root__`,
+  the corresponding value will be validated against the custom root type.
+* Otherwise, the dict itself is validated against the custom root type.    
+
+This is demonstrated in the following example:
+
+```py
+{!.tmp_examples/models_custom_root_field_parse_obj.py!}
+```
+
+!!! warning
+    Calling the `parse_obj` method on a dict with the single key `"__root__"` for non-mapping custom root types
+    is currently supported for backwards compatibility, but is not recommended and may be dropped in a future version.
+
 ## Faux Immutability
 
 Models can be configured to be immutable via `allow_mutation = False`. When this is set, attempting to change the

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -324,11 +324,10 @@ extending a base model with extra fields.
 
 ## Custom Root Types
 
-Pydantic models can be defined with a custom root type by declaring the `__root__` field.
-The root type can be of any type: dict, list, float, int, etc.
+Pydantic models can be defined with a custom root type by declaring the `__root__` field. 
 
-The root type is defined via the type hint on the `__root__` field.
-The root value can be passed to model `__init__` via the `__root__` keyword argument or as
+The root type can be any type supported by pydantic, and is specified by the type hint on the `__root__` field.
+The root value can be passed to the model `__init__` via the `__root__` keyword argument, or as
 the first and only argument to `parse_obj`.
 
 ```py

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -324,8 +324,8 @@ extending a base model with extra fields.
 
 ## Custom Root Types
 
-Pydantic models which do not represent a `dict` ("object" in JSON parlance) can have a custom
-root type defined via the `__root__` field. The root type can be of any type: list, float, int, etc.
+Pydantic models can be defined with a custom root type by declaring the `__root__` field.
+The root type can be of any type: list, float, int, etc.
 
 The root type is defined via the type hint on the `__root__` field.
 The root value can be passed to model `__init__` via the `__root__` keyword argument or as

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -384,7 +384,7 @@ class BaseModel(metaclass=ModelMetaclass):
             not (isinstance(obj, dict) and obj.keys() == {ROOT_KEY}) or cls.__fields__[ROOT_KEY].shape == SHAPE_MAPPING
         ):
             obj = {ROOT_KEY: obj}
-        if not isinstance(obj, dict):
+        elif not isinstance(obj, dict):
             try:
                 obj = dict(obj)
             except (TypeError, ValueError) as e:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 from .class_validators import ROOT_KEY, ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
 from .error_wrappers import ErrorWrapper, ValidationError
 from .errors import ConfigError, DictError, ExtraError, MissingError
-from .fields import ModelField
+from .fields import SHAPE_MAPPING, ModelField
 from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
@@ -380,7 +380,9 @@ class BaseModel(metaclass=ModelMetaclass):
 
     @classmethod
     def parse_obj(cls: Type['Model'], obj: Any) -> 'Model':
-        if cls.__custom_root_type__ and not (isinstance(obj, dict) and obj.keys() == {'__root__'}):
+        if cls.__custom_root_type__ and (
+            not (isinstance(obj, dict) and obj.keys() == {ROOT_KEY}) or cls.__fields__[ROOT_KEY].shape == SHAPE_MAPPING
+        ):
             obj = {ROOT_KEY: obj}
         if not isinstance(obj, dict):
             try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -908,7 +908,7 @@ def test_parse_root_as_mapping():
     with pytest.raises(ValidationError) as exc_info:
         MyModel.parse_obj({'__root__': {'1': '2'}})
     assert exc_info.value.errors() == [
-        {'loc': ('__root__', '__root__'), 'msg': 'str type expected', 'type': 'type_error.str',}
+        {'loc': ('__root__', '__root__'), 'msg': 'str type expected', 'type': 'type_error.str'}
     ]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -918,10 +918,16 @@ def test_parse_obj_non_mapping_root():
 
     assert MyModel.parse_obj(['a']).__root__ == ['a']
     assert MyModel.parse_obj({'__root__': ['a']}).__root__ == ['a']
-    with pytest.raises(ValidationError, match='...'):
+    with pytest.raises(ValidationError) as exc_info:
         MyModel.parse_obj({'__not_root__': ['a']})
-    with pytest.raises(ValidationError, match='...'):
+    assert exc_info.value.errors() == [
+        {'loc': ('__root__',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}
+    ]
+    with pytest.raises(ValidationError):
         MyModel.parse_obj({'__root__': ['a'], 'other': 1})
+    assert exc_info.value.errors() == [
+        {'loc': ('__root__',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}
+    ]
 
 
 def test_untouched_types():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -905,6 +905,20 @@ def test_parse_root_as_mapping():
 
     assert MyModel.parse_obj({1: 2}).__root__ == {'1': '2'}
 
+    with pytest.raises(ValidationError) as exc_info:
+        MyModel.parse_obj({'__root__': {'1': '2'}})
+    assert exc_info.value.errors() == [
+        {'loc': ('__root__', '__root__'), 'msg': 'str type expected', 'type': 'type_error.str',}
+    ]
+
+
+def test_parse_obj_non_mapping_root():
+    class MyModel(BaseModel):
+        __root__: List[str]
+
+    assert MyModel.parse_obj(['a']).__root__ == ['a']
+    assert MyModel.parse_obj({'__root__': ['a']}).__root__ == ['a']
+
 
 def test_untouched_types():
     from pydantic import BaseModel

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -918,6 +918,10 @@ def test_parse_obj_non_mapping_root():
 
     assert MyModel.parse_obj(['a']).__root__ == ['a']
     assert MyModel.parse_obj({'__root__': ['a']}).__root__ == ['a']
+    with pytest.raises(ValidationError, match='...'):
+        MyModel.parse_obj({'__not_root__': ['a']})
+    with pytest.raises(ValidationError, match='...'):
+        MyModel.parse_obj({'__root__': ['a'], 'other': 1})
 
 
 def test_untouched_types():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -900,10 +900,10 @@ def test_root_undefined_failed():
 
 
 def test_parse_root_as_mapping():
-    with pytest.raises(TypeError, match='custom root type cannot allow mapping'):
+    class MyModel(BaseModel):
+        __root__: Mapping[str, str]
 
-        class MyModel(BaseModel):
-            __root__: Mapping[str, str]
+    assert MyModel.parse_obj({1: 2}).__root__ == {'1': '2'}
 
 
 def test_untouched_types():


### PR DESCRIPTION
## Change Summary

Modifies `parse_obj` and `MetaModel` to allow mapping types with a custom root.

I needed this to address some of the feedback on #934 

## Related issue number

Closes #908

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
