### PR TITLE
add buy-sell-ads advert to docs

### DIFF
--- a/docs/extra/ad.css
+++ b/docs/extra/ad.css
@@ -1,0 +1,11 @@
+#bsa-cpc {
+  border-radius: .1rem;;
+  padding: 0.525rem 0.6rem;
+  min-height: 80px;
+}
+#bsa-cpc.loaded {
+  background: hsla(0, 0%, 92.5%, 0.5);
+}
+#_default_ a._default_, #_default_ .default-text {
+  width: 100% !important;
+}

--- a/docs/extra/ad.css
+++ b/docs/extra/ad.css
@@ -3,6 +3,11 @@
   padding: 0.525rem 0.6rem;
   min-height: 80px;
 }
+@media screen and (max-width: 799px) {
+  #bsa-cpc {
+    display: none;
+  }
+}
 #bsa-cpc.loaded {
   background: hsla(0, 0%, 92.5%, 0.5);
 }

--- a/docs/extra/ad.js
+++ b/docs/extra/ad.js
@@ -1,11 +1,16 @@
 function main () {
   const ad_el = document.getElementById('bsa-cpc')
-  if (!ad_el) {
-    // if no ad element, don't load buysellads
+  if (!ad_el || innerWidth < 800) {
+    // if no ad element or element hidden, don't load buysellads
     return
   }
   const script = document.createElement('script')
   script.onload = () => {
+    if (_bsa.isMobile()) {
+      // bsa doesn't show ads on mobile, hide th box
+      ad_el.remove()
+      return
+    }
     _bsa.init('default', 'CKYDVKJJ', 'placement:helpmanualio', {
       target: '#bsa-cpc',
       align: 'horizontal',

--- a/docs/extra/ad.js
+++ b/docs/extra/ad.js
@@ -1,0 +1,19 @@
+function main () {
+  const ad_el = document.getElementById('bsa-cpc')
+  if (!ad_el) {
+    // if no ad element, don't load buysellads
+    return
+  }
+  const script = document.createElement('script')
+  script.onload = () => {
+    _bsa.init('default', 'CKYDVKJJ', 'placement:helpmanualio', {
+      target: '#bsa-cpc',
+      align: 'horizontal',
+    })
+    ad_el.classList.add('loaded')
+  }
+  script.src = 'https://m.servedby-buysellads.com/monetization.js'
+  document.head.appendChild(script)
+}
+
+main()

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {# no ad on the home page #}
+  {% if not page.is_index %}
+    <div id="bsa-cpc"></div>
+  {% endif %}
+  {{ super() }}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://pydantic-docs.helpmanual.io/
 
 theme:
   name: 'material'
+  custom_dir: 'docs/theme'
   palette:
     primary: pink
     accent: pink
@@ -19,8 +20,10 @@ google_analytics:
 
 extra_css:
 - 'extra/terminal.css'
+- 'extra/ad.css'
 extra_javascript:
 - 'extra/redirects.js'
+- 'extra/ad.js'
 
 nav:
 - Overview: index.md


### PR DESCRIPTION
## Change Summary

Advertisements via buy-sell-ads.

Easy enough to add since [helpmanual.io](https://helpmanual.io/) already has the ads. 

I'll leave this for a few days, let me know if there's a problem.