### PR TITLE
Add exclude_none option

### DIFF
--- a/changes/587-niknetniko.md
+++ b/changes/587-niknetniko.md
@@ -1,0 +1,1 @@
+Add `exclude_none` option to `dict()` and friends

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -15,6 +15,8 @@ Arguments:
   Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
 * `exclude_defaults`: whether fields which are equal to their default values (whether set or otherwise) should
   be excluded from the returned dictionary; default `False`
+* `exclude_none`: whether fields which are equal to `None` should be excluded from the returned dictionary; default
+  `False`
 
 Example:
 
@@ -73,6 +75,8 @@ Arguments:
   Prior to **v1.0**, `exclude_unset` was known as `skip_defaults`; use of `skip_defaults` is now deprecated
 * `exclude_defaults`: whether fields which are equal to their default values (whether set or otherwise) should
   be excluded from the returned dictionary; default `False`
+* `exclude_none`: whether fields which are equal to `None` should be excluded from the returned dictionary; default
+  `False`
 * `encoder`: a custom encoder function passed to the `default` argument of `json.dumps()`; defaults to a custom
   encoder designed to take care of all common types
 * `**dumps_kwargs`: any other keyword arguments are passed to `json.dumps()`, e.g. `indent`.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -659,7 +659,7 @@ class BaseModel(metaclass=ModelMetaclass):
                     exclude_defaults=exclude_defaults,
                     exclude_none=exclude_none,
                 )
-                if (exclude_none and value is not None) or not exclude_none:
+                if not (exclude_none and value is None):
                     yield k, value
 
     def _calculate_keys(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -564,7 +564,7 @@ class BaseModel(metaclass=ModelMetaclass):
                     exclude_defaults=exclude_defaults,
                     include=include,
                     exclude=exclude,
-                    exclude_none=exclude_none
+                    exclude_none=exclude_none,
                 )
             else:
                 return v.copy(include=include, exclude=exclude)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -308,6 +308,7 @@ class BaseModel(metaclass=ModelMetaclass):
         skip_defaults: bool = None,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
+        exclude_none: bool = False,
     ) -> 'DictStrAny':
         """
         Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.
@@ -332,6 +333,7 @@ class BaseModel(metaclass=ModelMetaclass):
                 exclude=exclude,
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
             )
         }
 
@@ -350,6 +352,7 @@ class BaseModel(metaclass=ModelMetaclass):
         skip_defaults: bool = None,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
+        exclude_none: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
         **dumps_kwargs: Any,
     ) -> str:
@@ -371,6 +374,7 @@ class BaseModel(metaclass=ModelMetaclass):
             by_alias=by_alias,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
         )
         if self.__custom_root_type__:
             data = data[ROOT_KEY]
@@ -549,6 +553,7 @@ class BaseModel(metaclass=ModelMetaclass):
         exclude: Optional[Union['AbstractSetIntStr', 'DictIntStrAny']],
         exclude_unset: bool,
         exclude_defaults: bool,
+        exclude_none: bool,
     ) -> Any:
 
         if isinstance(v, BaseModel):
@@ -559,6 +564,7 @@ class BaseModel(metaclass=ModelMetaclass):
                     exclude_defaults=exclude_defaults,
                     include=include,
                     exclude=exclude,
+                    exclude_none=exclude_none
                 )
             else:
                 return v.copy(include=include, exclude=exclude)
@@ -576,6 +582,7 @@ class BaseModel(metaclass=ModelMetaclass):
                     exclude_defaults=exclude_defaults,
                     include=value_include and value_include.for_element(k_),
                     exclude=value_exclude and value_exclude.for_element(k_),
+                    exclude_none=exclude_none,
                 )
                 for k_, v_ in v.items()
                 if (not value_exclude or not value_exclude.is_excluded(k_))
@@ -592,6 +599,7 @@ class BaseModel(metaclass=ModelMetaclass):
                     exclude_defaults=exclude_defaults,
                     include=value_include and value_include.for_element(i),
                     exclude=value_exclude and value_exclude.for_element(i),
+                    exclude_none=exclude_none,
                 )
                 for i, v_ in enumerate(v)
                 if (not value_exclude or not value_exclude.is_excluded(i))
@@ -626,6 +634,7 @@ class BaseModel(metaclass=ModelMetaclass):
         exclude: Union['AbstractSetIntStr', 'DictIntStrAny'] = None,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
+        exclude_none: bool = False,
     ) -> 'TupleGenerator':
 
         value_exclude = ValueItems(self, exclude) if exclude else None
@@ -640,7 +649,7 @@ class BaseModel(metaclass=ModelMetaclass):
 
         for k, v in self.__dict__.items():
             if allowed_keys is None or k in allowed_keys:
-                yield k, self._get_value(
+                value = self._get_value(
                     v,
                     to_dict=to_dict,
                     by_alias=by_alias,
@@ -648,7 +657,10 @@ class BaseModel(metaclass=ModelMetaclass):
                     exclude=value_exclude and value_exclude.for_element(k),
                     exclude_unset=exclude_unset,
                     exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
                 )
+                if (exclude_none and value is not None) or not exclude_none:
+                    yield k, value
 
     def _calculate_keys(
         self,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1303,3 +1303,89 @@ def test_dict_any():
 
     m = MyModel(foo={'x': 'a', 'y': None})
     assert m.foo == {'x': 'a', 'y': None}
+
+
+def test_exclude_none_dict():
+    class MyModel(BaseModel):
+        a: Optional[int] = None
+        b: int = 2
+
+    m = MyModel(a=5)
+    assert m.dict(exclude_none=True) == {'a': 5, 'b': 2}
+
+    m = MyModel(b=3)
+    assert m.dict(exclude_none=True) == {'b': 3}
+
+    m = MyModel()
+    assert m.dict(exclude_none=True) == {'b': 2}
+
+
+def test_exclude_none_recursive():
+    class ModelA(BaseModel):
+        a: Optional[int] = None
+        b: int = 1
+
+    class ModelB(BaseModel):
+        c: int
+        d: int = 2
+        e: ModelA
+        f: Optional[str] = None
+
+    m = ModelB(c=5, e={'a': 0})
+    assert m.dict() == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}, 'f': None}
+    assert m.dict(exclude_none=True) == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}}
+    assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': 0, 'b': 1}, 'f': None}
+
+    m = ModelB(c=5, e={'b': 20}, f='test')
+    assert m.dict() == {'c': 5, 'd': 2, 'e': {'a': None, 'b': 20}, 'f': 'test'}
+    assert m.dict(exclude_none=True) == {'c': 5, 'd': 2, 'e': {'b': 20}, 'f': 'test'}
+    assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': None, 'b': 20}, 'f': 'test'}
+
+
+def test_dict_exclude_none_populated_by_alias():
+    class MyModel(BaseModel):
+        a: str = Field('default', alias='alias_a')
+        b: Optional[str] = Field(None, alias='alias_b')
+
+        class Config:
+            allow_population_by_field_name = True
+
+    m = MyModel(alias_a='a')
+
+    assert m.dict(exclude_none=True) == {'a': 'a'}
+    assert m.dict(exclude_none=True, by_alias=True) == {'alias_a': 'a'}
+    assert m.dict(by_alias=True) == {'alias_a': 'a', 'alias_b': None}
+
+
+def test_dict_exclude_none_populated_by_alias_with_extra():
+    class MyModel(BaseModel):
+        a: str = Field('default', alias='alias_a')
+        b: Optional[str] = Field(None, alias='alias_b')
+
+        class Config:
+            extra = 'allow'
+
+    m = MyModel(alias_a='a', c='c')
+
+    assert m.dict(exclude_none=True) == {'a': 'a', 'c': 'c'}
+    assert m.dict(exclude_none=True, by_alias=True) == {'alias_a': 'a', 'c': 'c'}
+    assert m.dict(by_alias=True) == {'alias_a': 'a', 'alias_b': None, 'c': 'c'}
+
+
+def test_dict_exclude_none_populated_with_extra():
+    class MyModel(BaseModel):
+        a: str = 'default'
+        b: Optional[str] = None
+
+        class Config:
+            extra = 'allow'
+
+    m = MyModel(a='a', c='c')
+
+    assert m.dict(exclude_none=True) == {'a': 'a', 'c': 'c'}
+    assert m.dict() == {'a': 'a', 'b': None, 'c': 'c'}
+
+    m = MyModel(a='a', b='b', c=None)
+
+    assert m.dict(exclude_none=True) == {'a': 'a', 'b': 'b'}
+    assert m.dict() == {'a': 'a', 'b': 'b', 'c': None}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1305,7 +1305,7 @@ def test_dict_any():
     assert m.foo == {'x': 'a', 'y': None}
 
 
-def test_exclude_none_dict():
+def test_exclude_none():
     class MyModel(BaseModel):
         a: Optional[int] = None
         b: int = 2
@@ -1315,9 +1315,7 @@ def test_exclude_none_dict():
 
     m = MyModel(b=3)
     assert m.dict(exclude_none=True) == {'b': 3}
-
-    m = MyModel()
-    assert m.dict(exclude_none=True) == {'b': 2}
+    assert m.json(exclude_none=True) == '{"b": 3}'
 
 
 def test_exclude_none_recursive():
@@ -1342,37 +1340,7 @@ def test_exclude_none_recursive():
     assert dict(m) == {'c': 5, 'd': 2, 'e': {'a': None, 'b': 20}, 'f': 'test'}
 
 
-def test_dict_exclude_none_populated_by_alias():
-    class MyModel(BaseModel):
-        a: str = Field('default', alias='alias_a')
-        b: Optional[str] = Field(None, alias='alias_b')
-
-        class Config:
-            allow_population_by_field_name = True
-
-    m = MyModel(alias_a='a')
-
-    assert m.dict(exclude_none=True) == {'a': 'a'}
-    assert m.dict(exclude_none=True, by_alias=True) == {'alias_a': 'a'}
-    assert m.dict(by_alias=True) == {'alias_a': 'a', 'alias_b': None}
-
-
-def test_dict_exclude_none_populated_by_alias_with_extra():
-    class MyModel(BaseModel):
-        a: str = Field('default', alias='alias_a')
-        b: Optional[str] = Field(None, alias='alias_b')
-
-        class Config:
-            extra = 'allow'
-
-    m = MyModel(alias_a='a', c='c')
-
-    assert m.dict(exclude_none=True) == {'a': 'a', 'c': 'c'}
-    assert m.dict(exclude_none=True, by_alias=True) == {'alias_a': 'a', 'c': 'c'}
-    assert m.dict(by_alias=True) == {'alias_a': 'a', 'alias_b': None, 'c': 'c'}
-
-
-def test_dict_exclude_none_populated_with_extra():
+def test_exclude_none_with_extra():
     class MyModel(BaseModel):
         a: str = 'default'
         b: Optional[str] = None


### PR DESCRIPTION
## Change Summary

- Add `exclude_none` option to `dict()` and friends.

The original issue talked about `skip_none`, but since all options are now in the `exclude_x` format, that is also what I've done.

## Related issue number

Resolves #587

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
