### PR TITLE
making field-reuse idempotent

### DIFF
--- a/changes/1015-samuelcolvin.md
+++ b/changes/1015-samuelcolvin.md
@@ -1,1 +1,1 @@
-Fix bug where use of complex fields on sub-models could case fields to be incorrectly configured
+Fix bug where use of complex fields on sub-models could cause fields to be incorrectly configured

--- a/changes/1015-samuelcolvin.md
+++ b/changes/1015-samuelcolvin.md
@@ -1,0 +1,1 @@
+Fix bug where use of complex fields on sub-models could case fields to be incorrectly configured

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -168,7 +168,7 @@ class ModelMetaclass(ABCMeta):
             if extra_validators:
                 f.class_validators.update(extra_validators)
                 # re-run prepare to add extra validators
-                f.prepare()
+                f.populate_validators()
 
         prepare_config(config, name)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1303,3 +1303,20 @@ def test_dict_any():
 
     m = MyModel(foo={'x': 'a', 'y': None})
     assert m.foo == {'x': 'a', 'y': None}
+
+
+def test_modify_fields():
+    class Foo(BaseModel):
+        foo: List[List[int]]
+
+        @validator('foo')
+        def check_something(cls, value):
+            return value
+
+    class Bar(Foo):
+        pass
+
+    assert repr(Foo.__fields__['foo']) == "ModelField(name='foo', type=List[List[int]], required=True)"
+    assert repr(Bar.__fields__['foo']) == "ModelField(name='foo', type=List[List[int]], required=True)"
+    assert Foo(foo=[[0, 1]]).foo == [[0, 1]]
+    assert Bar(foo=[[0, 1]]).foo == [[0, 1]]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1316,7 +1316,9 @@ def test_modify_fields():
     class Bar(Foo):
         pass
 
-    assert repr(Foo.__fields__['foo']) == "ModelField(name='foo', type=List[List[int]], required=True)"
-    assert repr(Bar.__fields__['foo']) == "ModelField(name='foo', type=List[List[int]], required=True)"
+    # output is slightly different for 3.6
+    if sys.version_info >= (3, 7):
+        assert repr(Foo.__fields__['foo']) == "ModelField(name='foo', type=List[List[int]], required=True)"
+        assert repr(Bar.__fields__['foo']) == "ModelField(name='foo', type=List[List[int]], required=True)"
     assert Foo(foo=[[0, 1]]).foo == [[0, 1]]
     assert Bar(foo=[[0, 1]]).foo == [[0, 1]]


### PR DESCRIPTION
## Change Summary

Call `populate_validators` not `prepare` on fields when they're reused in sub-models since `prepare` is not idempotent.

## Related issue number

fix #1015

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
