### PR TITLE
Support typing.Literal in python 3.8

### DIFF
--- a/changes/1026-dmontagu.md
+++ b/changes/1026-dmontagu.md
@@ -1,0 +1,1 @@
+Add support for `typing.Literal` for Python 3.8.

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,7 +28,7 @@ print('compiled:', pydantic.compiled)
 ```
 
 If you require email validation you can add [email-validator](https://github.com/JoshData/python-email-validator)
-as an optional dependency. Similarly, use of `Literal` relies on
+as an optional dependency. Similarly, use of `Literal` prior to python 3.8 relies on
 [typing-extensions](https://pypi.org/project/typing-extensions/):
 
 ```bash

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -305,11 +305,11 @@ _(This script is complete, it should run "as is")_
 ## Literal Type
 
 !!! note
-    This is not strictly part of the python standard library; 
-    it requires the [typing-extensions](https://pypi.org/project/typing-extensions/) package.
+    This is a new feature of the python standard library as of python 3.8; 
+    prior to python 3.8, it requires the [typing-extensions](https://pypi.org/project/typing-extensions/) package.
 
-*pydantic* supports the use of `typing_extensions.Literal` as a lightweight way to specify that a field
-may accept only specific literal values:
+*pydantic* supports the use of `typing.Literal` (or `typing_extensions.Literal` prior to python 3.8)
+as a lightweight way to specify that a field may accept only specific literal values:
 
 ```py
 {!.tmp_examples/types_literal1.py!}

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -28,11 +28,6 @@ from .typing import AnyType, Callable, ForwardRef, NoneType, display_as_type, is
 from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_like
 from .validators import constant_validator, dict_validator, find_validators, validate_json
 
-try:
-    from typing_extensions import Literal
-except ImportError:
-    Literal = None  # type: ignore
-
 Required: Any = Ellipsis
 
 if TYPE_CHECKING:

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -48,18 +48,13 @@ else:
 
     AnyCallable = TypingCallable[..., Any]
 
-try:
-    from typing import Literal as TypingLiteral
-except ImportError:
-    TypingLiteral = None  # type: ignore
-
-try:
-    from typing_extensions import Literal as TypingExtensionsLiteral
-except ImportError:
-    TypingExtensionsLiteral = None  # type: ignore
-
-Literal = TypingLiteral or TypingExtensionsLiteral  # prefer TypingLiteral if possible
-
+if sys.version_info < (3, 8):
+    try:
+        from typing_extensions import Literal
+    except ImportError:
+        Literal = None  # type: ignore
+else:
+    from typing import Literal
 
 if TYPE_CHECKING:
     from .fields import ModelField
@@ -159,10 +154,9 @@ def is_callable_type(type_: AnyType) -> bool:
 
 
 if sys.version_info >= (3, 7):
-    literal_types = {type_ for type_ in (TypingLiteral, TypingExtensionsLiteral) if type_ is not None}
 
     def is_literal_type(type_: AnyType) -> bool:
-        return Literal is not None and getattr(type_, '__origin__', None) in literal_types
+        return Literal is not None and getattr(type_, '__origin__', None) is Literal
 
     def literal_values(type_: AnyType) -> Tuple[Any, ...]:
         return type_.__args__

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -49,9 +49,16 @@ else:
     AnyCallable = TypingCallable[..., Any]
 
 try:
-    from typing_extensions import Literal
+    from typing import Literal as TypingLiteral
 except ImportError:
-    Literal = None  # type: ignore
+    TypingLiteral = None  # type: ignore
+
+try:
+    from typing_extensions import Literal as TypingExtensionsLiteral
+except ImportError:
+    TypingExtensionsLiteral = None  # type: ignore
+
+Literal = TypingLiteral or TypingExtensionsLiteral  # prefer TypingLiteral if possible
 
 
 if TYPE_CHECKING:
@@ -152,9 +159,10 @@ def is_callable_type(type_: AnyType) -> bool:
 
 
 if sys.version_info >= (3, 7):
+    literal_types = {type_ for type_ in (TypingLiteral, TypingExtensionsLiteral) if type_ is not None}
 
     def is_literal_type(type_: AnyType) -> bool:
-        return Literal is not None and getattr(type_, '__origin__', None) is Literal
+        return Literal is not None and getattr(type_, '__origin__', None) in literal_types
 
     def literal_values(type_: AnyType) -> Tuple[Any, ...]:
         return type_.__args__

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -49,10 +49,13 @@ else:
     AnyCallable = TypingCallable[..., Any]
 
 if sys.version_info < (3, 8):
-    try:
+    if TYPE_CHECKING:
         from typing_extensions import Literal
-    except ImportError:
-        Literal = None  # type: ignore
+    else:  # due to different mypy warnings raised during CI for python 3.7 and 3.8
+        try:
+            from typing_extensions import Literal
+        except ImportError:
+            Literal = None
 else:
     from typing import Literal
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -21,11 +21,6 @@ from typing import (
 
 from .typing import AnyType, display_as_type
 
-try:
-    from typing_extensions import Literal
-except ImportError:
-    Literal = None  # type: ignore
-
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
     from .typing import AbstractSetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,11 +6,7 @@ import pytest
 
 from pydantic import UUID1, BaseConfig, BaseModel, PydanticTypeError, ValidationError, conint, errors, validator
 from pydantic.error_wrappers import flatten_errors, get_exc_type
-
-try:
-    from typing_extensions import Literal
-except ImportError:
-    Literal = None
+from pydantic.typing import Literal
 
 
 def test_pydantic_error():


### PR DESCRIPTION
## Change Summary

Attempt to use `typing.Literal` if available (e.g., with python 3.8).

## Related issue number

Closes #1026 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
