### PR TITLE
Implement Optional required

### DIFF
--- a/changes/1031-tiangolo.md
+++ b/changes/1031-tiangolo.md
@@ -1,0 +1,1 @@
+Add support for required `Optional` with `name: Optional[AnyType] = Field(...)` and refactor `ModelField` creation to preserve `required` parameter value.

--- a/docs/examples/models_required_field_optional.py
+++ b/docs/examples/models_required_field_optional.py
@@ -1,0 +1,13 @@
+from typing import Optional
+from pydantic import BaseModel, Field, ValidationError
+
+class Model(BaseModel):
+    a: Optional[int]
+    b: Optional[int] = ...
+    c: Optional[int] = Field(...)
+
+print(Model(b=1, c=2))
+try:
+    Model(a=1, b=2)
+except ValidationError as e:
+    print(e)

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -424,6 +424,21 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
 Here `a`, `b` and `c` are all required. However, use of the ellipses in `b` will not work well
 with [mypy](mypy.md), and as of **v1.0** should be avoided in most cases.
 
+If you want to specify a field that can take a `None` value while still being required, you can use `Optional` with `...`:
+
+```py
+from typing import Optional
+from pydantic import BaseModel, Field
+
+class Model(BaseModel):
+    a: Optional[int]
+    b: Optional[int] = ...
+    c: Optional[int] = Field(...)
+```
+_(This script is complete, it should run "as is")_
+
+In this model, `a`, `b`, and `c` can take `None` as a value. But `a` is optional, while `b` and `c` are required. `b` and `c` require a value, even if the value is `None`.
+
 ## Data Conversion
 
 *pydantic* may cast input data to force it to conform to model field types,

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -427,13 +427,7 @@ with [mypy](mypy.md), and as of **v1.0** should be avoided in most cases.
 If you want to specify a field that can take a `None` value while still being required, you can use `Optional` with `...`:
 
 ```py
-from typing import Optional
-from pydantic import BaseModel, Field
-
-class Model(BaseModel):
-    a: Optional[int]
-    b: Optional[int] = ...
-    c: Optional[int] = Field(...)
+{!.tmp_examples/models_required_field_optional.py!}
 ```
 _(This script is complete, it should run "as is")_
 

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -73,7 +73,7 @@ with custom properties and validation.
 
 `typing.Optional`
 : `Optional[x]` is simply short hand for `Union[x, None]`;
-  see [Unions](#unions) below for more detail on parsing and validation
+  see [Unions](#unions) below for more detail on parsing and validation and [Required Fields](models.md#required-fields) for details about required fields that can receive `None` as a value.
 
 `typing.List`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
@@ -181,6 +181,13 @@ classes to preclude the unexpected representation as such:
 {!.tmp_examples/types_union_correct.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+!!! tip
+    The type `Optional[x]` is a shorthand for `Union[x, None]`.
+
+    `Optional[x]` can also be used to specify a required field that can take `None` as a value.
+
+    See more details in [Required Fields](models.md#required-fields).
 
 ### Enums and Choices
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -29,7 +29,14 @@ from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_lik
 from .validators import constant_validator, dict_validator, find_validators, validate_json
 
 Required: Any = Ellipsis
-Undefined = object()
+
+
+class UndefinedClass:
+    def __repr__(self) -> str:
+        return 'PydanticUndefined'
+
+
+Undefined = UndefinedClass()
 
 if TYPE_CHECKING:
     from .class_validators import ValidatorsList  # noqa: F401

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -31,12 +31,12 @@ from .validators import constant_validator, dict_validator, find_validators, val
 Required: Any = Ellipsis
 
 
-class UndefinedClass:
+class UndefinedType:
     def __repr__(self) -> str:
         return 'PydanticUndefined'
 
 
-Undefined = UndefinedClass()
+Undefined = UndefinedType()
 
 if TYPE_CHECKING:
     from .class_validators import ValidatorsList  # noqa: F401
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
     ValidateReturn = Tuple[Optional[Any], Optional[ErrorList]]
     LocStr = Union[Tuple[Union[int, str], ...], str]
+    BoolUndefined = Union[bool, UndefinedType]
 
 
 class FieldInfo(Representation):
@@ -212,7 +213,7 @@ class ModelField(Representation):
         class_validators: Optional[Dict[str, Validator]],
         model_config: Type['BaseConfig'],
         default: Any = None,
-        required: Union[bool, UndefinedClass] = Undefined,
+        required: BoolUndefined = Undefined,
         alias: str = None,
         field_info: Optional[FieldInfo] = None,
     ) -> None:
@@ -223,7 +224,7 @@ class ModelField(Representation):
         self.type_: Any = type_
         self.class_validators = class_validators or {}
         self.default: Any = default
-        self.required: Union[bool, UndefinedClass] = required
+        self.required: BoolUndefined = required
         self.model_config = model_config
         self.field_info: FieldInfo = field_info or FieldInfo(default)
 
@@ -257,7 +258,7 @@ class ModelField(Representation):
             value = field_info.default
         else:
             field_info = FieldInfo(value, **field_info_from_config)
-        required: Union[bool, UndefinedClass] = Undefined
+        required: BoolUndefined = Undefined
         if value is Required:
             required = True
             value = None

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -213,7 +213,7 @@ class ModelField(Representation):
         class_validators: Optional[Dict[str, Validator]],
         model_config: Type['BaseConfig'],
         default: Any = None,
-        required: BoolUndefined = Undefined,
+        required: 'BoolUndefined' = Undefined,
         alias: str = None,
         field_info: Optional[FieldInfo] = None,
     ) -> None:
@@ -224,7 +224,7 @@ class ModelField(Representation):
         self.type_: Any = type_
         self.class_validators = class_validators or {}
         self.default: Any = default
-        self.required: BoolUndefined = required
+        self.required: 'BoolUndefined' = required
         self.model_config = model_config
         self.field_info: FieldInfo = field_info or FieldInfo(default)
 
@@ -258,7 +258,7 @@ class ModelField(Representation):
             value = field_info.default
         else:
             field_info = FieldInfo(value, **field_info_from_config)
-        required: BoolUndefined = Undefined
+        required: 'BoolUndefined' = Undefined
         if value is Required:
             required = True
             value = None

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -212,7 +212,7 @@ class ModelField(Representation):
         class_validators: Optional[Dict[str, Validator]],
         model_config: Type['BaseConfig'],
         default: Any = None,
-        required: Union[bool, object] = Undefined,
+        required: Union[bool, UndefinedClass] = Undefined,
         alias: str = None,
         field_info: Optional[FieldInfo] = None,
     ) -> None:
@@ -223,7 +223,7 @@ class ModelField(Representation):
         self.type_: Any = type_
         self.class_validators = class_validators or {}
         self.default: Any = default
-        self.required: Union[bool, object] = required
+        self.required: Union[bool, UndefinedClass] = required
         self.model_config = model_config
         self.field_info: FieldInfo = field_info or FieldInfo(default)
 
@@ -256,13 +256,12 @@ class ModelField(Representation):
             field_info = value
             value = field_info.default
         else:
-            field_info = FieldInfo(value if value is not Undefined else Required, **field_info_from_config)
-        required = Undefined
-        if value == Required:
+            field_info = FieldInfo(value, **field_info_from_config)
+        required: Union[bool, UndefinedClass] = Undefined
+        if value is Required:
             required = True
-        elif value == Undefined:
-            value = Required
-        else:
+            value = None
+        elif value is not Undefined:
             required = False
         field_info.alias = field_info.alias or field_info_from_config.get('alias')
         annotation = get_annotation_from_field_info(annotation, field_info, name)
@@ -271,7 +270,7 @@ class ModelField(Representation):
             type_=annotation,
             alias=field_info.alias,
             class_validators=class_validators,
-            default=None if required is True else value,
+            default=value,
             required=required,
             model_config=config,
             field_info=field_info,
@@ -310,7 +309,8 @@ class ModelField(Representation):
         self._type_analysis()
         if self.required is Undefined:
             self.required = True
-        if self.default is Required:
+            self.field_info.default = Required
+        if self.default is Undefined:
             self.default = None
         self._populate_validators()
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 from .class_validators import ROOT_KEY, ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
 from .error_wrappers import ErrorWrapper, ValidationError
 from .errors import ConfigError, DictError, ExtraError, MissingError
-from .fields import SHAPE_MAPPING, ModelField
+from .fields import SHAPE_MAPPING, ModelField, Undefined
 from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
@@ -180,7 +180,7 @@ class ModelMetaclass(ABCMeta):
                     class_vars.add(ann_name)
                 elif is_valid_field(ann_name):
                     validate_field_name(bases, ann_name)
-                    value = namespace.get(ann_name, ...)
+                    value = namespace.get(ann_name, Undefined)
                     if (
                         isinstance(value, untouched_types)
                         and ann_type != PyObject

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1391,3 +1391,20 @@ def test_repr_method_inheritance():
 
     assert repr(Foo()) == '7'
     assert repr(Bar()) == '7'
+
+
+def test_optional_validator():
+    val_calls = []
+
+    class Model(BaseModel):
+        something: Optional[str]
+
+        @validator('something')
+        def check_something(cls, v):
+            val_calls.append(v)
+            return v
+
+    assert Model().dict() == {'something': None}
+    assert Model(something=None).dict() == {'something': None}
+    assert Model(something='hello').dict() == {'something': 'hello'}
+    assert val_calls == [None, 'hello']

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1408,3 +1408,69 @@ def test_optional_validator():
     assert Model(something=None).dict() == {'something': None}
     assert Model(something='hello').dict() == {'something': 'hello'}
     assert val_calls == [None, 'hello']
+
+
+def test_required_optional():
+    class Model(BaseModel):
+        nullable1: Optional[int] = ...
+        nullable2: Optional[int] = Field(...)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model()
+    assert exc_info.value.errors() == [
+        {'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'},
+        {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+    with pytest.raises(ValidationError) as exc_info:
+        Model(nullable1=1)
+    assert exc_info.value.errors() == [{'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'}]
+    with pytest.raises(ValidationError) as exc_info:
+        Model(nullable2=2)
+    assert exc_info.value.errors() == [{'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'}]
+    assert Model(nullable1=None, nullable2=None).dict() == {'nullable1': None, 'nullable2': None}
+    assert Model(nullable1=1, nullable2=2).dict() == {'nullable1': 1, 'nullable2': 2}
+    with pytest.raises(ValidationError) as exc_info:
+        Model(nullable1='some text')
+    assert exc_info.value.errors() == [
+        {'loc': ('nullable1',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+
+
+def test_required_any():
+    class Model(BaseModel):
+        optional1: Any
+        optional2: Any = None
+        nullable1: Any = ...
+        nullable2: Any = Field(...)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model()
+    assert exc_info.value.errors() == [
+        {'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'},
+        {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+    with pytest.raises(ValidationError) as exc_info:
+        Model(nullable1='a')
+    assert exc_info.value.errors() == [{'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'}]
+    with pytest.raises(ValidationError) as exc_info:
+        Model(nullable2=False)
+    assert exc_info.value.errors() == [{'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'}]
+    assert Model(nullable1=None, nullable2=None).dict() == {
+        'optional1': None,
+        'optional2': None,
+        'nullable1': None,
+        'nullable2': None,
+    }
+    assert Model(nullable1=1, nullable2='two').dict() == {
+        'optional1': None,
+        'optional2': None,
+        'nullable1': 1,
+        'nullable2': 'two',
+    }
+    assert Model(optional1='op1', optional2=False, nullable1=1, nullable2='two').dict() == {
+        'optional1': 'op1',
+        'optional2': False,
+        'nullable1': 1,
+        'nullable2': 'two',
+    }

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from pydantic import BaseModel, ConfigError, Extra, ValidationError, errors, validator
+from pydantic import BaseModel, ConfigError, Extra, Field, ValidationError, errors, validator
 from pydantic.class_validators import make_generic_validator, root_validator
 
 
@@ -731,6 +731,18 @@ def test_optional_validator():
     assert Model(something=None).dict() == {'something': None}
     assert Model(something='hello').dict() == {'something': 'hello'}
     assert val_calls == [None, 'hello']
+
+
+def test_required_optional():
+    class Model(BaseModel):
+        nullable: Optional[int] = Field(...)
+
+    with pytest.raises(ValidationError):
+        Model()
+    assert Model(nullable=None).dict() == {'nullable': None}
+    assert Model(nullable=3).dict() == {'nullable': 3}
+    with pytest.raises(ValidationError):
+        Model(nullable='some text')
 
 
 def test_whole():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -719,23 +719,6 @@ def test_assert_raises_validation_error():
     ]
 
 
-def test_optional_validator():
-    val_calls = []
-
-    class Model(BaseModel):
-        something: Optional[str]
-
-        @validator('something')
-        def check_something(cls, v):
-            val_calls.append(v)
-            return v
-
-    assert Model().dict() == {'something': None}
-    assert Model(something=None).dict() == {'something': None}
-    assert Model(something='hello').dict() == {'something': 'hello'}
-    assert val_calls == [None, 'hello']
-
-
 def test_required_optional():
     class Model(BaseModel):
         nullable1: Optional[int] = ...

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from itertools import product
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from pydantic import BaseModel, ConfigError, Extra, Field, ValidationError, errors, validator
+from pydantic import BaseModel, ConfigError, Extra, ValidationError, errors, validator
 from pydantic.class_validators import make_generic_validator, root_validator
 
 
@@ -717,72 +717,6 @@ def test_assert_raises_validation_error():
     assert exc_info.value.errors() == [
         {'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}
     ]
-
-
-def test_required_optional():
-    class Model(BaseModel):
-        nullable1: Optional[int] = ...
-        nullable2: Optional[int] = Field(...)
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model()
-    assert exc_info.value.errors() == [
-        {'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
-    with pytest.raises(ValidationError) as exc_info:
-        Model(nullable1=1)
-    assert exc_info.value.errors() == [{'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'}]
-    with pytest.raises(ValidationError) as exc_info:
-        Model(nullable2=2)
-    assert exc_info.value.errors() == [{'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'}]
-    assert Model(nullable1=None, nullable2=None).dict() == {'nullable1': None, 'nullable2': None}
-    assert Model(nullable1=1, nullable2=2).dict() == {'nullable1': 1, 'nullable2': 2}
-    with pytest.raises(ValidationError) as exc_info:
-        Model(nullable1='some text')
-    assert exc_info.value.errors() == [
-        {'loc': ('nullable1',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-        {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
-
-
-def test_required_any():
-    class Model(BaseModel):
-        optional1: Any
-        optional2: Any = None
-        nullable1: Any = ...
-        nullable2: Any = Field(...)
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model()
-    assert exc_info.value.errors() == [
-        {'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
-    with pytest.raises(ValidationError) as exc_info:
-        Model(nullable1='a')
-    assert exc_info.value.errors() == [{'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'}]
-    with pytest.raises(ValidationError) as exc_info:
-        Model(nullable2=False)
-    assert exc_info.value.errors() == [{'loc': ('nullable1',), 'msg': 'field required', 'type': 'value_error.missing'}]
-    assert Model(nullable1=None, nullable2=None).dict() == {
-        'optional1': None,
-        'optional2': None,
-        'nullable1': None,
-        'nullable2': None,
-    }
-    assert Model(nullable1=1, nullable2='two').dict() == {
-        'optional1': None,
-        'optional2': None,
-        'nullable1': 1,
-        'nullable2': 'two',
-    }
-    assert Model(optional1='op1', optional2=False, nullable1=1, nullable2='two').dict() == {
-        'optional1': 'op1',
-        'optional2': False,
-        'nullable1': 1,
-        'nullable2': 'two',
-    }
 
 
 def test_whole():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Make `ModelField(required=True)` keep the required flag.

This allows solving https://github.com/tiangolo/fastapi/pull/646 without hacks, and solves https://github.com/samuelcolvin/pydantic/issues/990, allowing required nullables with:

```Python
class Model(BaseModel):
    nullable: Optional[int] = Field(...)
```

A benefit is that external libraries using Pydantic like FastAPI or others (and more to come) can create a `ModelField` object, set the `required` argument (`ModelField(required=True)`) and expect it to be preserved without having to re-set it after creation with `field.required = True`.

<!-- Please give a short summary of the changes. -->

## Related issue number

#990 #1028

<!-- Are there any issues opened that will be resolved by merging this change? -->
## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
