### PR TITLE
Make dataclass compatible with schema

### DIFF
--- a/changes/792-aviramha.md
+++ b/changes/792-aviramha.md
@@ -1,0 +1,1 @@
+Change schema and schema_model to handle dataclasses by using their `__pydantic_model__` feature.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -72,16 +72,17 @@ from .typing import (
     literal_values,
     new_type_supertype,
 )
-from .utils import lenient_issubclass
+from .utils import get_model, lenient_issubclass
 
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
+    from .dataclasses import DataclassType  # noqa: F401
 
 default_prefix = '#/definitions/'
 
 
 def schema(
-    models: Sequence[Type['BaseModel']],
+    models: Sequence[Union[Type['BaseModel'], Type['DataclassType']]],
     *,
     by_alias: bool = True,
     title: Optional[str] = None,
@@ -104,8 +105,9 @@ def schema(
     :return: dict with the JSON Schema with a ``definitions`` top-level key including the schema definitions for
       the models and sub-models passed in ``models``.
     """
+    clean_models = [get_model(model) for model in models]
     ref_prefix = ref_prefix or default_prefix
-    flat_models = get_flat_models_from_models(models)
+    flat_models = get_flat_models_from_models(clean_models)
     model_name_map = get_model_name_map(flat_models)
     definitions = {}
     output_schema: Dict[str, Any] = {}
@@ -113,7 +115,7 @@ def schema(
         output_schema['title'] = title
     if description:
         output_schema['description'] = description
-    for model in models:
+    for model in clean_models:
         m_schema, m_definitions, m_nested_models = model_process_schema(
             model, by_alias=by_alias, model_name_map=model_name_map, ref_prefix=ref_prefix
         )
@@ -125,7 +127,9 @@ def schema(
     return output_schema
 
 
-def model_schema(model: Type['BaseModel'], by_alias: bool = True, ref_prefix: Optional[str] = None) -> Dict[str, Any]:
+def model_schema(
+    model: Union[Type['BaseModel'], Type['DataclassType']], by_alias: bool = True, ref_prefix: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Generate a JSON Schema for one model. With all the sub-models defined in the ``definitions`` top-level
     JSON key.
@@ -139,6 +143,7 @@ def model_schema(model: Type['BaseModel'], by_alias: bool = True, ref_prefix: Op
       prefix.
     :return: dict with the JSON Schema for the passed ``model``
     """
+    model = get_model(model)
     ref_prefix = ref_prefix or default_prefix
     flat_models = get_flat_models_from_model(model)
     model_name_map = get_model_name_map(flat_models)

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -24,6 +24,7 @@ from .typing import AnyType, display_as_type
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
     from .typing import AbstractSetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
+    from .dataclasses import DataclassType  # noqa: F401
 
 KeyType = TypeVar('KeyType')
 
@@ -112,6 +113,19 @@ def almost_equal_floats(value_1: float, value_2: float, *, delta: float = 1e-8) 
     Return True if two floats are almost equal
     """
     return abs(value_1 - value_2) <= delta
+
+
+def get_model(obj: Union[Type['BaseModel'], Type['DataclassType']]) -> Type['BaseModel']:
+    from .main import BaseModel  # noqa: F811
+
+    try:
+        model_cls = obj.__pydantic_model__  # type: ignore
+    except AttributeError:
+        model_cls = obj
+
+    if not issubclass(model_cls, BaseModel):
+        raise TypeError('Unsupported type, must be either BaseModel or dataclass')
+    return model_cls
 
 
 class PyObjectStr(str):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,6 +13,7 @@ import pytest
 
 from pydantic import BaseModel, Extra, Field, ValidationError, conlist, validator
 from pydantic.color import Color
+from pydantic.dataclasses import dataclass
 from pydantic.networks import AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, NameEmail, stricturl
 from pydantic.schema import (
     get_flat_models_from_model,
@@ -1638,4 +1639,28 @@ def test_subfield_field_info():
             }
         },
         'required': ['entries'],
+    }
+
+
+def test_dataclass():
+    @dataclass
+    class Model:
+        a: bool
+
+    assert schema([Model]) == {
+        'definitions': {
+            'Model': {
+                'title': 'Model',
+                'type': 'object',
+                'properties': {'a': {'title': 'A', 'type': 'boolean'}},
+                'required': ['a'],
+            }
+        }
+    }
+
+    assert model_schema(Model) == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'boolean'}},
+        'required': ['a'],
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,10 @@ import pytest
 
 from pydantic import BaseModel
 from pydantic.color import Color
+from pydantic.dataclasses import dataclass
 from pydantic.fields import Undefined
 from pydantic.typing import display_as_type, is_new_type, new_type_supertype
-from pydantic.utils import ValueItems, deep_update, import_string, lenient_issubclass, truncate
+from pydantic.utils import ValueItems, deep_update, get_model, import_string, lenient_issubclass, truncate
 
 try:
     import devtools
@@ -265,3 +266,22 @@ def test_deep_update_is_not_mutating():
 
 def test_undefined_repr():
     assert repr(Undefined) == 'PydanticUndefined'
+
+
+def test_get_model():
+    class A(BaseModel):
+        a: str
+
+    assert get_model(A) == A
+
+    @dataclass
+    class B:
+        a: str
+
+    assert get_model(B) == B.__pydantic_model__
+
+    class C:
+        pass
+
+    with pytest.raises(TypeError):
+        get_model(C)


### PR DESCRIPTION
## Change Summary

Add compatibility for schema and schema_model so it can be used easily on a dataclass.
Also add a proxy method for dataclass of schema.

## Related issue number

fix #792 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)

It's a pretty hacky way, but it's also simple and easy.
I know I'm failing on mypy run but am not sure how to handle this (not so familiar with mypy). Advice is welcome.