### PR TITLE
Added optional for root_validator to be skipped if values validation fails

### DIFF
--- a/changes/1049-aviramha.md
+++ b/changes/1049-aviramha.md
@@ -1,1 +1,1 @@
-Added optional for root_validator to be skipped if values validation fails using keyword `skip_on_failure=True`
+Added optional for `root_validator` to be skipped if values validation fails using keyword `skip_on_failure=True`

--- a/changes/1049-aviramha.md
+++ b/changes/1049-aviramha.md
@@ -1,0 +1,1 @@
+Added optional for root_validator to be skipped if values validation fails using keyword `skip_on_failure=True`

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -78,7 +78,10 @@ validation occurs (and are provided with the raw input data), or `pre=False` (th
 they're called after field validation.
 
 Field validation will not occur if `pre=True` root validators raise an error. As with field validators,
-"post" (i.e. `pre=False`) root validators by default will be called if field validation fails; this behaviour can be changed by setting the `skip_on_failure=True` keyword argument to the validator. The `values` argument will be a dict containing the values which passed field validation and field defaults where applicable.
+"post" (i.e. `pre=False`) root validators by default will be called even if field validation fails; this
+behaviour can be changed by setting the `skip_on_failure=True` keyword argument to the validator.
+The `values` argument will be a dict containing the values which passed field validation and
+field defaults where applicable.
 
 ## Field Checks
 

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -78,8 +78,7 @@ validation occurs (and are provided with the raw input data), or `pre=False` (th
 they're called after field validation.
 
 Field validation will not occur if `pre=True` root validators raise an error. As with field validators,
-"post" (i.e. `pre=False`) root validators will be called even if field validation fails; the `values` argument will
-be a dict containing the values which passed field validation and field defaults where applicable.
+"post" (i.e. `pre=False`) root validators by default will be called if field validation fails; this behaviour can be changed by setting the `skip_on_failure=True` keyword argument to the validator. The `values` argument will be a dict containing the values which passed field validation and field defaults where applicable.
 
 ## Field Checks
 

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -12,6 +12,7 @@ from .utils import in_ipython
 
 
 class Validator:
+    SKIP_ON_FAILURE_KEY = '__validator_skip_on_failure__'  # Applies only to RootValidators
     __slots__ = 'func', 'pre', 'each_item', 'always', 'check_fields'
 
     def __init__(
@@ -105,7 +106,7 @@ def root_validator(*, pre: bool = False) -> Callable[[AnyCallable], classmethod]
 
 
 def root_validator(
-    _func: Optional[AnyCallable] = None, *, pre: bool = False, allow_reuse: bool = False
+    _func: Optional[AnyCallable] = None, *, pre: bool = False, allow_reuse: bool = False, skip_on_failure: bool = False
 ) -> Union[classmethod, Callable[[AnyCallable], classmethod]]:
     """
     Decorate methods on a model indicating that they should be used to validate (and perhaps modify) data either
@@ -114,11 +115,13 @@ def root_validator(
     if _func:
         f_cls = _prepare_validator(_func, allow_reuse)
         setattr(f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=f_cls.__func__, pre=pre))
+        setattr(f_cls.__func__, Validator.SKIP_ON_FAILURE_KEY, skip_on_failure)
         return f_cls
 
     def dec(f: AnyCallable) -> classmethod:
         f_cls = _prepare_validator(f, allow_reuse)
         setattr(f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=f_cls.__func__, pre=pre))
+        setattr(f_cls.__func__, Validator.SKIP_ON_FAILURE_KEY, skip_on_failure)
         return f_cls
 
     return dec

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -9,7 +9,14 @@ from pathlib import Path
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast, no_type_check
 
-from .class_validators import ROOT_KEY, ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
+from .class_validators import (
+    ROOT_KEY,
+    Validator,
+    ValidatorGroup,
+    extract_root_validators,
+    extract_validators,
+    inherit_validators,
+)
 from .error_wrappers import ErrorWrapper, ValidationError
 from .errors import ConfigError, DictError, ExtraError, MissingError
 from .fields import SHAPE_MAPPING, ModelField, Undefined
@@ -853,6 +860,8 @@ def validate_model(  # noqa: C901 (ignore complexity)
                     errors.append(ErrorWrapper(ExtraError(), loc=f))
 
     for validator in model.__post_root_validators__:
+        if errors and getattr(validator, Validator.SKIP_ON_FAILURE_KEY, False):
+            continue
         try:
             values = validator(cls_, values)
         except (ValueError, TypeError, AssertionError) as exc:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -988,3 +988,32 @@ def test_root_validator_classmethod(validator_classmethod, root_validator_classm
     ]
 
     assert root_val_values == [{'a': 123, 'b': 'barbar'}, {'a': 1, 'b': 'snap dragonsnap dragon'}, {'b': 'barbar'}]
+
+
+def test_root_validator_skip_on_failure():
+    a_called = False
+
+    class ModelA(BaseModel):
+        a: int
+
+        @root_validator
+        def example_root_validator(cls, values):
+            nonlocal a_called
+            a_called = True
+
+    with pytest.raises(ValidationError):
+        ModelA(a='a')
+    assert a_called
+    b_called = False
+
+    class ModelB(BaseModel):
+        a: int
+
+        @root_validator(skip_on_failure=True)
+        def example_root_validator(cls, values):
+            nonlocal b_called
+            b_called = True
+
+    with pytest.raises(ValidationError):
+        ModelB(a='a')
+    assert not b_called


### PR DESCRIPTION
Title, addressing #1049.

## Change Summary

Added keyword argument skip_on_failure to root_validator decorator.
## Related issue number
#1049.
<!-- Are there any issues opened that will be resolved by merging this change? -->
#1049.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
