### PR TITLE
Allow schema_extra to be a callable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ black = black -S -l 120 --target-version py36 pydantic tests
 
 .PHONY: install
 install:
-	pip install -U setuptools pip
+	python -m pip install -U setuptools pip
 	pip install -U -r requirements.txt
 	SKIP_CYTHON=1 pip install -e .
 
@@ -91,7 +91,7 @@ clean:
 
 .PHONY: docs
 docs:
-	./docs/build/main.py
+	python docs/build/main.py
 	mkdocs build
 	@# to work with the old sphinx build and deploy:
 	@rm -rf docs/_build/
@@ -100,7 +100,7 @@ docs:
 
 .PHONY: docs-serve
 docs-serve:
-	./docs/build/main.py
+	python docs/build/main.py
 	mkdocs serve
 
 .PHONY: publish

--- a/changes/1054-selimb.md
+++ b/changes/1054-selimb.md
@@ -1,0 +1,1 @@
+Allow `Config.schema_extra` to be a callable so that the generated schema can be post-processed.

--- a/docs/build/exec_examples.py
+++ b/docs/build/exec_examples.py
@@ -91,7 +91,6 @@ def exec_examples():
     errors = []
     all_md = all_md_contents()
     new_files = {}
-    os.environ.clear()
     os.environ.update({'my_auth_key': 'xxx', 'my_api_key': 'xxx'})
 
     sys.path.append(str(EXAMPLES_DIR))
@@ -113,7 +112,7 @@ def exec_examples():
         if f'{{!.tmp_examples/{file.name}!}}' not in all_md:
             error('file not used anywhere')
 
-        file_text = file.read_text()
+        file_text = file.read_text('utf-8')
         if '\n\n\n' in file_text:
             error('too many new lines')
         if not file_text.endswith('\n'):
@@ -184,7 +183,7 @@ def exec_examples():
     print(f'writing {len(new_files)} example files to {TMP_EXAMPLES_DIR}')
     TMP_EXAMPLES_DIR.mkdir()
     for file_name, content in new_files.items():
-        (TMP_EXAMPLES_DIR / file_name).write_text(content)
+        (TMP_EXAMPLES_DIR / file_name).write_text(content, 'utf-8')
     gen_ansi_output()
     return 0
 

--- a/docs/examples/schema_extra_callable.py
+++ b/docs/examples/schema_extra_callable.py
@@ -1,0 +1,15 @@
+# output-json
+from typing import Dict, Any
+from pydantic import BaseModel
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any]) -> None:
+            for prop in schema.get('properties', {}).values():
+                prop.pop('title', None)
+
+print(Person.schema_json(indent=2))

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -66,7 +66,7 @@ Options:
 not be included in the model schemas. **Note**: this means that attributes on the model with *defaults of this type*, not *annotations of this type*, will be left alone.
   
 **`schema_extra`**
-: a `dict` used to extend/update the generated JSON Schema
+: a `dict` used to extend/update the generated JSON Schema, or a callable to post-process it; see [Schema customization](schema.md#schema-customization)
 
 **`json_loads`**
 : a custom function for decoding JSON; see [custom JSON (de)serialisation](exporting_models.md#custom-json-deserialisation)

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -146,3 +146,20 @@ Outputs:
 ```json
 {!.tmp_examples/schema_with_example.json!}
 ```
+
+For more fine-grained control, you can alternatively set `schema_extra` to a callable and post-process the generated schema.
+The callable is passed the schema dictionary as the first and only argument, and is expected to mutate it *in-place*; the return value is not used.
+
+For example, the `title` key can be removed from the model's `properties`:
+
+```py
+{!.tmp_examples/schema_extra_callable.py!}
+```
+
+_(This script is complete, it should run "as is")_
+
+Outputs:
+
+```json
+{!.tmp_examples/schema_extra_callable.json!}
+```

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -66,7 +66,7 @@ class BaseConfig:
     getter_dict: Type[GetterDict] = GetterDict
     alias_generator: Optional[Callable[[str], str]] = None
     keep_untouched: Tuple[type, ...] = ()
-    schema_extra: Dict[str, Any] = {}
+    schema_extra: Union[Dict[str, Any], Callable[[Dict[str, Any]], None]] = {}
     json_loads: Callable[[str], Any] = json.loads
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[AnyType, AnyCallable] = {}

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -466,7 +466,11 @@ def model_process_schema(
         model, by_alias=by_alias, model_name_map=model_name_map, ref_prefix=ref_prefix, known_models=known_models
     )
     s.update(m_schema)
-    s.update(model.__config__.schema_extra)
+    schema_extra = model.__config__.schema_extra
+    if callable(schema_extra):
+        schema_extra(s)
+    else:
+        s.update(schema_extra)
     return s, m_definitions, nested_models
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1482,6 +1482,22 @@ def test_model_with_schema_extra():
     }
 
 
+def test_model_with_schema_extra_callable():
+    class Model(BaseModel):
+        name: str = None
+
+        class Config:
+            @staticmethod
+            def schema_extra(schema):
+                schema.pop('properties')
+                schema['type'] = 'override'
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'override',
+    }
+
+
 def test_model_with_extra_forbidden():
     class Model(BaseModel):
         a: str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Allow `Config.schema_extra` to be a callable so that the generated schema can be post-processed.
Also includes some fixes to the dev scripts for Windows development (I'm on Windows with cmder). *Those can be moved to another PR if needed.*

## Related issue number

fix #889, fix #1051 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/1054-selimb.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
