### PR TITLE
Prevent type attributes being added to schema unintentionally

### DIFF
--- a/changes/1064-samuelcolvin.md
+++ b/changes/1064-samuelcolvin.md
@@ -1,0 +1,1 @@
+Prevent type attributes being added to schema unless the attribute `__schema_attributes__` is `True` 

--- a/docs/examples/types_custom_type.py
+++ b/docs/examples/types_custom_type.py
@@ -1,21 +1,64 @@
-from pydantic import BaseModel, ValidationError
+import re
+from pydantic import BaseModel
 
-class StrictStr(str):
+# https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom#Validation
+post_code_regex = re.compile(
+    r'(?:'
+    r'([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?'
+    r'([0-9][A-Z]{2})|'
+    r'(BFPO) ?([0-9]{1,4})|'
+    r'(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|'
+    r'([A-Z]{2}) ?([0-9]{2})|'
+    r'(GE) ?(CX)|'
+    r'(GIR) ?(0A{2})|'
+    r'(SAN) ?(TA1)'
+    r')'
+)
+
+class PostCode(str):
+    """
+    Partial UK postcode validation. Note: this is just an example, and is not
+    intended for use in production; in particular this does NOT guarantee
+    a postcode exists, just that it has a valid format.
+    """
     @classmethod
     def __get_validators__(cls):
+        # one or more validators may be yielded which will be called in the
+        # order to validate the input, each validator will receive as an input
+        # the value returned from the previous validator
         yield cls.validate
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        # __modify_schema__ should mutate the dict it receives in place,
+        # the returned value will be ignored
+        field_schema.update(
+            # simplified regex here for brevity, see the wikipedia link above
+            pattern='^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$',
+            # some example postcodes
+            examples=['SP11 9DG', 'w1j7bu'],
+        )
 
     @classmethod
     def validate(cls, v):
         if not isinstance(v, str):
-            raise ValueError(f'strict string: str expected not {type(v)}')
-        return v
+            raise TypeError('string required')
+        m = post_code_regex.fullmatch(v.upper())
+        if not m:
+            raise ValueError('invalid postcode format')
+        # you could also return a string here which would mean model.post_code
+        # would be a string, pydantic won't care but you could end up with some
+        # confusion since the value's type won't match the type annotation
+        # exactly
+        return cls(f'{m.group(1)} {m.group(2)}')
+
+    def __repr__(self):
+        return f'PostCode({super().__repr__()})'
 
 class Model(BaseModel):
-    s: StrictStr
+    post_code: PostCode
 
-print(Model(s='hello'))
-try:
-    print(Model(s=123))
-except ValidationError as e:
-    print(e.json())
+model = Model(post_code='sw8 5el')
+print(model)
+print(model.post_code)
+print(Model.schema())

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -73,7 +73,7 @@ to set all of the arguments above except `default`.
 
 ### Unenforced Field constraints
 
-If *pydantic* finds constraints which are not being enforced, an error will be raised. If you want to force the 
+If *pydantic* finds constraints which are not being enforced, an error will be raised. If you want to force the
 constraint to appear in the schema, even though it's not being checked upon parsing, you can use variadic arguments
 to `Field()` with the raw schema attribute name:
 
@@ -81,6 +81,11 @@ to `Field()` with the raw schema attribute name:
 {!.tmp_examples/schema_unenforced_constraints.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+## Modifying schema in custom fields
+
+Custom field types can customise the schema generate for them using the `__modify_schema__` class method,
+see [Custom Data Types](types.md#custom-data-types) for more details.
 
 ## JSON Schema Types
 

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -84,7 +84,7 @@ _(This script is complete, it should run "as is")_
 
 ## Modifying schema in custom fields
 
-Custom field types can customise the schema generate for them using the `__modify_schema__` class method,
+Custom field types can customise the schema generated for them using the `__modify_schema__` class method;
 see [Custom Data Types](types.md#custom-data-types) for more details.
 
 ## JSON Schema Types

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -1,5 +1,5 @@
-Where possible *pydantic* uses [standard library types](#standard-library-types) to define fields, thus smoothing 
-the learning curve. For many useful applications, however, no standard library type exists, 
+Where possible *pydantic* uses [standard library types](#standard-library-types) to define fields, thus smoothing
+the learning curve. For many useful applications, however, no standard library type exists,
 so *pydantic* implements [many commonly used types](#pydantic-types).
 
 If no existing type suits your purpose you can also implement your [own pydantic-compatible types](#custom-data-types)
@@ -7,7 +7,7 @@ with custom properties and validation.
 
 ## Standard Library Types
 
-*pydantic* supports many common types from the python standard library. If you need stricter processing see 
+*pydantic* supports many common types from the python standard library. If you need stricter processing see
 [Strict Types](#strict-types); if you need to constrain the values allowed (e.g. to require a positive int) see
 [Constrained Types](#constrained-types).
 
@@ -18,12 +18,12 @@ with custom properties and validation.
 : *pydantic* uses `int(v)` to coerce types to an `int`;
   see [this](models.md#data-conversion) warning on loss of information during data conversion
 
-`float` 
+`float`
 : similarly, `float(v)` is used to coerce values to floats
 
 `str`
 : strings are accepted as-is, `int` `float` and `Decimal` are coerced using `str(v)`, `bytes` and `bytearray` are
-  converted using `v.decode()`, enums inheriting from `str` are converted using `v.value`, 
+  converted using `v.decode()`, enums inheriting from `str` are converted using `v.value`,
   and all other types cause an error
 
 `bytes`
@@ -103,23 +103,23 @@ with custom properties and validation.
 : will cause the input value to be passed to `re.compile(v)` to create a regex pattern
 
 `ipaddress.IPv4Address`
-: simply uses the type itself for validation by passing the value to `IPv4Address(v)`; 
+: simply uses the type itself for validation by passing the value to `IPv4Address(v)`;
   see [Pydantic Types](#pydantic-types) for other custom IP address types
 
 `ipaddress.IPv4Interface`
-: simply uses the type itself for validation by passing the value to `IPv4Address(v)`; 
+: simply uses the type itself for validation by passing the value to `IPv4Address(v)`;
   see [Pydantic Types](#pydantic-types) for other custom IP address types
 
 `ipaddress.IPv4Network`
-: simply uses the type itself for validation by passing the value to `IPv4Network(v)`; 
+: simply uses the type itself for validation by passing the value to `IPv4Network(v)`;
   see [Pydantic Types](#pydantic-types) for other custom IP address types
 
 `ipaddress.IPv6Address`
-: simply uses the type itself for validation by passing the value to `IPv6Address(v)`; 
+: simply uses the type itself for validation by passing the value to `IPv6Address(v)`;
   see [Pydantic Types](#pydantic-types) for other custom IP address types
 
 `ipaddress.IPv6Interface`
-: simply uses the type itself for validation by passing the value to `IPv6Interface(v)`; 
+: simply uses the type itself for validation by passing the value to `IPv6Interface(v)`;
   see [Pydantic Types](#pydantic-types) for other custom IP address types
 
 `ipaddress.IPv6Network`
@@ -138,7 +138,7 @@ with custom properties and validation.
 : *pydantic* attempts to convert the value to a string, then passes the string to `Decimal(v)`
 
 `pathlib.Path`
-: simply uses the type itself for validation by passing the value to `Path(v)`; 
+: simply uses the type itself for validation by passing the value to `Path(v)`;
   see [Pydantic Types](#pydantic-types) for other more strict path types
 
 `uuid.UUID`
@@ -312,7 +312,7 @@ _(This script is complete, it should run "as is")_
 ## Literal Type
 
 !!! note
-    This is a new feature of the python standard library as of python 3.8; 
+    This is a new feature of the python standard library as of python 3.8;
     prior to python 3.8, it requires the [typing-extensions](https://pypi.org/project/typing-extensions/) package.
 
 *pydantic* supports the use of `typing.Literal` (or `typing_extensions.Literal` prior to python 3.8)
@@ -351,8 +351,8 @@ _(This script is complete, it should run "as is")_
 `EmailStr`
 : requires [email-validator](https://github.com/JoshData/python-email-validator) to be installed;
   the input string must be a valid email address, and the output is a simple string
-  
-  
+
+
 
 `NameEmail`
 : requires [email-validator](https://github.com/JoshData/python-email-validator) to be installed;
@@ -360,7 +360,7 @@ _(This script is complete, it should run "as is")_
   and the output is a `NameEmail` object which has two properties: `name` and `email`.
   For `Fred Bloggs <fred.bloggs@example.com>` the name would be `"Fred Bloggs"`;
   for `fred.bloggs@example.com` it would be `"fred.bloggs"`.
-  
+
 
 `PyObject`
 : expects a string and loads the python object importable at that dotted path;
@@ -406,7 +406,7 @@ _(This script is complete, it should run "as is")_
 : requires a valid UUID of type 5; see `UUID` [above](#standard-library-types)
 
 `SecretBytes`
-: bytes where the value is kept partially secret; see [Secrets](#secret-types) 
+: bytes where the value is kept partially secret; see [Secrets](#secret-types)
 
 `SecretStr`
 : string where the value is kept partially secret; see [Secrets](#secret-types)
@@ -616,7 +616,7 @@ _(This script is complete, it should run "as is")_
 ### Json Type
 
 You can use `Json` data type to make *pydantic* first load a raw JSON string.
-It can also optionally be used to parse the loaded object into another type base on 
+It can also optionally be used to parse the loaded object into another type base on
 the type `Json` is parameterised with:
 
 ```py
@@ -683,7 +683,7 @@ _(This script is complete, it should run "as is")_
 You can use the `ByteSize` data type to convert byte string representation to
 raw bytes and print out human readable versions of the bytes as well.
 
-!!! info 
+!!! info
     Note that `1b` will be parsed as "1 byte" and not "1 bit".
 
 ```py
@@ -702,3 +702,8 @@ to get validators to parse and validate the input data.
 {!.tmp_examples/types_custom_type.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+Similar validation could be achieved using [`constr(regex=...)`](#constrained-types) except the value won't be
+formatted with a space, the schema would just include the full pattern and the returned value would be a vanilla string.
+
+See [Schema](schema.md) for more details on how the model's schema is generated.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -140,8 +140,8 @@ class AnyUrl(str):
         return url
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
-        update_not_none(schema, minLength=cls.min_length, maxLength=cls.max_length)
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        update_not_none(field_schema, minLength=cls.min_length, maxLength=cls.max_length)
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -68,6 +68,7 @@ int_domain_regex = re.compile(fr'(?:{_int_chunk}\.)*?{_int_chunk}{_domain_ending
 
 
 class AnyUrl(str):
+    __schema_attributes__ = True
     strip_whitespace = True
     min_length = 1
     max_length = 2 ** 16

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -12,7 +12,7 @@ from ipaddress import (
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Set, Tuple, Type, Union, cast, no_type_check
 
 from . import errors
-from .utils import Representation
+from .utils import Representation, update_not_none
 from .validators import constr_length_validator, str_validator
 
 if TYPE_CHECKING:
@@ -68,7 +68,6 @@ int_domain_regex = re.compile(fr'(?:{_int_chunk}\.)*?{_int_chunk}{_domain_ending
 
 
 class AnyUrl(str):
-    __schema_attributes__ = True
     strip_whitespace = True
     min_length = 1
     max_length = 2 ** 16
@@ -139,6 +138,10 @@ class AnyUrl(str):
         if fragment:
             url += '#' + fragment
         return url
+
+    @classmethod
+    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+        update_not_none(schema, minLength=cls.min_length, maxLength=cls.max_length)
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -688,7 +688,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         f_schema.update({'enum': [item.value for item in field_type]})
         # Don't return immediately, to allow adding specific types
 
-    if getattr(field_type, '__schema_attributes__', False) is True:
+    if getattr(field_type, '__schema_attributes__', False):
         for field_name, schema_name in validation_attribute_to_schema_keyword.items():
             field_value = getattr(field_type, field_name, None)
             if field_value is not None:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -687,12 +687,15 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     if issubclass(field_type, Enum):
         f_schema.update({'enum': [item.value for item in field_type]})
         # Don't return immediately, to allow adding specific types
-    for field_name, schema_name in validation_attribute_to_schema_keyword.items():
-        field_value = getattr(field_type, field_name, None)
-        if field_value is not None:
-            if field_name == 'regex':
-                field_value = field_value.pattern
-            f_schema[schema_name] = field_value
+
+    if getattr(field_type, '__schema_attributes__', False) is True:
+        for field_name, schema_name in validation_attribute_to_schema_keyword.items():
+            field_value = getattr(field_type, field_name, None)
+            if field_value is not None:
+                if field_name == 'regex':
+                    field_value = field_value.pattern
+                f_schema[schema_name] = field_value
+
     for type_, t_schema in field_class_to_schema_enum_enabled:
         if issubclass(field_type, type_):
             f_schema.update(t_schema)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -91,9 +91,9 @@ class ConstrainedBytes(bytes):
     max_length: OptionalInt = None
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         update_not_none(
-            schema, minLength=cls.min_length, maxLength=cls.max_length,
+            field_schema, minLength=cls.min_length, maxLength=cls.max_length,
         )
 
     @classmethod
@@ -128,9 +128,9 @@ class ConstrainedList(list):  # type: ignore
         yield cls.list_length_validator
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         update_not_none(
-            schema, minLength=cls.min_items, maxLength=cls.max_items,
+            field_schema, minLength=cls.min_items, maxLength=cls.max_items,
         )
 
     @classmethod
@@ -162,9 +162,9 @@ class ConstrainedStr(str):
     strict = False
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         update_not_none(
-            schema, minLength=cls.min_length, maxLength=cls.max_length, pattern=cls.regex and cls.regex.pattern
+            field_schema, minLength=cls.min_length, maxLength=cls.max_length, pattern=cls.regex and cls.regex.pattern
         )
 
     @classmethod
@@ -279,9 +279,9 @@ class ConstrainedInt(int, metaclass=ConstrainedNumberMeta):
     multiple_of: OptionalInt = None
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         update_not_none(
-            schema,
+            field_schema,
             exclusiveMinimum=cls.gt,
             exclusiveMaximum=cls.lt,
             minimum=cls.ge,
@@ -326,9 +326,9 @@ class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
     multiple_of: OptionalIntFloat = None
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         update_not_none(
-            schema,
+            field_schema,
             exclusiveMinimum=cls.gt,
             exclusiveMaximum=cls.lt,
             minimum=cls.ge,
@@ -379,9 +379,9 @@ class ConstrainedDecimal(Decimal, metaclass=ConstrainedNumberMeta):
     multiple_of: OptionalIntFloatDecimal = None
 
     @classmethod
-    def __modify_schema__(cls, schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         update_not_none(
-            schema,
+            field_schema,
             exclusiveMinimum=cls.gt,
             exclusiveMaximum=cls.lt,
             minimum=cls.ge,

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
 
 
 class ConstrainedBytes(bytes):
+    __schema_attributes__ = True
     strip_whitespace = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
@@ -108,6 +109,7 @@ T = TypeVar('T')
 
 # This types superclass should be List[T], but cython chokes on that...
 class ConstrainedList(list):  # type: ignore
+    __schema_attributes__ = True
     # Needed for pydantic to detect that this is a list
     __origin__ = list
     __args__: List[Type[T]]  # type: ignore
@@ -142,6 +144,7 @@ def conlist(item_type: Type[T], *, min_items: int = None, max_items: int = None)
 
 
 class ConstrainedStr(str):
+    __schema_attributes__ = True
     strip_whitespace = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
@@ -253,6 +256,7 @@ class ConstrainedNumberMeta(type):
 
 
 class ConstrainedInt(int, metaclass=ConstrainedNumberMeta):
+    __schema_attributes__ = True
     strict: bool = False
     gt: OptionalInt = None
     ge: OptionalInt = None
@@ -289,6 +293,7 @@ class StrictInt(ConstrainedInt):
 
 
 class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
+    __schema_attributes__ = True
     strict: bool = False
     gt: OptionalIntFloat = None
     ge: OptionalIntFloat = None
@@ -330,6 +335,7 @@ class StrictFloat(ConstrainedFloat):
 
 
 class ConstrainedDecimal(Decimal, metaclass=ConstrainedNumberMeta):
+    __schema_attributes__ = True
     gt: OptionalIntFloatDecimal = None
     ge: OptionalIntFloatDecimal = None
     lt: OptionalIntFloatDecimal = None

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -108,6 +108,10 @@ def deep_update(mapping: Dict[KeyType, Any], updating_mapping: Dict[KeyType, Any
     return updated_mapping
 
 
+def update_not_none(mapping: Dict[Any, Any], **update: Any) -> None:
+    mapping.update({k: v for k, v in update.items() if v is not None})
+
+
 def almost_equal_floats(value_1: float, value_2: float, *, delta: float = 1e-8) -> bool:
     """
     Return True if two floats are almost equal

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1664,3 +1664,24 @@ def test_dataclass():
         'properties': {'a': {'title': 'A', 'type': 'boolean'}},
         'required': ['a'],
     }
+
+
+def test_schema_attributes():
+    class ExampleEnum(Enum):
+        gt = 'GT'
+        lt = 'LT'
+        ge = 'GE'
+        le = 'LE'
+        max_length = 'ML'
+        multiple_of = 'MO'
+        regex = 'RE'
+
+    class Example(BaseModel):
+        example: ExampleEnum
+
+    assert Example.schema() == {
+        'title': 'Example',
+        'type': 'object',
+        'properties': {'example': {'title': 'Example', 'enum': ['GT', 'LT', 'GE', 'LE', 'ML', 'MO', 'RE']}},
+        'required': ['example'],
+    }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -513,10 +513,13 @@ def test_str_constrained_types(field_type, expected_schema):
     class Model(BaseModel):
         a: field_type
 
+    model_schema = Model.schema()
+    assert model_schema['properties']['a'] == expected_schema
+
     base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': {}}, 'required': ['a']}
     base_schema['properties']['a'] = expected_schema
 
-    assert Model.schema() == base_schema
+    assert model_schema == base_schema
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

Constrained types which add properties to schema now ~~need to have `__schema_attributes__ = True`~~ implement `__modify_schema__` to update the schema, this prevents unexpected conflicts like on enums attributes named liked `.regex`.

Technically this could not be backwards compatible if people have created their own constrained types. Is anyone concerned about this? Otherwise I think the chance of a problem is remote enough to allow this in a minor release.

## Related issue number

* fix #1064
* fix #789
* fix #667

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] documentation updated
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
