### PR TITLE
Change BaseModel.parse_file to use Config.json_loads

### DIFF
--- a/changes/1067-kierandarcy.md
+++ b/changes/1067-kierandarcy.md
@@ -1,1 +1,1 @@
-Change BaseModel.parse_file to use Config.json_loads
+Change `BaseModel.parse_file` to use `Config.json_loads`

--- a/changes/1067-kierandarcy.md
+++ b/changes/1067-kierandarcy.md
@@ -1,0 +1,1 @@
+Change BaseModel.parse_file to use Config.json_loads

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -425,7 +425,14 @@ class BaseModel(metaclass=ModelMetaclass):
         proto: Protocol = None,
         allow_pickle: bool = False,
     ) -> 'Model':
-        obj = load_file(path, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle)
+        obj = load_file(
+            path, 
+            proto=proto, 
+            content_type=content_type, 
+            encoding=encoding, 
+            allow_pickle=allow_pickle, 
+            json_loads=cls.__config__.json_loads,
+        )
         return cls.parse_obj(obj)
 
     @classmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -426,11 +426,11 @@ class BaseModel(metaclass=ModelMetaclass):
         allow_pickle: bool = False,
     ) -> 'Model':
         obj = load_file(
-            path, 
-            proto=proto, 
-            content_type=content_type, 
-            encoding=encoding, 
-            allow_pickle=allow_pickle, 
+            path,
+            proto=proto,
+            content_type=content_type,
+            encoding=encoding,
+            allow_pickle=allow_pickle,
             json_loads=cls.__config__.json_loads,
         )
         return cls.parse_obj(obj)

--- a/pydantic/parse.py
+++ b/pydantic/parse.py
@@ -51,6 +51,7 @@ def load_file(
     encoding: str = 'utf8',
     proto: Protocol = None,
     allow_pickle: bool = False,
+    json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
     path = Path(path)
     b = path.read_bytes()
@@ -60,4 +61,11 @@ def load_file(
         elif path.suffix == '.pkl':
             proto = Protocol.pickle
 
-    return load_str_bytes(b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle)
+    return load_str_bytes(
+        b,
+        proto=proto,
+        content_type=content_type,
+        encoding=encoding,
+        allow_pickle=allow_pickle,
+        json_loads=json_load,
+    )

--- a/pydantic/parse.py
+++ b/pydantic/parse.py
@@ -62,10 +62,5 @@ def load_file(
             proto = Protocol.pickle
 
     return load_str_bytes(
-        b,
-        proto=proto,
-        content_type=content_type,
-        encoding=encoding,
-        allow_pickle=allow_pickle,
-        json_loads=json_load,
+        b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle, json_loads=json_loads,
     )

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -1,3 +1,4 @@
+import json
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Optional, Type, TypeVar, Union
@@ -42,6 +43,7 @@ def parse_file_as(
     encoding: str = 'utf8',
     proto: Protocol = None,
     allow_pickle: bool = False,
+    json_loads: Callable[[str], Any] = json.loads,
     type_name: Optional[NameFactory] = None,
 ) -> T:
     obj = load_file(path, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle)

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -46,5 +46,12 @@ def parse_file_as(
     json_loads: Callable[[str], Any] = json.loads,
     type_name: Optional[NameFactory] = None,
 ) -> T:
-    obj = load_file(path, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle)
+    obj = load_file(
+        path,
+        proto=proto,
+        content_type=content_type,
+        encoding=encoding,
+        allow_pickle=allow_pickle,
+        json_loads=json_loads,
+    )
     return parse_obj_as(type_, obj, type_name=type_name)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 from typing import List, Union
 
@@ -104,6 +105,24 @@ def test_file_json_no_ext(tmpdir):
     p = tmpdir.join('test')
     p.write('{"a": 12, "b": 8}')
     assert Model.parse_file(str(p)) == Model(a=12, b=8)
+
+
+def test_file_json_loads(tmpdir):
+    def custom_json_loads(*args, **kwargs):
+        data = json.loads(*args, **kwargs)
+        data['a'] = 99
+        return data
+
+    class Example(BaseModel):
+        a: int
+
+        class Config:
+            json_loads = custom_json_loads
+
+    p = tmpdir.join('test_json_loads.json')
+    p.write('{"a": 12}')
+
+    assert Example.parse_file(str(p)) == Example(a=99)
 
 
 def test_file_pickle(tmpdir):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -107,7 +107,7 @@ def test_file_json_no_ext(tmpdir):
     assert Model.parse_file(str(p)) == Model(a=12, b=8)
 
 
-def test_file_json_loads(tmpdir):
+def test_file_json_loads(tmp_path):
     def custom_json_loads(*args, **kwargs):
         data = json.loads(*args, **kwargs)
         data['a'] = 99
@@ -119,10 +119,10 @@ def test_file_json_loads(tmpdir):
         class Config:
             json_loads = custom_json_loads
 
-    p = tmpdir.join('test_json_loads.json')
-    p.write('{"a": 12}')
+    p = tmp_path / 'test_json_loads.json'
+    p.write_text('{"a": 12}')
 
-    assert Example.parse_file(str(p)) == Example(a=99)
+    assert Example.parse_file(p) == Example(a=99)
 
 
 def test_file_pickle(tmpdir):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, List, Mapping
 
 import pytest
@@ -76,3 +77,14 @@ def test_parse_file_as(tmp_path):
     p = tmp_path / 'test.json'
     p.write_text('{"1": "2"}')
     assert parse_file_as(Dict[int, int], p) == {1: 2}
+
+
+def test_parse_file_as_json_loads(tmp_path):
+    def custom_json_loads(*args, **kwargs):
+        data = json.loads(*args, **kwargs)
+        data[1] = 99
+        return data
+
+    p = tmp_path / 'test_json_loads.json'
+    p.write_text('{"1": "2"}')
+    assert parse_file_as(Dict[int, int], p, json_loads=custom_json_loads) == {1: 99}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
<!-- Please give a short summary of the changes. -->
Changed the signature of `load_file` function to accept the same `json_loads` parameter as the `load_str_bytes` function.

Changed the `parse_file` class method to specify the `Config.json_loads` value when calling `load_file`.

Also, added a `json_loads` parameter to the `parse_file_as` function.

## Related issue number
#1067 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
