### PR TITLE
change cython nthreads default to zero

### DIFF
--- a/changes/1074-samuelcolvin.md
+++ b/changes/1074-samuelcolvin.md
@@ -1,0 +1,2 @@
+Change the default number of threads used when compiling with cython to zero,
+allow override via the `CYTHON_NTHREADS` environment variable.

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if not any(arg in sys.argv for arg in ['clean', 'check']) and 'SKIP_CYTHON' not 
         ext_modules = cythonize(
             'pydantic/*.py',
             exclude=['pydantic/generics.py'],
-            nthreads=4,
+            nthreads=int(os.getenv('CYTHON_NTHREADS', 0)),
             language_level=3,
             compiler_directives=compiler_directives,
         )


### PR DESCRIPTION
## Change Summary

Change the default number of threads used when compiling with cython to zero, allow override via the `CYTHON_NTHREADS` env. variable.

## Related issue number

https://github.com/conda-forge/pydantic-feedstock/pull/31
