### PR TITLE
Let SecretStrs be value equals

### DIFF
--- a/changes/1079-sbv-trueenergy.md
+++ b/changes/1079-sbv-trueenergy.md
@@ -1,0 +1,1 @@
+Add `__eq__` to SecretStr and SecretBytes to allow "value equals"

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -477,6 +477,9 @@ class SecretStr:
     def __str__(self) -> str:
         return '**********' if self._secret_value else ''
 
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, SecretStr) and self.get_secret_value() == other.get_secret_value()
+
     def display(self) -> str:
         warnings.warn('`secret_str.display()` is deprecated, use `str(secret_str)` instead', DeprecationWarning)
         return str(self)
@@ -503,6 +506,9 @@ class SecretBytes:
 
     def __str__(self) -> str:
         return '**********' if self._secret_value else ''
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, SecretBytes) and self.get_secret_value() == other.get_secret_value()
 
     def display(self) -> str:
         warnings.warn('`secret_bytes.display()` is deprecated, use `str(secret_bytes)` instead', DeprecationWarning)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1699,6 +1699,17 @@ def test_secretstr():
     with pytest.warns(DeprecationWarning, match=r'`secret_str.display\(\)` is deprecated'):
         assert f.empty_password.display() == ''
 
+    # Assert that SecretStr is equal to SecretStr if the secret is the same.
+    assert f == f.copy()
+    assert f != f.copy(update=dict(password='4321'))
+
+
+def test_secretstr_equality():
+    assert SecretStr('abc') == SecretStr('abc')
+    assert SecretStr('123') != SecretStr('321')
+    assert SecretStr('123') != '123'
+    assert SecretStr('123') is not SecretStr('123')
+
 
 def test_secretstr_error():
     class Foobar(BaseModel):
@@ -1735,6 +1746,17 @@ def test_secretbytes():
         assert f.password.display() == '**********'
     with pytest.warns(DeprecationWarning, match=r'`secret_bytes.display\(\)` is deprecated'):
         assert f.empty_password.display() == ''
+
+    # Assert that SecretBytes is equal to SecretBytes if the secret is the same.
+    assert f == f.copy()
+    assert f != f.copy(update=dict(password=b'4321'))
+
+
+def test_secretbytes_equality():
+    assert SecretBytes(b'abc') == SecretBytes(b'abc')
+    assert SecretBytes(b'123') != SecretBytes(b'321')
+    assert SecretBytes(b'123') != b'123'
+    assert SecretBytes(b'123') is not SecretBytes(b'123')
 
 
 def test_secretbytes_error():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

As discussed in the issue, this PR adds a `__eq__` method for SecretStr that compares the secret value such that SecretStr('a') == SecretStr('a') and SecretStr('a') != SecretStr('b')

## Related issue number
#1078 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
