### PR TITLE
Fix for Optional Json fields

### DIFF
--- a/changes/1073-volker48.md
+++ b/changes/1073-volker48.md
@@ -1,2 +1,1 @@
-Change validate_json to pass None through instead of
-trying to parse it.
+Fix for optional `Json` fields

--- a/changes/1073-volker48.md
+++ b/changes/1073-volker48.md
@@ -1,0 +1,2 @@
+Change validate_json to pass None through instead of
+trying to parse it.

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -424,6 +424,9 @@ def constr_strip_whitespace(v: 'StrBytes', field: 'ModelField', config: 'BaseCon
 
 
 def validate_json(v: Any, config: 'BaseConfig') -> Any:
+    if v is None:
+        # pass None through to other validators
+        return v
     try:
         return config.json_loads(v)  # type: ignore
     except ValueError:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1677,14 +1677,6 @@ def test_json_explicitly_required():
         JsonRequired()
 
 
-def test_json_implicitly_required():
-    class JsonRequired(BaseModel):
-        json_obj: Json
-
-    with pytest.raises(ValidationError):
-        JsonRequired()
-
-
 def test_pattern():
     class Foobar(BaseModel):
         pattern: Pattern

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterator, List, MutableSet, NewType, Pattern, Sequence, Set, Tuple
+from typing import Dict, FrozenSet, Iterator, List, MutableSet, NewType, Optional, Pattern, Sequence, Set, Tuple
 from uuid import UUID
 
 import pytest
@@ -1647,6 +1647,42 @@ def test_json_pre_validator():
 
     assert JsonModel(json_obj='"foobar"').dict() == {'json_obj': 'foobar'}
     assert call_count == 1
+
+
+def test_json_optional_simple():
+    class JsonOptionalModel(BaseModel):
+        json_obj: Optional[Json]
+
+    JsonOptionalModel(json_obj=None)
+
+
+def test_json_optional_complex():
+    class JsonOptionalModel(BaseModel):
+        json_obj: Optional[Json[List[int]]]
+
+    JsonOptionalModel(json_obj=None)
+
+    good = JsonOptionalModel(json_obj='[1, 2, 3]')
+    assert good.json_obj == [1, 2, 3]
+
+    with pytest.raises(ValidationError):
+        JsonOptionalModel(json_obj='["i should fail"]')
+
+
+def test_json_explicitly_required():
+    class JsonRequired(BaseModel):
+        json_obj: Json = ...
+
+    with pytest.raises(ValidationError):
+        JsonRequired()
+
+
+def test_json_implicitly_required():
+    class JsonRequired(BaseModel):
+        json_obj: Json
+
+    with pytest.raises(ValidationError):
+        JsonRequired()
 
 
 def test_pattern():


### PR DESCRIPTION
## Change Summary

Fix for Optional Json fields.

There is a test failure for a test I added, `test_json_implicitly_required`, that is unrelated to this change as the same test will fail if run in master, but I wanted to push this out to discuss how best to address that failure.

## Related issue number

fix #1073 

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
