### PR TITLE
Fix schema for fields with nested None as default

### DIFF
--- a/changes/1088-lutostag.md
+++ b/changes/1088-lutostag.md
@@ -1,0 +1,1 @@
+Fix schema generation for nested None case

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -750,6 +750,8 @@ def encode_default(dft: Any) -> Any:
         return t(encode_default(v) for v in dft)
     elif isinstance(dft, dict):
         return {encode_default(k): encode_default(v) for k, v in dft.items()}
+    elif dft is None:
+        return None
     else:
         return pydantic_encoder(dft)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -129,6 +129,17 @@ def test_dict_dict():
     assert Model(v={'foo': 1}).dict() == {'v': {'foo': 1}}
 
 
+def test_none_list():
+    class Model(BaseModel):
+        v = [None]
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'v': {'title': 'V', 'default': [None], 'type': 'array', 'items': {}}},
+    }
+
+
 @pytest.mark.parametrize(
     'value,result',
     [


### PR DESCRIPTION
As None is typically used for the default value, it is not usually
encoded on its own into schemas. Issue #1087 , where using None
not as the top-level value, but rather inside other objects (e.g.
[None]) will throw a Traceback.

Original issue found downstream at https://github.com/tiangolo/fastapi/issues/776

## Change Summary
Handle the None case in `pydantic.schema.encode_default`

## Related issue number
https://github.com/samuelcolvin/pydantic/issues/1087

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)

Not sure if any documentation is needed here. If you are looking for anything different or this doesnt work for some case, please let me know, and I will be more than happy to follow any suggestions!

Thanks!