### PR TITLE
docs: Fix explanation of case sensitivity for `Settings`

### DIFF
--- a/changes/1105-tribals.md
+++ b/changes/1105-tribals.md
@@ -1,0 +1,1 @@
+docs: Fix explanation of case sensitive environment variable names when populating `BaseSettings` subclass attributes.

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -50,7 +50,8 @@ Case-sensitivity can be turned on through the `Config`:
 {!.tmp_examples/settings_case_sensitive.py!}
 ```
 
-When `case_sensitive` is `True`, the environment variable must be exactly the same as attribute, so in this example
+When `case_sensitive` is `True`, the environment variable names must match field names (optionally with a prefix),
+so in this example
 `redis_host` could only be modified via `export redis_host`. And if you want to name environment variables
 all upper-case, you should name attribute all upper-case too. You can still name environment variables anything
 you like through `Field(..., env=...)`.

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -52,7 +52,7 @@ Case-sensitivity can be turned on through the `Config`:
 
 When `case_sensitive` is `True`, the environment variable must be exactly the same as attribute, so in this example
 `redis_host` could only be modified via `export redis_host`. And if you want to name environment variables
-all upper-case, you should name attribute all upper-case too. I can still name environment variable anything
+all upper-case, you should name attribute all upper-case too. You can still name environment variables anything
 you like through `Field(..., env=...)`.
 
 !!! note

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -50,8 +50,10 @@ Case-sensitivity can be turned on through the `Config`:
 {!.tmp_examples/settings_case_sensitive.py!}
 ```
 
-When `case_sensitive` is `True`, the environment variable must be in all-caps,
-so in this example `redis_host` could only be modified via `export REDIS_HOST`.
+When `case_sensitive` is `True`, the environment variable must be exactly the same as attribute, so in this example
+`redis_host` could only be modified via `export redis_host`. And if you want to name environment variables
+all upper-case, you should name attribute all upper-case too. I can still name environment variable anything
+you like through `Field(..., env=...)`.
 
 !!! note
     On Windows, python's `os` module always treats environment variables as case-insensitive, so the

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -52,7 +52,7 @@ Case-sensitivity can be turned on through the `Config`:
 
 When `case_sensitive` is `True`, the environment variable names must match field names (optionally with a prefix),
 so in this example
-`redis_host` could only be modified via `export redis_host`. And if you want to name environment variables
+`redis_host` could only be modified via `export redis_host`. If you want to name environment variables
 all upper-case, you should name attribute all upper-case too. You can still name environment variables anything
 you like through `Field(..., env=...)`.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Fix incorrect explanation of how `BaseSettings` treats environment variable names when populating attributes.

## Related issue number

Closes #1105 

## Checklist

* [ ] Unit tests for the changes exist (not appropriate?)
* [ ] Tests pass on CI and coverage remains at 100% (not appropriate?)
* [x] Documentation reflects the changes where applicable
* [x] `changes/1105-tribals.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
