### PR TITLE
Change url_regex to disallow / in username or pwd 

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -47,7 +47,7 @@ __all__ = [
 host_part_names = ('domain', 'ipv4', 'ipv6')
 url_regex = re.compile(
     r'(?:(?P<scheme>[a-z0-9]+?)://)?'  # scheme
-    r'(?:(?P<user>[^\s:]+)(?::(?P<password>\S*))?@)?'  # user info
+    r'(?:(?P<user>[^\s:/]+)(?::(?P<password>[^\s/]*))?@)?'  # user info
     r'(?:'
     r'(?P<ipv4>(?:\d{1,3}\.){3}\d{1,3})|'  # ipv4
     r'(?P<ipv6>\[[A-F0-9]*:[A-F0-9:]+\])|'  # ipv6


### PR DESCRIPTION
#<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Small modification to `url_regex` used for validating URL fields (subclasses of AnyUrl) to disallow
/ in username and password components. This makes the URL http://twitter.com/@handle pass
validation instead of throwing an error that there is no host.
<!-- Please give a short summary of the changes. -->

## Related issue number
#1115 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
