### PR TITLE
Documentation: rename benchmark django-restful-framework -> django-rest-framework

### DIFF
--- a/benchmarks/test_drf.py
+++ b/benchmarks/test_drf.py
@@ -10,7 +10,7 @@ from rest_framework import __version__, serializers
 
 
 class TestDRF:
-    package = 'django-restful-framework'
+    package = 'django-rest-framework'
     version = __version__
 
     def __init__(self, allow_extra):

--- a/changes/1119-frankie567.md
+++ b/changes/1119-frankie567.md
@@ -1,0 +1,1 @@
+Rename django-rest-framework benchmark in documentation

--- a/docs/.benchmarks_table.md
+++ b/docs/.benchmarks_table.md
@@ -2,10 +2,10 @@
 
 Package | Version | Relative Performance | Mean validation time
 --- | --- | --- | ---
-valideer | `0.4.2` |  | 83.1μs
-attrs + cattrs | `19.3.0` | 1.0x slower | 84.1μs
-pydantic | `1.2` | 1.1x slower | 92.7μs
-marshmallow | `3.3.0` | 1.7x slower | 141.8μs
-trafaret | `2.0.2` | 2.4x slower | 202.0μs
-django-rest-framework | `3.11.0` | 8.6x slower | 712.7μs
-cerberus | `1.3.2` | 19.0x slower | 1578.6μs
+pydantic | `1.1` |  | 43.6μs
+attrs + cattrs | `19.3.0` | 1.4x slower | 59.9μs
+valideer | `0.4.2` | 1.4x slower | 61.8μs
+marshmallow | `3.2.2` | 2.5x slower | 107.6μs
+trafaret | `2.0.0` | 3.4x slower | 148.7μs
+django-rest-framework | `3.10.3` | 12.6x slower | 551.2μs
+cerberus | `1.3.2` | 26.3x slower | 1146.3μs

--- a/docs/.benchmarks_table.md
+++ b/docs/.benchmarks_table.md
@@ -2,10 +2,10 @@
 
 Package | Version | Relative Performance | Mean validation time
 --- | --- | --- | ---
-pydantic | `1.1` |  | 43.6μs
-attrs + cattrs | `19.3.0` | 1.4x slower | 59.9μs
-valideer | `0.4.2` | 1.4x slower | 61.8μs
-marshmallow | `3.2.2` | 2.5x slower | 107.6μs
-trafaret | `2.0.0` | 3.4x slower | 148.7μs
-django-restful-framework | `3.10.3` | 12.6x slower | 551.2μs
-cerberus | `1.3.2` | 26.3x slower | 1146.3μs
+valideer | `0.4.2` |  | 83.1μs
+attrs + cattrs | `19.3.0` | 1.0x slower | 84.1μs
+pydantic | `1.2` | 1.1x slower | 92.7μs
+marshmallow | `3.3.0` | 1.7x slower | 141.8μs
+trafaret | `2.0.2` | 2.4x slower | 202.0μs
+django-rest-framework | `3.11.0` | 8.6x slower | 712.7μs
+cerberus | `1.3.2` | 19.0x slower | 1578.6μs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

I came across this while reading the [benchmark page](https://pydantic-docs.helpmanual.io/benchmarks/) in the docs: benchmark for [`django-rest-framework`](https://www.django-rest-framework.org/) was named `django-restful-framework`. This confused me a bit.

I changed the package name in the benchmark script and run the script instead of modifying directly the generated MD file, as specified.

Problem is that, on my machine, the benchmark is not in favor of pydantic 😟So I don't know what you prefer for this (I would be okay to just edit the previous results).

## Related issue number

Nope.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
