### PR TITLE
add explicit re-exports to __init__.py

### DIFF
--- a/changes/1072-samuelcolvin.md
+++ b/changes/1072-samuelcolvin.md
@@ -1,0 +1,1 @@
+add `__all__` to `__init__.py` to prevent "implicit reexport" errors from mypy

--- a/docs/mypy_plugin.md
+++ b/docs/mypy_plugin.md
@@ -40,7 +40,7 @@ There are other benefits too! See below for more details.
   `__init__` will raise errors even if `Config.extra` is not `"forbid"`.
 * **Optional:** If the [`init_typed` **plugin setting**](#plugin-settings) is set to `True`, the generated signature
   will use the types of the model fields (otherwise they will be annotated as `Any` to allow parsing).
- 
+
 #### Generate a typed signature for `Model.construct`
 * The [`construct`](usage/models.md#creating-models-without-validation) method is a faster alternative to `__init__`
   when input data is known to be valid and does not need to be parsed. But because this method performs no runtime
@@ -64,7 +64,7 @@ There are other benefits too! See below for more details.
   error any time you use a dynamically-determined alias or alias generator on a model with
   `Config.allow_population_by_field_name=False`.
 * This is important because if such aliases are present, mypy cannot properly type check calls to `__init__`.
-  In this case, it will default to treating all arguments as optional. 
+  In this case, it will default to treating all arguments as optional.
 
 #### Prevent the use of untyped fields
 * If the [`warn_untyped_fields` **plugin setting**](#plugin-settings) is set to `True`, you'll get a mypy error
@@ -95,7 +95,7 @@ The plugin offers a few optional strictness flags if you want even stronger chec
 * `init_forbid_extra`
 
     If enabled, disallow extra arguments to the `__init__` call even when `Config.extra` is not `"forbid"`.
-  
+
 * `init_typed`
 
     If enabled, include the field types as type hints in the generated signature for the `__init__` method.
@@ -117,7 +117,7 @@ The plugin offers a few optional strictness flags if you want even stronger chec
 To change the values of the plugin settings, create a section in your mypy config file called `[pydantic-mypy]`,
 and add any key-value pairs for settings you want to override.
 
-A `mypy.ini` file with all plugin strictness flags enabled (and some other mypy strictness flags, too) might look like: 
+A `mypy.ini` file with all plugin strictness flags enabled (and some other mypy strictness flags, too) might look like:
 ```ini
 [mypy]
 plugins = pydantic.mypy
@@ -128,6 +128,7 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 disallow_any_generics = True
 check_untyped_defs = True
+no_implicit_reexport = True
 
 # for strict mypy: (this is the tricky one :-))
 disallow_untyped_defs = True

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -11,3 +11,85 @@ from .parse import Protocol
 from .tools import *
 from .types import *
 from .version import VERSION
+
+# WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
+# please use "from pydantic.errors import ..." instead
+__all__ = [
+    # dataclasses
+    'dataclasses',
+    'root_validator',
+    'validator',
+    # env_settings
+    'BaseSettings',
+    # error_wrappers
+    'ValidationError',
+    # fields
+    'Field',
+    'Required',
+    'Schema',
+    # main
+    'BaseConfig',
+    'BaseModel',
+    'Extra',
+    'compiled',
+    'create_model',
+    'validate_model',
+    # network
+    'AnyUrl',
+    'AnyHttpUrl',
+    'HttpUrl',
+    'stricturl',
+    'EmailStr',
+    'NameEmail',
+    'IPvAnyAddress',
+    'IPvAnyInterface',
+    'IPvAnyNetwork',
+    'PostgresDsn',
+    'RedisDsn',
+    'validate_email',
+    # parse
+    'Protocol',
+    # tools
+    'parse_file_as',
+    'parse_obj_as',
+    # types
+    'NoneStr',
+    'NoneBytes',
+    'StrBytes',
+    'NoneStrBytes',
+    'StrictStr',
+    'ConstrainedBytes',
+    'conbytes',
+    'ConstrainedList',
+    'conlist',
+    'ConstrainedStr',
+    'constr',
+    'PyObject',
+    'ConstrainedInt',
+    'conint',
+    'PositiveInt',
+    'NegativeInt',
+    'ConstrainedFloat',
+    'confloat',
+    'PositiveFloat',
+    'NegativeFloat',
+    'ConstrainedDecimal',
+    'condecimal',
+    'UUID1',
+    'UUID3',
+    'UUID4',
+    'UUID5',
+    'FilePath',
+    'DirectoryPath',
+    'Json',
+    'JsonWrapper',
+    'SecretStr',
+    'SecretBytes',
+    'StrictBool',
+    'StrictInt',
+    'StrictFloat',
+    'PaymentCardNumber',
+    'ByteSize',
+    # version
+    'VERSION',
+]

--- a/tests/mypy/configs/mypy-default.ini
+++ b/tests/mypy/configs/mypy-default.ini
@@ -5,7 +5,7 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 disallow_any_generics = True
 check_untyped_defs = True
-;no_implicit_reexport = True
+no_implicit_reexport = True
 
 # for strict mypy: (this is the tricky one :-))
 disallow_untyped_defs = True

--- a/tests/mypy/configs/mypy-plugin-strict.ini
+++ b/tests/mypy/configs/mypy-plugin-strict.ini
@@ -7,9 +7,7 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 disallow_any_generics = True
 check_untyped_defs = True
-;no_implicit_reexport = True
-
-# for strict mypy: (this is the tricky one :-))
+no_implicit_reexport = True
 disallow_untyped_defs = True
 
 [pydantic-mypy]

--- a/tests/mypy/configs/mypy-plugin.ini
+++ b/tests/mypy/configs/mypy-plugin.ini
@@ -7,7 +7,7 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 disallow_any_generics = True
 check_untyped_defs = True
-;no_implicit_reexport = True
+no_implicit_reexport = True
 
 # for strict mypy: (this is the tricky one :-))
 disallow_untyped_defs = True

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -83,3 +83,15 @@ def test_generation_is_disabled():
     Makes sure we don't accidentally leave generation on
     """
     assert not GENERATE
+
+
+def test_explicit_reexports():
+    from pydantic import __all__ as root_all
+    from pydantic.main import __all__ as main
+    from pydantic.networks import __all__ as networks
+    from pydantic.tools import __all__ as tools
+    from pydantic.types import __all__ as types
+
+    for name, export_all in [('main', main), ('network', networks), ('tools', tools), ('types', types)]:
+        for export in export_all:
+            assert export in root_all, f'{export} is in {name}.__all__ but missing from re-export in __init__.py'


### PR DESCRIPTION
## Change Summary

Add `__all__` to `__init__.py`, thereby remove explicit re-exports.

## Related issue number

 fix #1072

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added