### PR TITLE
improve pydantic import time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-examples:
 	@find docs/examples -type f -name '*.py' | xargs -I'{}' sh -c 'python {} >/dev/null 2>&1 || (echo "{} failed")'
 
 .PHONY: all
-all: testcov lint mypy
+all: lint mypy testcov
 
 .PHONY: benchmark-all
 benchmark-all:

--- a/changes/1127-samuelcolvin.md
+++ b/changes/1127-samuelcolvin.md
@@ -1,0 +1,1 @@
+Improve pydantic import time by roughly 50% by deferring some module loading and regex compilation.

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import ChainMap
 from functools import wraps
-from inspect import Signature, signature
 from itertools import chain
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union, overload
@@ -32,6 +31,8 @@ class Validator:
 
 
 if TYPE_CHECKING:
+    from inspect import Signature
+
     from .main import BaseConfig
     from .fields import ModelField
     from .types import ModelOrDc
@@ -191,6 +192,8 @@ def extract_validators(namespace: Dict[str, Any]) -> Dict[str, List[Validator]]:
 
 
 def extract_root_validators(namespace: Dict[str, Any]) -> Tuple[List[AnyCallable], List[Tuple[bool, AnyCallable]]]:
+    from inspect import signature
+
     pre_validators: List[AnyCallable] = []
     post_validators: List[Tuple[bool, AnyCallable]] = []
     for name, value in namespace.items():
@@ -231,6 +234,8 @@ def make_generic_validator(validator: AnyCallable) -> 'ValidatorCallable':
     It's done like this so validators don't all need **kwargs in their signature, eg. any combination of
     the arguments "values", "fields" and/or "config" are permitted.
     """
+    from inspect import signature
+
     sig = signature(validator)
     args = list(sig.parameters.keys())
     first_arg = args.pop(0)
@@ -254,7 +259,7 @@ def prep_validators(v_funcs: Iterable[AnyCallable]) -> 'ValidatorsList':
 all_kwargs = {'values', 'field', 'config'}
 
 
-def _generic_validator_cls(validator: AnyCallable, sig: Signature, args: Set[str]) -> 'ValidatorCallable':
+def _generic_validator_cls(validator: AnyCallable, sig: 'Signature', args: Set[str]) -> 'ValidatorCallable':
     # assume the first argument is value
     has_kwargs = False
     if 'kwargs' in args:
@@ -288,7 +293,7 @@ def _generic_validator_cls(validator: AnyCallable, sig: Signature, args: Set[str
         return lambda cls, v, values, field, config: validator(cls, v, values=values, field=field, config=config)
 
 
-def _generic_validator_basic(validator: AnyCallable, sig: Signature, args: Set[str]) -> 'ValidatorCallable':
+def _generic_validator_basic(validator: AnyCallable, sig: 'Signature', args: Set[str]) -> 'ValidatorCallable':
     has_kwargs = False
     if 'kwargs' in args:
         has_kwargs = True

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -42,17 +42,18 @@ class RGBA:
         return self._tuple[item]
 
 
-r_hex_short = re.compile(r'\s*(?:#|0x)?([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])?\s*')
-r_hex_long = re.compile(r'\s*(?:#|0x)?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?\s*')
+# these are not compiled here to avoid import slowdown, they'll be compiled the first time they're used, then cached
+r_hex_short = r'\s*(?:#|0x)?([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])?\s*'
+r_hex_long = r'\s*(?:#|0x)?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?\s*'
 _r_255 = r'(\d{1,3}(?:\.\d+)?)'
 _r_comma = r'\s*,\s*'
-r_rgb = re.compile(fr'\s*rgb\(\s*{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_255}\)\s*')
+r_rgb = fr'\s*rgb\(\s*{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_255}\)\s*'
 _r_alpha = r'(\d(?:\.\d+)?|\.\d+|\d{1,2}%)'
-r_rgba = re.compile(fr'\s*rgba\(\s*{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_alpha}\s*\)\s*')
+r_rgba = fr'\s*rgba\(\s*{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_alpha}\s*\)\s*'
 _r_h = r'(-?\d+(?:\.\d+)?|-?\.\d+)(deg|rad|turn)?'
 _r_sl = r'(\d{1,3}(?:\.\d+)?)%'
-r_hsl = re.compile(fr'\s*hsl\(\s*{_r_h}{_r_comma}{_r_sl}{_r_comma}{_r_sl}\s*\)\s*')
-r_hsla = re.compile(fr'\s*hsl\(\s*{_r_h}{_r_comma}{_r_sl}{_r_comma}{_r_sl}{_r_comma}{_r_alpha}\s*\)\s*')
+r_hsl = fr'\s*hsl\(\s*{_r_h}{_r_comma}{_r_sl}{_r_comma}{_r_sl}\s*\)\s*'
+r_hsla = fr'\s*hsl\(\s*{_r_h}{_r_comma}{_r_sl}{_r_comma}{_r_sl}{_r_comma}{_r_alpha}\s*\)\s*'
 
 # colors where the two hex characters are the same, if all colors match this the short version of hex colors can be used
 repeat_colors = {int(c * 2, 16) for c in '0123456789abcdef'}
@@ -226,7 +227,7 @@ def parse_str(value: str) -> RGBA:
     else:
         return ints_to_rgba(r, g, b, None)
 
-    m = r_hex_short.fullmatch(value_lower)
+    m = re.fullmatch(r_hex_short, value_lower)
     if m:
         *rgb, a = m.groups()
         r, g, b = [int(v * 2, 16) for v in rgb]
@@ -236,7 +237,7 @@ def parse_str(value: str) -> RGBA:
             alpha = None
         return ints_to_rgba(r, g, b, alpha)
 
-    m = r_hex_long.fullmatch(value_lower)
+    m = re.fullmatch(r_hex_long, value_lower)
     if m:
         *rgb, a = m.groups()
         r, g, b = [int(v, 16) for v in rgb]
@@ -246,20 +247,20 @@ def parse_str(value: str) -> RGBA:
             alpha = None
         return ints_to_rgba(r, g, b, alpha)
 
-    m = r_rgb.fullmatch(value_lower)
+    m = re.fullmatch(r_rgb, value_lower)
     if m:
         return ints_to_rgba(*m.groups(), None)  # type: ignore
 
-    m = r_rgba.fullmatch(value_lower)
+    m = re.fullmatch(r_rgba, value_lower)
     if m:
         return ints_to_rgba(*m.groups())  # type: ignore
 
-    m = r_hsl.fullmatch(value_lower)
+    m = re.fullmatch(r_hsl, value_lower)
     if m:
         h, h_units, s, l_ = m.groups()
         return parse_hsl(h, h_units, s, l_)
 
-    m = r_hsla.fullmatch(value_lower)
+    m = re.fullmatch(r_hsla, value_lower)
     if m:
         h, h_units, s, l_, a = m.groups()
         return parse_hsl(h, h_units, s, l_, parse_float_alpha(a))

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Optional, Type, TypeVar, Union
 
 from .class_validators import gather_all_validators
@@ -66,6 +65,8 @@ def _process_class(
     frozen: bool,
     config: Optional[Type[Any]],
 ) -> 'DataclassType':
+    import dataclasses
+
     post_init_original = getattr(_cls, '__post_init__', None)
     if post_init_original and post_init_original.__name__ == '_pydantic_post_init':
         post_init_original = None

--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -23,7 +23,7 @@ from . import errors
 date_re = re.compile(r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$')
 
 time_re = re.compile(
-    r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})' r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
 )
 
 datetime_re = re.compile(

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -1,5 +1,4 @@
 import datetime
-from dataclasses import asdict, is_dataclass
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -42,6 +41,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 
 
 def pydantic_encoder(obj: Any) -> Any:
+    from dataclasses import asdict, is_dataclass
     from .main import BaseModel
 
     if isinstance(obj, BaseModel):

--- a/pydantic/parse.py
+++ b/pydantic/parse.py
@@ -62,5 +62,5 @@ def load_file(
             proto = Protocol.pickle
 
     return load_str_bytes(
-        b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle, json_loads=json_loads,
+        b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle, json_loads=json_loads
     )

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -1,4 +1,3 @@
-import inspect
 import re
 import warnings
 from datetime import date, datetime, time, timedelta
@@ -451,10 +450,12 @@ def model_process_schema(
     sub-models of the returned schema will be referenced, but their definitions will not be included in the schema. All
     the definitions are returned as the second value.
     """
+    from inspect import getdoc
+
     ref_prefix = ref_prefix or default_prefix
     known_models = known_models or set()
     s = {'title': model.__config__.title or model.__name__}
-    doc = inspect.getdoc(model)
+    doc = getdoc(model)
     if doc:
         s['description'] = doc
     known_models.add(model)

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -1,6 +1,5 @@
-import inspect
 import warnings
-from pathlib import Path
+from types import GeneratorType
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -69,7 +68,7 @@ ExcType = Type[Exception]
 
 
 def sequence_like(v: AnyType) -> bool:
-    return isinstance(v, (list, tuple, set, frozenset)) or inspect.isgenerator(v)
+    return isinstance(v, (list, tuple, set, frozenset, GeneratorType))
 
 
 def validate_field_name(bases: List[Type['BaseModel']], field_name: str) -> None:
@@ -336,9 +335,11 @@ class ValueItems(Representation):
 
 
 def version_info() -> str:
-    from importlib import import_module
     import platform
     import sys
+    from importlib import import_module
+    from pathlib import Path
+
     from .main import compiled
     from .version import VERSION
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -1,6 +1,4 @@
 import inspect
-import platform
-import sys
 import warnings
 from importlib import import_module
 from pathlib import Path
@@ -337,6 +335,8 @@ class ValueItems(Representation):
 
 
 def version_info() -> str:
+    import platform
+    import sys
     from .main import compiled
     from .version import VERSION
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -1,6 +1,5 @@
 import inspect
 import warnings
-from importlib import import_module
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -35,6 +34,8 @@ def import_string(dotted_path: str) -> Any:
     Stolen approximately from django. Import a dotted module path and return the attribute/class designated by the
     last name in the path. Raise ImportError if the import fails.
     """
+    from importlib import import_module
+
     try:
         module_path, class_name = dotted_path.strip(' ').rsplit('.', 1)
     except ValueError as e:
@@ -335,6 +336,7 @@ class ValueItems(Representation):
 
 
 def version_info() -> str:
+    from importlib import import_module
     import platform
     import sys
     from .main import compiled

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -1,5 +1,3 @@
-from distutils.version import StrictVersion
-
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('1.3')
+VERSION = '1.3'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1743,6 +1743,6 @@ def test_frozen_set():
                 'type': 'array',
                 'items': {'type': 'integer'},
                 'uniqueItems': True,
-            },
+            }
         },
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,13 @@
 import os
 import re
 import string
+from distutils.version import StrictVersion
 from enum import Enum
 from typing import NewType, Union
 
 import pytest
 
-from pydantic import BaseModel
+from pydantic import VERSION, BaseModel
 from pydantic.color import Color
 from pydantic.dataclasses import dataclass
 from pydantic.fields import Undefined
@@ -292,3 +293,7 @@ def test_version_info():
     s = version_info()
     assert re.match(' *pydantic version: ', s)
     assert s.count('\n') == 5
+
+
+def test_version_strict():
+    assert str(StrictVersion(VERSION)) == VERSION


### PR DESCRIPTION
## Change Summary

Roughly halve the time to import pydantic, see #1127 for discussion.

Changes:
* `dataclasses` is only imported when used
* three regexes `url_regex`, `ascii_domain_regex` and `int_domain_regex` in `network.py` now only compiled when used. Thus `url_regex` etc. are now accessible as a function `url_regex()`
* `email_validator` is only imported when it's used.
* `pydantic.VERSION` is no longer a `StrictVersion`, just a standard str
* `version_info` will only import `platform` and `sys` when it's called
* `Color` regexes are not compiled until used.

## Related issue number

fix #1127 and also fix #1039

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] ~~Documentation reflects the changes where applicable~~
* [x] `changes/<pull request or issue id>-<github username>.md` file added