### PR TITLE
encourage use of version_info() in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,12 +10,12 @@ Output of `python -c "import pydantic.utils; print(pydantic.utils.version_info()
 ```
 ...
 ```
-<!-- or if you're using pydantic before v1.3, manually add os, python version and pydantic version -->
+<!-- or if you're using pydantic prior to v1.3, manually include: OS, python version and pydantic version -->
 
 <!-- Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
 confirm your bug hasn't already been reported. -->
 
-<!-- Where possible please include a self contained code snippet describing your bug: -->
+<!-- Where possible please include a self-contained code snippet describing your bug: -->
 
 ```py
 import pydantic

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -6,15 +6,16 @@ labels: bug
 
 # Bug
 
-Please complete:
-* OS: **?**
-* Python version `import sys; print(sys.version)`: **?**
-* Pydantic version `import pydantic; print(pydantic.VERSION)`: **?**
+Output of `python -c "import pydantic.utils; print(pydantic.utils.version_info())"`:
+```
+...
+```
+<!-- or if you're using pydantic before v1.3, manually add os, python version and pydantic version -->
 
-**Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
-confirm your bug hasn't already been reported.**
+<!-- Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
+confirm your bug hasn't already been reported. -->
 
-Where possible please include a self contained code snippet describing your bug:
+<!-- Where possible please include a self contained code snippet describing your bug: -->
 
 ```py
 import pydantic

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,15 +6,16 @@ labels: feature request
 
 # Feature Request
 
-Please complete:
-* OS: **?**
-* Python version `import sys; print(sys.version)`: **?**
-* Pydantic version `import pydantic; print(pydantic.VERSION)`: **?**
+Output of `python -c "import pydantic.utils; print(pydantic.utils.version_info())"`:
+```
+...
+```
+<!-- or if you're using pydantic before v1.3, manually add os, python version and pydantic version -->
 
-**Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
-confirm your feature hasn't been asked for before, or already implemented.**
+<!-- Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
+confirm your feature hasn't been asked for before, or already implemented. -->
 
-Where possible please include a self contained code snippet describing your feature request:
+<!-- Where possible please include a self contained code snippet describing your feature request: -->
 
 ```py
 import pydantic

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,12 +10,12 @@ Output of `python -c "import pydantic.utils; print(pydantic.utils.version_info()
 ```
 ...
 ```
-<!-- or if you're using pydantic before v1.3, manually add os, python version and pydantic version -->
+<!-- or if you're using pydantic prior to v1.3, manually include: OS, python version and pydantic version -->
 
 <!-- Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
 confirm your feature hasn't been asked for before, or already implemented. -->
 
-<!-- Where possible please include a self contained code snippet describing your feature request: -->
+<!-- Where possible please include a self-contained code snippet describing your feature request: -->
 
 ```py
 import pydantic

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,15 +6,16 @@ labels: question
 
 # Question
 
-Please complete:
-* OS: **?**
-* Python version `import sys; print(sys.version)`: **?**
-* Pydantic version `import pydantic; print(pydantic.VERSION)`: **?**
+Output of `python -c "import pydantic.utils; print(pydantic.utils.version_info())"`:
+```
+...
+```
+<!-- or if you're using pydantic before v1.3, manually add os, python version and pydantic version -->
 
-**Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
-confirm your question hasn't already been answered.**
+<!-- Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
+confirm your question hasn't already been answered. -->
 
-Where possible please include a self contained code snippet describing your question:
+<!-- Where possible please include a self contained code snippet describing your question: -->
 
 ```py
 import pydantic

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,12 +10,12 @@ Output of `python -c "import pydantic.utils; print(pydantic.utils.version_info()
 ```
 ...
 ```
-<!-- or if you're using pydantic before v1.3, manually add os, python version and pydantic version -->
+<!-- or if you're using pydantic prior to v1.3, manually include: OS, python version and pydantic version -->
 
 <!-- Please read the [docs](https://pydantic-docs.helpmanual.io/) and search through issues to
 confirm your question hasn't already been answered. -->
 
-<!-- Where possible please include a self contained code snippet describing your question: -->
+<!-- Where possible please include a self-contained code snippet describing your question: -->
 
 ```py
 import pydantic

--- a/changes/1138-samuelcolvin.md
+++ b/changes/1138-samuelcolvin.md
@@ -1,0 +1,1 @@
+move `version_info()` to `version.py`, suggest its use in issues.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,13 +4,15 @@ We'd love you to contribute to *pydantic*!
 
 Questions, feature requests and bug reports are all welcome as issues.
 
-To make it as simple as possible for us to help you please include the output of the following call in your issue:
+To make it as simple as possible for us to help you, please include the output of the following call in your issue:
 
 ```bash
 python -c "import pydantic.utils; print(pydantic.utils.version_info())"
 ```
+If you're using *pydantic* prior to **v1.3** (when `version_info()` was added), please manually include OS, python
+version and pydantic version.
 
-Please try to always include the above output unless you're unable to install *pydantic* or **know** it's not relevant
+Please try to always include the above unless you're unable to install *pydantic* or **know** it's not relevant
 to your question or feature request.
 
 ## Pull Requests

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -19,13 +19,29 @@ from typing import (
 )
 
 from .typing import AnyType, display_as_type
+from .version import version_info
 
 if TYPE_CHECKING:
     from .main import BaseModel  # noqa: F401
     from .typing import AbstractSetIntStr, DictIntStrAny, IntStr, ReprArgs  # noqa: F401
     from .dataclasses import DataclassType  # noqa: F401
 
-KeyType = TypeVar('KeyType')
+__all__ = (
+    'import_string',
+    'sequence_like',
+    'validate_field_name',
+    'lenient_issubclass',
+    'in_ipython',
+    'deep_update',
+    'update_not_none',
+    'almost_equal_floats',
+    'get_model',
+    'PyObjectStr',
+    'Representation',
+    'GetterDict',
+    'ValueItems',
+    'version_info',  # required here to match behaviour in v1.3
+)
 
 
 def import_string(dotted_path: str) -> Any:
@@ -64,9 +80,6 @@ def truncate(v: Union[str], *, max_len: int = 80) -> str:
     return v
 
 
-ExcType = Type[Exception]
-
-
 def sequence_like(v: AnyType) -> bool:
     return isinstance(v, (list, tuple, set, frozenset, GeneratorType))
 
@@ -97,6 +110,9 @@ def in_ipython() -> bool:
         return False
     else:  # pragma: no cover
         return True
+
+
+KeyType = TypeVar('KeyType')
 
 
 def deep_update(mapping: Dict[KeyType, Any], updating_mapping: Dict[KeyType, Any]) -> Dict[KeyType, Any]:
@@ -332,31 +348,3 @@ class ValueItems(Representation):
 
     def __repr_args__(self) -> 'ReprArgs':
         return [(None, self._items)]
-
-
-def version_info() -> str:
-    import platform
-    import sys
-    from importlib import import_module
-    from pathlib import Path
-
-    from .main import compiled
-    from .version import VERSION
-
-    optional_deps = []
-    for p in ('typing-extensions', 'email-validator', 'devtools'):
-        try:
-            import_module(p.replace('-', '_'))
-        except ImportError:
-            continue
-        optional_deps.append(p)
-
-    info = {
-        'pydantic version': VERSION,
-        'pydantic compiled': compiled,
-        'install path': Path(__file__).resolve().parent,
-        'python version': sys.version,
-        'platform': platform.platform(),
-        'optional deps. installed': optional_deps,
-    }
-    return '\n'.join('{:>30} {}'.format(k + ':', str(v).replace('\n', ' ')) for k, v in info.items())

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -1,3 +1,30 @@
-__all__ = ['VERSION']
+__all__ = ['VERSION', 'version_info']
 
-VERSION = '1.3'
+VERSION = '1.3a1'
+
+
+def version_info() -> str:
+    import platform
+    import sys
+    from importlib import import_module
+    from pathlib import Path
+
+    from .main import compiled
+
+    optional_deps = []
+    for p in ('typing-extensions', 'email-validator', 'devtools'):
+        try:
+            import_module(p.replace('-', '_'))
+        except ImportError:
+            continue
+        optional_deps.append(p)
+
+    info = {
+        'pydantic version': VERSION,
+        'pydantic compiled': compiled,
+        'install path': Path(__file__).resolve().parent,
+        'python version': sys.version,
+        'platform': platform.platform(),
+        'optional deps. installed': optional_deps,
+    }
+    return '\n'.join('{:>30} {}'.format(k + ':', str(v).replace('\n', ' ')) for k, v in info.items())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,8 @@ from pydantic.color import Color
 from pydantic.dataclasses import dataclass
 from pydantic.fields import Undefined
 from pydantic.typing import display_as_type, is_new_type, new_type_supertype
-from pydantic.utils import ValueItems, deep_update, get_model, import_string, lenient_issubclass, truncate, version_info
+from pydantic.utils import ValueItems, deep_update, get_model, import_string, lenient_issubclass, truncate
+from pydantic.version import version_info
 
 try:
     import devtools


### PR DESCRIPTION
## Change Summary

* Move `version_info()` to `version.py` (still usable from `utils.py` for backwards compatibility).
* Change issue templates to use `version_info()` not it's been released for a while

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
