### PR TITLE
Implement support for declaring infinite generators

### DIFF
--- a/changes/1152-tiangolo.md
+++ b/changes/1152-tiangolo.md
@@ -1,0 +1,1 @@
+add support for infinite generators with `Iterable`

--- a/docs/examples/types_infinite_generator.py
+++ b/docs/examples/types_infinite_generator.py
@@ -1,0 +1,19 @@
+from typing import Iterable, Sequence
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    infinite: Iterable[int]
+
+def infinite_ints():
+    i = 0
+    while True:
+        yield i
+        i += 1
+
+m = Model(infinite=infinite_ints())
+print(m)
+
+for i in m.infinite:
+    print(i)
+    if i == 10:
+        break

--- a/docs/examples/types_infinite_generator.py
+++ b/docs/examples/types_infinite_generator.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence
+from typing import Iterable
 from pydantic import BaseModel
 
 class Model(BaseModel):

--- a/docs/examples/types_infinite_generator_validate_first.py
+++ b/docs/examples/types_infinite_generator_validate_first.py
@@ -31,11 +31,6 @@ def infinite_ints():
 m = Model(infinite=infinite_ints())
 print(m)
 
-for i in m.infinite:
-    print(i)
-    if i == 10:
-        break
-
 def infinite_strs():
     while True:
         for letter in 'allthesingleladies':

--- a/docs/examples/types_infinite_generator_validate_first.py
+++ b/docs/examples/types_infinite_generator_validate_first.py
@@ -1,0 +1,47 @@
+import itertools
+from typing import Iterable
+from pydantic import BaseModel, validator, ValidationError
+from pydantic.fields import ModelField
+
+class Model(BaseModel):
+    infinite: Iterable[int]
+
+    @validator('infinite')
+    # You don't need to add the "ModelField", but it will help your
+    # editor give you completion and catch errors
+    def infinite_first_int(cls, iterable, field: ModelField):
+        first_value = next(iterable)
+        if field.sub_fields:
+            # The Iterable had a parameter type, in this case it's int
+            # We use it to validate the first value
+            sub_field = field.sub_fields[0]
+            v, error = sub_field.validate(first_value, {}, loc='first_value')
+            if error:
+                raise ValidationError([error], cls)
+        # This creates a new generator that returns the first value and then
+        # the rest of the values from the (already started) iterable
+        return itertools.chain([first_value], iterable)
+
+def infinite_ints():
+    i = 0
+    while True:
+        yield i
+        i += 1
+
+m = Model(infinite=infinite_ints())
+print(m)
+
+for i in m.infinite:
+    print(i)
+    if i == 10:
+        break
+
+def infinite_strs():
+    while True:
+        for letter in 'allthesingleladies':
+            yield letter
+
+try:
+    Model(infinite=infinite_strs())
+except ValidationError as e:
+    print(e)

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -181,6 +181,15 @@ _(This script is complete, it should run "as is")_
 
     pydantic can't validate the values automatically for you because it would require consuming the infinite generator.
 
+#### Infinite Generators with Validation for First Value
+
+You can create a [Validator](validators.md) to validate the first value in an infinite generator and still not consume it entirely.
+
+```py
+{!.tmp_examples/types_infinite_generator_validate_first.py!}
+```
+_(This script is complete, it should run "as is")_
+
 ### Unions
 
 The `Union` type allows a model attribute to accept different types, e.g.:

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -162,9 +162,12 @@ _(This script is complete, it should run "as is")_
 
 ### Infinite Generators
 
-If you have a generator you can use `Sequence` as described above. In that case, the generator will be consumed and its values will be validated with the sub-type of `Sequence` (e.g. `int` in `Sequence[int]`).
+If you have a generator you can use `Sequence` as described above. In that case, the
+generator will be consumed and stored on the model as a list and its values will be
+validated with the sub-type of `Sequence` (e.g. `int` in `Sequence[int]`).
 
-But if you have a generator that you don't want to be consumed, e.g. an infinite generator or a remote data loader, you can define its type with `Iterable`:
+But if you have a generator that you don't want to be consumed, e.g. an infinite
+generator or a remote data loader, you can define its type with `Iterable`:
 
 ```py
 {!.tmp_examples/types_infinite_generator.py!}
@@ -172,18 +175,23 @@ But if you have a generator that you don't want to be consumed, e.g. an infinite
 _(This script is complete, it should run "as is")_
 
 !!! warning
-    `Iterable` fields only perform a simple check that the argument is iterable and won't be consumed.
+    `Iterable` fields only perform a simple check that the argument is iterable and
+    won't be consumed.
 
-    No validation of their values is performed as it cannot be done without consuming the iterable.
+    No validation of their values is performed as it cannot be done without consuming
+    the iterable.
 
 !!! tip
-    If you want to validate the values of an infinite generator you can create a separate model and use it while consuming the generator, reporting the validation errors as appropriate.
+    If you want to validate the values of an infinite generator you can create a
+    separate model and use it while consuming the generator, reporting the validation
+    errors as appropriate.
 
-    pydantic can't validate the values automatically for you because it would require consuming the infinite generator.
+    pydantic can't validate the values automatically for you because it would require
+    consuming the infinite generator.
 
-#### Infinite Generators with Validation for First Value
+## Validating the first value
 
-You can create a [Validator](validators.md) to validate the first value in an infinite generator and still not consume it entirely.
+You can create a [validator](validators.md) to validate the first value in an infinite generator and still not consume it entirely.
 
 ```py
 {!.tmp_examples/types_infinite_generator_validate_first.py!}

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -93,6 +93,9 @@ with custom properties and validation.
 `typing.Sequence`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
+`typing.Iterable`
+: this is reserved for iterables that shouldn't be consumed. See [Infinite Generators](#infinite-generators) below for more detail on parsing and validation
+
 `typing.Type`
 : see [Type](#type) below for more detail on parsing and validation
 
@@ -156,6 +159,27 @@ with custom properties and validation.
 {!.tmp_examples/types_iterables.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+### Infinite Generators
+
+If you have a generator you can use `Sequence` as described above. In that case, the generator will be consumed and its values will be validated with the sub-type of `Sequence` (e.g. `int` in `Sequence[int]`).
+
+But if you have a generator that you don't want to be consumed, e.g. an infinite generator or a remote data loader, you can define its type with `Iterable`:
+
+```py
+{!.tmp_examples/types_infinite_generator.py!}
+```
+_(This script is complete, it should run "as is")_
+
+!!! warning
+    `Iterable` fields only perform a simple check that the argument is iterable and won't be consumed.
+
+    No validation of their values is performed as it cannot be done without consuming the iterable.
+
+!!! tip
+    If you want to validate the values of an infinite generator you can create a separate model and use it while consuming the generator, reporting the validation errors as appropriate.
+
+    pydantic can't validate the values automatically for you because it would require consuming the infinite generator.
 
 ### Unions
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -238,6 +238,10 @@ class SequenceError(PydanticTypeError):
     msg_template = 'value is not a valid sequence'
 
 
+class IterableError(PydanticTypeError):
+    msg_template = 'value is not a valid iterable'
+
+
 class ListError(PydanticTypeError):
     msg_template = 'value is not a valid list'
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -425,6 +425,7 @@ class ModelField(Representation):
         elif origin == Iterable or origin == abc.Iterable:
             self.type_ = self.type_.__args__[0]
             self.shape = SHAPE_ITERABLE
+            self.sub_fields = [self._create_sub_type(self.type_, f'{self.name}_type')]
         elif issubclass(origin, Type):  # type: ignore
             return
         else:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,5 +1,5 @@
 import warnings
-from collections import abc
+from collections.abc import Iterable as CollectionsIterable
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -420,9 +420,9 @@ class ModelField(Representation):
             self.key_field = self._create_sub_type(self.type_.__args__[0], 'key_' + self.name, for_keys=True)
             self.type_ = self.type_.__args__[1]
             self.shape = SHAPE_MAPPING
-        # Equality check as almost everything inherit form Iterable, including str
-        # check for typing.Iterable and abc.Iterable, as it could receive one even when declared with the other
-        elif origin == Iterable or origin == abc.Iterable:
+        # Equality check as almost everything inherits form Iterable, including str
+        # check for Iterable and CollectionsIterable, as it could receive one even when declared with the other
+        elif origin in {Iterable, CollectionsIterable}:
             self.type_ = self.type_.__args__[0]
             self.shape = SHAPE_ITERABLE
             self.sub_fields = [self._create_sub_type(self.type_, f'{self.name}_type')]
@@ -569,12 +569,10 @@ class ModelField(Representation):
         This intentionally doesn't validate values to allow infinite generators.
         """
 
-        e: Optional[Exception] = None
         try:
             iterable = iter(v)
         except TypeError:
-            e = errors_.IterableError()
-            return v, ErrorWrapper(e, loc)
+            return v, ErrorWrapper(errors_.IterableError(), loc)
         return iterable, None
 
     def _validate_tuple(

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -26,6 +26,7 @@ from uuid import UUID
 from .class_validators import ROOT_KEY
 from .fields import (
     SHAPE_FROZENSET,
+    SHAPE_ITERABLE,
     SHAPE_LIST,
     SHAPE_MAPPING,
     SHAPE_SEQUENCE,
@@ -375,7 +376,7 @@ def field_type_schema(
     nested_models: Set[str] = set()
     f_schema: Dict[str, Any]
     ref_prefix = ref_prefix or default_prefix
-    if field.shape in {SHAPE_LIST, SHAPE_TUPLE_ELLIPSIS, SHAPE_SEQUENCE, SHAPE_SET, SHAPE_FROZENSET}:
+    if field.shape in {SHAPE_LIST, SHAPE_TUPLE_ELLIPSIS, SHAPE_SEQUENCE, SHAPE_SET, SHAPE_FROZENSET, SHAPE_ITERABLE}:
         items_schema, f_definitions, f_nested_models = field_singleton_schema(
             field, by_alias=by_alias, model_name_map=model_name_map, ref_prefix=ref_prefix, known_models=known_models
         )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, List, NewType, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, NewType, Optional, Set, Tuple, Union
 from uuid import UUID
 
 import pytest
@@ -1745,4 +1745,16 @@ def test_frozen_set():
                 'uniqueItems': True,
             }
         },
+    }
+
+
+def test_iterable():
+    class Model(BaseModel):
+        a: Iterable[int]
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'},}},
+        'required': ['a'],
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1755,6 +1755,6 @@ def test_iterable():
     assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'},}},
+        'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'}}},
         'required': ['a'],
     }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -816,7 +816,7 @@ def test_invalid_iterable():
         b: int
 
     with pytest.raises(ValidationError) as exc_info:
-        m = Model(it=3, b=3)
+        Model(it=3, b=3)
     assert exc_info.value.errors() == [
         {'loc': ('it',), 'msg': 'value is not a valid iterable', 'type': 'type_error.iterable'}
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This implements support for adding typing declarations for infinite generators.

The current implementation allows annotating a generator with `Sequence[subType]`, but it consumes the generator to validate the internal data, so an infinite generator would just hang on model creation, while the model consumes the generator.

The recommended way to annotate a generator that doesn't support `len` nor `__getitem__` (e.g. an infinite generator) is with `Iterable[subType]`: https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html#standard-duck-types

This implementation intentionally doesn't consume the generator, assuming it could be infinite or expensive, so it doesn't validate the iterated values. But it allows supporting these infinite generators in pydantic models.

The added docs give an explanation/warning about these generators not being validated and how they are there mainly to support infinite generators, but having `Sequence` as the (probably) preferred way to annotate consumable generators.

The use case for this is that pydantic will be a requirement for https://github.com/explosion/spaCy and https://github.com/explosion/thinc (already on the `develop` branches). pydantic is used throughout the libraries, and for some configurations, the libraries take possibly infinite or expensive generators. For things like Machine Learning dataset loading, etc. So it's not viable to have the generators consumed at model creation.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
