### PR TITLE
Bug Fix: field shape value is wrong for native sequence types #1112

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -361,7 +361,7 @@ class ModelField(Representation):
         origin = getattr(self.type_, '__origin__', None)
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.
-            self.shape = TYPES_TO_SHAPE.get(self.type_)
+            self.shape = TYPES_TO_SHAPE.get(self.type_, self.shape)
             return
         if origin is Callable:
             return

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -181,6 +181,12 @@ SHAPE_NAME_LOOKUP = {
     SHAPE_SEQUENCE: 'Sequence[{}]',
     SHAPE_FROZENSET: 'FrozenSet[{}]',
 }
+TYPES_TO_SHAPE = {
+    tuple: SHAPE_TUPLE,
+    list: SHAPE_LIST,
+    set: SHAPE_SET,
+    frozenset: SHAPE_FROZENSET,
+}
 
 
 class ModelField(Representation):
@@ -355,18 +361,7 @@ class ModelField(Representation):
         origin = getattr(self.type_, '__origin__', None)
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.
-            if self.type_ is tuple:
-                self.shape = SHAPE_TUPLE
-                return
-            if self.type_ is list:
-                self.shape = SHAPE_LIST
-                return
-            if self.type_ is set:
-                self.shape = SHAPE_SET
-                return
-            if self.type_ is frozenset:
-                self.shape = SHAPE_FROZENSET
-                return
+            self.shape = TYPES_TO_SHAPE.get(self.type_)
             return
         if origin is Callable:
             return

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -355,6 +355,18 @@ class ModelField(Representation):
         origin = getattr(self.type_, '__origin__', None)
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.
+            if self.type_ is tuple:
+                self.shape = SHAPE_TUPLE
+                return
+            if self.type_ is list:
+                self.shape = SHAPE_LIST
+                return
+            if self.type_ is set:
+                self.shape = SHAPE_SET
+                return
+            if self.type_ is frozenset:
+                self.shape = SHAPE_FROZENSET
+                return
             return
         if origin is Callable:
             return


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
In `pydantic/fields.py:ModelField._type_analysis()` where the `field.shape`  field get assign depending on the `field` type. `getattr(self.type_, '__origin__', None)` is returning `None` so the function is getting returned from there without assigning the value to `field.shape` variable.

https://github.com/samuelcolvin/pydantic/blob/e65d11240a6febcd569ad44a61e2374eb00b9ba6/pydantic/fields.py#L355-L358

So I added a check which checks if the `origin` is `None` then it checks if the `self.type_` is a native sequence type and based on that it set the value of `self.shape`.

## Related issue number

Fix #1112 

## Checklist

* [x] Added Check for Checking if `type_` is a native sequence and set `field` value based on that.
