### PR TITLE
Add support for generics with __get_validators__

### DIFF
--- a/changes/1159-tiangolo.md
+++ b/changes/1159-tiangolo.md
@@ -1,1 +1,1 @@
-add basic support for generics that implement `__get_validators__` like a custom data type.
+add support for generics that implement `__get_validators__` like a custom data type.

--- a/changes/1159-tiangolo.md
+++ b/changes/1159-tiangolo.md
@@ -1,0 +1,1 @@
+add basic support for generics that implement `__get_validators__` like a custom data type.

--- a/docs/examples/types_arbitrary_allowed.py
+++ b/docs/examples/types_arbitrary_allowed.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, ValidationError
+
+# This is not a pydantic model, it's an arbitrary class
+class Pet:
+    def __init__(self, name: str):
+        self.name = name
+
+class Model(BaseModel):
+    pet: Pet
+    owner: str
+
+    class Config:
+        arbitrary_types_allowed = True
+
+pet = Pet(name='Hedwig')
+# A simple check of instance type is used to validate the data
+model = Model(owner='Harry', pet=pet)
+print(model)
+print(model.pet)
+print(model.pet.name)
+print(type(model.pet))
+try:
+    # If the value is not an instance of the type, it's invalid
+    Model(owner='Harry', pet='Hedwig')
+except ValidationError as e:
+    print(e)
+# Nothing in the instance of the arbitrary type is checked
+# Here name probably should have been a str, but it's not validated
+pet2 = Pet(name=42)
+model2 = Model(owner='Harry', pet=pet2)
+print(model2)
+print(model2.pet)
+print(model2.pet.name)
+print(type(model2.pet))

--- a/docs/examples/types_generics.py
+++ b/docs/examples/types_generics.py
@@ -1,0 +1,81 @@
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import ModelField
+from typing import TypeVar, Generic
+
+OldType = TypeVar('OldType')
+GradeType = TypeVar('GradeType')
+
+# This is not a pydantic model, it's an arbitrary generic class
+class Assessment(Generic[OldType, GradeType]):
+    def __init__(self, name: str, old: OldType, grade: GradeType):
+        self.name = name
+        self.old = old
+        self.grade = grade
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    # You don't need to add the "ModelField", but it will help your
+    # editor give you completion and catch errors
+    def validate(cls, v, field: ModelField):
+        if not isinstance(v, cls):
+            # The value is not even an Assessment
+            raise ValueError('Invalid value')
+        if not field.sub_fields:
+            # Generic parameters were not provided so we don't try to validate
+            # them and just return the value as is
+            return v
+        sub_field_old = field.sub_fields[0]
+        sub_field_grade = field.sub_fields[1]
+        errors = []
+        # Here we don't need the validated value, but we want the errors
+        value_old, error = sub_field_old.validate(v.old, {}, loc='old')
+        if error:
+            errors.append(error)
+        # Here we don't need the validated value, but we want the errors
+        value_grade, error = sub_field_grade.validate(v.grade, {}, loc='grade')
+        if error:
+            errors.append(error)
+        if errors:
+            raise ValidationError(errors, cls)
+        # Validation passed without errors, return the same instance received
+        return v
+
+class Model(BaseModel):
+    student: Assessment[int, float]  # old is an int, grade a float
+    cheese: Assessment[bool, str]  # old is a bool, grade a str
+    thing: Assessment  # old is Any, grade is Any
+
+model = Model(
+    student=Assessment(name='Harry', old=15, grade=87),
+    cheese=Assessment(name='Gouda', old=True, grade='Good'),
+    thing=Assessment(name='Python', old='Nah', grade='Awesome')
+    )
+print(model)
+print(model.student)
+print(model.student.name)
+print(model.student.old)
+print(model.student.grade)
+print(model.cheese)
+print(model.cheese.name)
+print(model.cheese.old)
+print(model.cheese.grade)
+print(model.thing)
+print(model.thing.name)
+print(model.thing.old)
+print(model.thing.grade)
+try:
+    # If the values of the sub-types are invalid, we get an error
+    Model(
+        # For student, old should be an int, and grade a float
+        student=Assessment(name='Harry', old=True, grade='Fail'),
+        # For cheese, old should be a bool, and grade a str
+        cheese=Assessment(name='Gouda', old='yeah', grade=5),
+        # For thing, no type parameters are declared, and we skipped validation
+        # in those cases in the Assessment.validate() function
+        thing=Assessment(name='Python', old='Nah', grade='Awesome')
+    )
+except ValidationError as e:
+    print(e)

--- a/docs/examples/types_generics.py
+++ b/docs/examples/types_generics.py
@@ -58,7 +58,7 @@ model = Model(
     cheese=TastingModel(name='Gouda', aged=True, quality='Good'),
     # This Python thing has aged "Not much" and has a quality "Awesome"
     thing=TastingModel(name='Python', aged='Not much', quality='Awesome')
-    )
+)
 print(model)
 print(model.wine.aged)
 print(model.wine.quality)
@@ -75,6 +75,6 @@ try:
         # For thing, no type parameters are declared, and we skipped validation
         # in those cases in the Assessment.validate() function
         thing=TastingModel(name='Python', aged='Not much', quality='Awesome')
-)
+    )
 except ValidationError as e:
     print(e)

--- a/docs/examples/types_generics.py
+++ b/docs/examples/types_generics.py
@@ -2,15 +2,15 @@ from pydantic import BaseModel, ValidationError
 from pydantic.fields import ModelField
 from typing import TypeVar, Generic
 
-OldType = TypeVar('OldType')
-GradeType = TypeVar('GradeType')
+AgedType = TypeVar('AgedType')
+QualityType = TypeVar('QualityType')
 
 # This is not a pydantic model, it's an arbitrary generic class
-class Assessment(Generic[OldType, GradeType]):
-    def __init__(self, name: str, old: OldType, grade: GradeType):
+class TastingModel(Generic[AgedType, QualityType]):
+    def __init__(self, name: str, aged: AgedType, quality: QualityType):
         self.name = name
-        self.old = old
-        self.grade = grade
+        self.aged = aged
+        self.quality = quality
 
     @classmethod
     def __get_validators__(cls):
@@ -21,21 +21,21 @@ class Assessment(Generic[OldType, GradeType]):
     # editor give you completion and catch errors
     def validate(cls, v, field: ModelField):
         if not isinstance(v, cls):
-            # The value is not even an Assessment
-            raise ValueError('Invalid value')
+            # The value is not even a TastingModel
+            raise TypeError('Invalid value')
         if not field.sub_fields:
             # Generic parameters were not provided so we don't try to validate
             # them and just return the value as is
             return v
-        sub_field_old = field.sub_fields[0]
-        sub_field_grade = field.sub_fields[1]
+        aged_f = field.sub_fields[0]
+        quality_f = field.sub_fields[1]
         errors = []
         # Here we don't need the validated value, but we want the errors
-        value_old, error = sub_field_old.validate(v.old, {}, loc='old')
+        valid_value, error = aged_f.validate(v.aged, {}, loc='aged')
         if error:
             errors.append(error)
         # Here we don't need the validated value, but we want the errors
-        value_grade, error = sub_field_grade.validate(v.grade, {}, loc='grade')
+        valid_value, error = quality_f.validate(v.quality, {}, loc='quality')
         if error:
             errors.append(error)
         if errors:
@@ -44,38 +44,37 @@ class Assessment(Generic[OldType, GradeType]):
         return v
 
 class Model(BaseModel):
-    student: Assessment[int, float]  # old is an int, grade a float
-    cheese: Assessment[bool, str]  # old is a bool, grade a str
-    thing: Assessment  # old is Any, grade is Any
+    # for wine, "aged" is an int with years, "quality" is a float
+    wine: TastingModel[int, float]
+    # for cheese, "aged" is a bool, "quality" is a str
+    cheese: TastingModel[bool, str]
+    # for thing, "aged" is a Any, "quality" is Any
+    thing: TastingModel
 
 model = Model(
-    student=Assessment(name='Harry', old=15, grade=87),
-    cheese=Assessment(name='Gouda', old=True, grade='Good'),
-    thing=Assessment(name='Python', old='Nah', grade='Awesome')
+    # This wine was aged for 20 years and has a quality of 85.6
+    wine=TastingModel(name='Cabernet Sauvignon', aged=20, quality=85.6),
+    # This cheese is aged (is mature) and has "Good" quality
+    cheese=TastingModel(name='Gouda', aged=True, quality='Good'),
+    # This Python thing has aged "Not much" and has a quality "Awesome"
+    thing=TastingModel(name='Python', aged='Not much', quality='Awesome')
     )
 print(model)
-print(model.student)
-print(model.student.name)
-print(model.student.old)
-print(model.student.grade)
-print(model.cheese)
-print(model.cheese.name)
-print(model.cheese.old)
-print(model.cheese.grade)
-print(model.thing)
-print(model.thing.name)
-print(model.thing.old)
-print(model.thing.grade)
+print(model.wine.aged)
+print(model.wine.quality)
+print(model.cheese.aged)
+print(model.cheese.quality)
+print(model.thing.aged)
 try:
     # If the values of the sub-types are invalid, we get an error
     Model(
-        # For student, old should be an int, and grade a float
-        student=Assessment(name='Harry', old=True, grade='Fail'),
-        # For cheese, old should be a bool, and grade a str
-        cheese=Assessment(name='Gouda', old='yeah', grade=5),
+        # For wine, aged should be an int with the years, and quality a float
+        wine=TastingModel(name='Merlot', aged=True, quality='Kinda good'),
+        # For cheese, aged should be a bool, and quality a str
+        cheese=TastingModel(name='Gouda', aged='yeah', quality=5),
         # For thing, no type parameters are declared, and we skipped validation
         # in those cases in the Assessment.validate() function
-        thing=Assessment(name='Python', old='Nah', grade='Awesome')
-    )
+        thing=TastingModel(name='Python', aged='Not much', quality='Awesome')
+)
 except ValidationError as e:
     print(e)

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -48,8 +48,10 @@ Options:
   Pass in a dictionary with keys matching the error messages you want to override (default: `{}`)
 
 **`arbitrary_types_allowed`**
-: whether to allow arbitrary user types for fields (they are validated simply by checking if the
-  value is an instance of the type). If `False`, `RuntimeError` will be raised on model declaration (default: `False`)
+: whether to allow arbitrary user types for fields (they are validated simply by
+  checking if the value is an instance of the type). If `False`, `RuntimeError` will be
+  raised on model declaration (default: `False`). See an example in
+  [Field Types](types.md#arbitrary-types-allowed).
 
 **`orm_mode`**
 : whether to allow usage of [ORM mode](models.md#orm-mode)

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -693,11 +693,16 @@ _(This script is complete, it should run "as is")_
 
 ## Custom Data Types
 
-You can also define your own custom data types. The classmethod `__get_validators__` will be called
+You can also define your own custom data types. There are several ways to achieve it.
+
+### Classes with `__get_validators__`
+
+You use a custom class with a classmethod `__get_validators__`. It will be called
 to get validators to parse and validate the input data.
 
 !!! tip
-    These validators have the same semantics as in [Validators](validators.md), you can declare a parameter `config`, `field`, etc.
+    These validators have the same semantics as in [Validators](validators.md), you can
+    declare a parameter `config`, `field`, etc.
 
 ```py
 {!.tmp_examples/types_custom_type.py!}
@@ -709,25 +714,32 @@ formatted with a space, the schema would just include the full pattern and the r
 
 See [Schema](schema.md) for more details on how the model's schema is generated.
 
-## Allow Arbitrary Types
+### Arbitrary Types Allowed
 
-You can allow arbitrary types using the `arbitrary_types_allowed` config in the [Model Config](model_config.md).
+You can allow arbitrary types using the `arbitrary_types_allowed` config in the
+[Model Config](model_config.md).
 
 ```py
 {!.tmp_examples/types_arbitrary_allowed.py!}
 ```
 _(This script is complete, it should run "as is")_
 
-## Generic Classes as Types
+### Generic Classes as Types
 
 !!! warning
-    This is an advanced technique that you might not need in the beginning. In most of the cases you will probably be fine with standard *pydantic* models.
+    This is an advanced technique that you might not need in the beginning. In most of
+    the cases you will probably be fine with standard *pydantic* models.
 
-You can use [Generic Classes](https://mypy.readthedocs.io/en/latest/generics.html) as field types and perform custom validation based on the "type parameters" (or sub-types) with `__get_validators__`.
+You can use
+[Generic Classes](https://docs.python.org/3/library/typing.html#typing.Generic) as
+field types and perform custom validation based on the "type parameters" (or sub-types)
+with `__get_validators__`.
 
-If the Generic class that you are using as a sub-type has a classmethod `__get_validators__`, you don't need to use `arbitrary_types_allowed` for it to work.
+If the Generic class that you are using as a sub-type has a classmethod
+`__get_validators__` you don't need to use `arbitrary_types_allowed` for it to work.
 
-Because you can declare validators that receive the current `field`, you can extract the `sub_fields` (from the generic class type parameters) and validate data with them.
+Because you can declare validators that receive the current `field`, you can extract
+the `sub_fields` (from the generic class type parameters) and validate data with them.
 
 ```py
 {!.tmp_examples/types_generics.py!}

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -691,12 +691,13 @@ raw bytes and print out human readable versions of the bytes as well.
 ```
 _(This script is complete, it should run "as is")_
 
-
-
 ## Custom Data Types
 
 You can also define your own custom data types. The classmethod `__get_validators__` will be called
 to get validators to parse and validate the input data.
+
+!!! tip
+    These validators have the same semantics as in [Validators](validators.md), you can declare a parameter `config`, `field`, etc.
 
 ```py
 {!.tmp_examples/types_custom_type.py!}
@@ -707,3 +708,28 @@ Similar validation could be achieved using [`constr(regex=...)`](#constrained-ty
 formatted with a space, the schema would just include the full pattern and the returned value would be a vanilla string.
 
 See [Schema](schema.md) for more details on how the model's schema is generated.
+
+## Allow Arbitrary Types
+
+You can allow arbitrary types using the `arbitrary_types_allowed` config in the [Model Config](model_config.md).
+
+```py
+{!.tmp_examples/types_arbitrary_allowed.py!}
+```
+_(This script is complete, it should run "as is")_
+
+## Generic Classes as Types
+
+!!! warning
+    This is an advanced technique that you might not need in the beginning. In most of the cases you will probably be fine with standard *pydantic* models.
+
+You can use [Generic Classes](https://mypy.readthedocs.io/en/latest/generics.html) as field types and perform custom validation based on the "type parameters" (or sub-types) with `__get_validators__`.
+
+If the Generic class that you are using as a sub-type has a classmethod `__get_validators__`, you don't need to use `arbitrary_types_allowed` for it to work.
+
+Because you can declare validators that receive the current `field`, you can extract the `sub_fields` (from the generic class type parameters) and validate data with them.
+
+```py
+{!.tmp_examples/types_generics.py!}
+```
+_(This script is complete, it should run "as is")_

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -418,6 +418,10 @@ class ModelField(Representation):
             self.shape = SHAPE_MAPPING
         elif issubclass(origin, Type):  # type: ignore
             return
+        elif hasattr(origin, '__get_validators__'):
+            # Is a Pydantic-compatible generic that handles itself
+            self.type_ = origin
+            return
         else:
             raise TypeError(f'Fields of type "{origin}" are not supported.')
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -421,10 +421,9 @@ class ModelField(Representation):
             return
         elif hasattr(origin, '__get_validators__') or self.model_config.arbitrary_types_allowed:
             # Is a Pydantic-compatible generic that handles itself
+            # or we have arbitrary_types_allowed = True
             self.shape = SHAPE_GENERIC
-            self.sub_fields = []
-            for i, t in enumerate(self.type_.__args__):
-                self.sub_fields.append(self._create_sub_type(t, f'{self.name}_{i}'))
+            self.sub_fields = [self._create_sub_type(t, f'{self.name}_{i}') for i, t in enumerate(self.type_.__args__)]
             self.type_ = origin
             return
         else:
@@ -448,7 +447,7 @@ class ModelField(Representation):
         without mis-configuring the field.
         """
         class_validators_ = self.class_validators.values()
-        if not self.sub_fields or (self.shape == SHAPE_GENERIC):
+        if not self.sub_fields or self.shape == SHAPE_GENERIC:
             get_validators = getattr(self.type_, '__get_validators__', None)
             v_funcs = (
                 *[v.func for v in class_validators_ if v.each_item and v.pre],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This adds support for generics that implement `__get_validators__` or when `arbitrary_types_allowed`.

The generic type parameters are saved in `field.sub_fields` and custom validations using those sub-types are documented.

This would fix/related to #1158

<!-- Please give a short summary of the changes. -->

## Related issue number

#1158

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
