### PR TITLE
Fix parse obj root

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -559,7 +559,7 @@ class BaseModel(metaclass=ModelMetaclass):
                 value_as_dict = dict(value)
             except (TypeError, ValueError) as e:
                 if cls.__custom_root_type__:
-                    value_as_dict = {"__root__": value}
+                    value_as_dict = {'__root__': value}
                 else:
                     raise DictError() from e
             return cls(**value_as_dict)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -278,11 +278,14 @@ class BaseModel(metaclass=ModelMetaclass):
         if TYPE_CHECKING:
             __pydantic_self__.__dict__: Dict[str, Any] = {}
             __pydantic_self__.__fields_set__: 'SetStr' = set()
-        values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
+        __pydantic_self__._initialize(data)
+
+    def _initialize(self, data: Any) -> None:
+        values, fields_set, validation_error = validate_model(self.__class__, data)
         if validation_error:
             raise validation_error
-        object.__setattr__(__pydantic_self__, '__dict__', values)
-        object.__setattr__(__pydantic_self__, '__fields_set__', fields_set)
+        object.__setattr__(self, '__dict__', values)
+        object.__setattr__(self, '__fields_set__', fields_set)
 
     @no_type_check
     def __setattr__(self, name, value):
@@ -450,11 +453,7 @@ class BaseModel(metaclass=ModelMetaclass):
             raise ConfigError('You must have the config attribute orm_mode=True to use from_orm')
         obj = cls._decompose_class(obj)
         m = cls.__new__(cls)
-        values, fields_set, validation_error = validate_model(cls, obj)
-        if validation_error:
-            raise validation_error
-        object.__setattr__(m, '__dict__', values)
-        object.__setattr__(m, '__fields_set__', fields_set)
+        m._initialize(obj)
         return m
 
     @classmethod

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -166,10 +166,10 @@ def test_parse_nested_custom_root_mapping():
 
 def test_parse_nested_custom_root_tuple():
     class NestedRootTuple(BaseModel):
-        __root__: Tuple[int, Optional["NestedRootTuple"]]
+        __root__: Tuple[int, Optional['NestedRootTuple']]
 
     NestedRootTuple.update_forward_refs()
 
     obj = NestedRootTuple.parse_obj(('1', ('2', ('3', None))))
     assert obj.dict() == {'__root__': (1, {'__root__': (2, {'__root__': (3, None)})})}
-    assert obj.json() == "[1, [2, [3, null]]]"
+    assert obj.json() == '[1, [2, [3, null]]]'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,7 +36,7 @@ def test_parse_obj_preserves_subclasses():
     assert parsed == [model_b]
 
 
-def test_parse_obj_fails():
+def test_parse_obj_as_fails():
     with pytest.raises(ValidationError) as exc_info:
         parse_obj_as(int, 'a')
     assert exc_info.value.errors() == [


### PR DESCRIPTION
## Change Summary

Makes nested root models work properly. In particular, the code raising errors in #1190 doesn't raise errors with this patch. I suspect this may resolve other issues related to custom root models as well.

Also required a new flag to make nested root models generate proper json.

I believe all of the newly added checks for the `__custom_root_type__` could be moved to model creation time by making use of some method-wrapping logic in the metaclass.

The fact that the `unpack_custom_root` argument is passed in the various recursive calls to `.dict` is the only performance thing that I think is likely hard to eliminate (without breaking the json generation). But it *would* be possible to move the actual *check* (and subsequent unwrapping) into a wrapper function so that it is only performed for types that actually have a custom root. I'm not sure if adding another argument itself adds an amount of performance overhead that is worth fretting over. (But I would also understand if you don't want to add the flag at all.)

## Related issue number

Addresses #1190 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
