### PR TITLE
Dynamic default value

### DIFF
--- a/changes/1210-prettywood.md
+++ b/changes/1210-prettywood.md
@@ -1,0 +1,1 @@
+Add `default_factory` argument to `Field` to create a dynamic default value by passing a zero-argument callable.

--- a/docs/examples/models_default_factory.py
+++ b/docs/examples/models_default_factory.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+from uuid import UUID, uuid4
+
+class Model(BaseModel):
+    uid: UUID = Field(default_factory=uuid4)
+
+m1 = Model()
+m2 = Model()
+assert m1.uid != m2.uid

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -463,6 +463,26 @@ _(This script is complete, it should run "as is")_
 In this model, `a`, `b`, and `c` can take `None` as a value. But `a` is optional, while `b` and `c` are required.
 `b` and `c` require a value, even if the value is `None`.
 
+## Field with dynamic default value
+
+When declaring a field with a default value, you may want it to be dynamic (i.e. different for each model).
+To do this, you may want to use a `default_factory`.
+
+!!! info "In Beta"
+    The `default_factory` argument is in **beta**, it has been added to *pydantic* in **v1.5** on a
+    **provisional basis**. It may change significantly in future releases and its signature or behaviour will not
+    be concrete until **v2**. Feedback from the community while it's still provisional would be extremely useful;
+    either comment on [#866](https://github.com/samuelcolvin/pydantic/issues/866) or create a new issue.
+
+Example of usage:
+
+```py
+{!.tmp_examples/models_default_factory.py!}
+```
+_(This script is complete, it should run "as is")_
+
+Where `Field` refers to the [field function](schema.md#field-customisation).
+
 ## Parsing data into a specified type
 
 Pydantic includes a standalone utility function `parse_obj_as` that can be used to apply the parsing

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -41,6 +41,9 @@ It has the following arguments:
 * `default`: (a positional argument) the default value of the field.
     Since the `Field` replaces the field's default, this first argument can be used to set the default.
     Use ellipsis (`...`) to indicate the field is required.
+* `default_factory`: a zero-argument callable that will be called when a default value is needed for this field.
+    Among other purposes, this can be used to set dynamic default values.
+    It is forbidden to set both `default` and `default_factory`.
 * `alias`: the public name of the field
 * `title`: if omitted, `field_name.title()` is used
 * `description`: if omitted and the annotation is a sub-model,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -296,7 +296,7 @@ class ModelField(Representation):
 
         if isinstance(value, FieldInfo):
             field_info = value
-            value = field_info.default_factory if field_info.default_factory is not None else field_info.default
+            value = field_info.default_factory() if field_info.default_factory is not None else field_info.default
         else:
             field_info = FieldInfo(value, **field_info_from_config)
         required: 'BoolUndefined' = Undefined

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -832,7 +832,9 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.append(ErrorWrapper(MissingError(), loc=field.alias))
                 continue
 
-            if field.default is None:
+            if field.default_factory is not None:
+                value = field.default_factory()
+            elif field.default is None:
                 # deepcopy is quite slow on None
                 value = None
             else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -832,13 +832,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.append(ErrorWrapper(MissingError(), loc=field.alias))
                 continue
 
-            if field.default_factory is not None:
-                value = field.default_factory()
-            elif field.default is None:
-                # deepcopy is quite slow on None
-                value = None
-            else:
-                value = deepcopy(field.default)
+            value = field.get_default()
 
             if not config.validate_all and not field.validate_always:
                 values[name] = value

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -42,11 +42,13 @@ if sys.version_info < (3, 7):
     from typing import Callable as Callable
 
     AnyCallable = Callable[..., Any]
+    NoArgAnyCallable = Callable[[], Any]
 else:
     from collections.abc import Callable as Callable
     from typing import Callable as TypingCallable
 
     AnyCallable = TypingCallable[..., Any]
+    NoArgAnyCallable = TypingCallable[[], Any]
 
 if sys.version_info < (3, 8):
     if TYPE_CHECKING:
@@ -77,6 +79,7 @@ __all__ = (
     'ForwardRef',
     'Callable',
     'AnyCallable',
+    'NoArgAnyCallable',
     'AnyType',
     'NoneType',
     'display_as_type',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import Any, ClassVar, List, Mapping, Type
+from typing import Any, Callable, ClassVar, List, Mapping, Type
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -48,6 +49,28 @@ def test_ultra_simple_repr():
     assert m.json() == '{"a": 10.2, "b": 10}'
     with pytest.raises(DeprecationWarning, match=r'`model.to_string\(\)` method is deprecated'):
         assert m.to_string() == 'a=10.2 b=10'
+
+
+def test_default_dict_repr():
+    def myfunc():
+        return 1
+
+    class Model(BaseModel):
+        a: int = Field(default_factory=myfunc)
+        b = Field(default_factory=myfunc)
+
+    m = Model()
+    assert str(m) == 'a=1 b=1'
+    assert repr(m) == 'Model(a=1, b=1)'
+    assert (
+        repr(m.__fields__['a']) == "ModelField(name='a', type=int, required=False, default_factory='<function myfunc>')"
+    )
+    assert (
+        repr(m.__fields__['b']) == "ModelField(name='b', type=int, required=False, default_factory='<function myfunc>')"
+    )
+    assert dict(m) == {'a': 1, 'b': 1}
+    assert m.dict() == {'a': 1, 'b': 1}
+    assert m.json() == '{"a": 1, "b": 1}'
 
 
 def test_comparing():
@@ -970,3 +993,35 @@ def test_custom_init_subclass_params():
         something = 1
 
     assert NewModel.something == 2
+
+
+def test_two_defaults():
+    with pytest.raises(ValueError, match='^cannot specify both default and default_factory$'):
+
+        class Model(BaseModel):
+            a: int = Field(default=3, default_factory=lambda: 3)
+
+
+def test_default_factory():
+    class ValueModel(BaseModel):
+        uid: UUID = uuid4()
+
+    m1 = ValueModel()
+    m2 = ValueModel()
+    assert m1.uid == m2.uid
+
+    class DynamicValueModel(BaseModel):
+        uid: UUID = Field(default_factory=uuid4)
+
+    m1 = DynamicValueModel()
+    m2 = DynamicValueModel()
+    assert isinstance(m1.uid, UUID)
+    assert m1.uid != m2.uid
+
+    # With a callable: we still should be able to set callables as defaults
+    class FunctionModel(BaseModel):
+        a: int = 1
+        uid: Callable[[], UUID] = Field(uuid4)
+
+    m = FunctionModel()
+    assert m.uid is uuid4


### PR DESCRIPTION
## Change Summary
Following #155 and #866, here is a proposal of implementation to simplify dynamic default values

Right now, to have a dynamic default value, we need to use `validators` like
```python
class DynamicValueModel(BaseModel):
    ts: datetime = None

    @validator('ts', pre=True, always=True)
        def set_ts_now(cls, v):
            return v or datetime.now()
```

Now, we can use `default_factory` (same name as [dataclasses](https://docs.python.org/3/library/dataclasses.html#dataclasses.field).to be consistent)
```python
class DynamicValueModel(BaseModel):
    ts: datetime = Field(default_factory=datetime.now)
```

## Related issue number
#155 and #866

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
