### PR TITLE
Accept pre-compiled Pattern objects

### DIFF
--- a/changes/1237-adamgreg.md
+++ b/changes/1237-adamgreg.md
@@ -1,0 +1,1 @@
+Make `pattern_validator()` accept pre-compiled `Pattern` objects. Fix `str_validator()` return type to `str`.

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -14,7 +14,6 @@ from typing import (
     FrozenSet,
     Generator,
     List,
-    Optional,
     Pattern,
     Set,
     Tuple,
@@ -40,7 +39,7 @@ if TYPE_CHECKING:
     StrBytes = Union[str, bytes]
 
 
-def str_validator(v: Any) -> Optional[str]:
+def str_validator(v: Any) -> str:
     if isinstance(v, str):
         if isinstance(v, Enum):
             return v.value

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     StrBytes = Union[str, bytes]
 
 
-def str_validator(v: Any) -> str:
+def str_validator(v: Any) -> Union[str]:
     if isinstance(v, str):
         if isinstance(v, Enum):
             return v.value

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -462,8 +462,13 @@ def any_class_validator(v: Any) -> Type[T]:
 
 
 def pattern_validator(v: Any) -> Pattern[str]:
+    if isinstance(v, Pattern):
+        return v
+
+    str_value = str_validator(v)
+
     try:
-        return re.compile(v)
+        return re.compile(str_value)
     except re.error:
         raise errors.PatternError()
 
@@ -477,7 +482,6 @@ class IfConfig:
         return any(getattr(config, name) not in {None, False} for name in self.config_attr_names)
 
 
-pattern_validators = [str_validator, pattern_validator]
 # order is important here, for example: bool is a subclass of int so has to come first, datetime before date same,
 # IPv4Interface before IPv4Address, etc
 _VALIDATORS: List[Tuple[AnyType, List[Any]]] = [
@@ -533,7 +537,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if type_type == ForwardRef or type_type == TypeVar:
         return
     if type_ is Pattern:
-        yield from pattern_validators
+        yield pattern_validator
         return
     if is_callable_type(type_):
         yield callable_validator

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import re
 import sys
 import uuid
 from collections import OrderedDict
@@ -1836,6 +1837,11 @@ def test_pattern():
     # check it's really a proper pattern
     assert f.pattern.match('whatever1')
     assert not f.pattern.match(' whatever1')
+
+    # Check that pre-compiled patterns are accepted unchanged
+    p = re.compile(r'^whatev.r\d$')
+    f2 = Foobar(pattern=p)
+    assert f2.pattern is p
 
 
 def test_pattern_error():


### PR DESCRIPTION
Make `pattern_validator()` accept pre-compiled `Pattern` objects.



<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1237.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
