### PR TITLE
Fix type annotations in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ from pydantic import BaseModel
 class User(BaseModel):
     id: int
     name = 'John Doe'
-    signup_ts: Optional[datetime]
+    signup_ts: Optional[datetime] = None
     friends: List[int] = []
 
 external_data = {'id': '123', 'signup_ts': '2017-06-01 12:22', 'friends': [1, '2', b'3']}

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ see the [Install](https://pydantic-docs.helpmanual.io/install/) section in the d
 
 ```py
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 
 class User(BaseModel):
     id: int
     name = 'John Doe'
-    signup_ts: datetime = None
+    signup_ts: Optional[datetime]
     friends: List[int] = []
 
 external_data = {'id': '123', 'signup_ts': '2017-06-01 12:22', 'friends': [1, '2', b'3']}

--- a/changes/1248-kokes.md
+++ b/changes/1248-kokes.md
@@ -1,0 +1,1 @@
+In examples, type nullable fields as `Optional`, so that these are valid mypy annotations.

--- a/docs/examples/index_main.py
+++ b/docs/examples/index_main.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 
 class User(BaseModel):
     id: int
     name = 'John Doe'
-    signup_ts: datetime = None
+    signup_ts: Optional[datetime]
     friends: List[int] = []
 
 external_data = {

--- a/docs/examples/index_main.py
+++ b/docs/examples/index_main.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 class User(BaseModel):
     id: int
     name = 'John Doe'
-    signup_ts: Optional[datetime]
+    signup_ts: Optional[datetime] = None
     friends: List[int] = []
 
 external_data = {


### PR DESCRIPTION
## Change Summary

As discussed in #1072, the very first example in the docs does not feature valid mypy annotations (nullable datetime is not designated as optional). I suggest fixing this to follow mypy annotations fully.

There was some discussion about adding more narrative to these docs - I have not done so, because I can't quite figure out what to say exactly - if the `Optional` type hint should be elaborated on or something? I'd welcome suggestions regarding this.

## Related issue number

#1072

## Checklist

* ~~[ ] Unit tests for the changes exist~~
* ~~[ ] Tests pass on CI and coverage remains at 100%~~
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
