### PR TITLE
Fix parsing nested custom root type models

### DIFF
--- a/changes/1190-Shados.md
+++ b/changes/1190-Shados.md
@@ -1,0 +1,1 @@
+Fixed parsing of nested 'custom root type' models.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -546,6 +546,8 @@ class BaseModel(metaclass=ModelMetaclass):
             return value.copy()
         elif cls.__config__.orm_mode:
             return cls.from_orm(value)
+        elif cls.__custom_root_type__:
+            return cls.parse_obj(value)
         else:
             try:
                 value_as_dict = dict(value)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,10 +1,10 @@
 import json
 import pickle
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import pytest
 
-from pydantic import BaseModel, Field, Protocol, ValidationError
+from pydantic import BaseModel, Field, Protocol, ValidationError, parse_obj_as
 
 
 class Model(BaseModel):
@@ -55,6 +55,55 @@ def test_parse_root_list():
     m = MyModel.parse_obj(['a'])
     assert m.dict() == {'__root__': ['a']}
     assert m.__root__ == ['a']
+
+
+def test_parse_nested_root_list():
+    class NestedData(BaseModel):
+        id: str
+
+    class NestedModel(BaseModel):
+        __root__: List[NestedData]
+
+    class MyModel(BaseModel):
+        nested: NestedModel
+
+    m = MyModel.parse_obj({'nested': [{'id': 'foo'}]})
+    assert isinstance(m.nested, NestedModel)
+    assert isinstance(m.nested.__root__[0], NestedData)
+
+
+def test_parse_nested_root_tuple():
+    class NestedData(BaseModel):
+        id: str
+
+    class NestedModel(BaseModel):
+        __root__: Tuple[int, NestedData]
+
+    class MyModel(BaseModel):
+        nested: List[NestedModel]
+
+    data = [0, {'id': 'foo'}]
+    m = MyModel.parse_obj({'nested': [data]})
+    assert isinstance(m.nested[0], NestedModel)
+    assert isinstance(m.nested[0].__root__[1], NestedData)
+
+    nested = parse_obj_as(NestedModel, data)
+    assert isinstance(nested, NestedModel)
+
+
+def test_parse_nested_custom_root():
+    class NestedModel(BaseModel):
+        __root__: List[str]
+
+    class MyModel(BaseModel):
+        __root__: NestedModel
+
+    nested = ['foo', 'bar']
+    m = MyModel.parse_obj(nested)
+    assert isinstance(m, MyModel)
+    assert isinstance(m.__root__, NestedModel)
+    assert isinstance(m.__root__.__root__, List)
+    assert isinstance(m.__root__.__root__[0], str)
 
 
 def test_json():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

When validating fields that are pydantic models, if all else fails explicitly check if `__custom_root_type__` is true, and try to `parse_obj` if it is.

## Related issue number

Fixes #1190.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
