### PR TITLE
add pydantic.color.Color objects as available input for Color fields

### DIFF
--- a/changes/1258-leosussan.md
+++ b/changes/1258-leosussan.md
@@ -1,0 +1,1 @@
+Add pydantic.color.Color objects as available input for Color fields

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -70,11 +70,13 @@ class Color(Representation):
             self._rgba = parse_tuple(value)
         elif isinstance(value, str):
             self._rgba = parse_str(value)
+        elif isinstance(value, Color):
+            self._rgba = value._rgba
         else:
-            raise ColorError(reason='value must be a tuple, list or string')
+            raise ColorError(reason='value must be a tuple, list, string or pydantic.color.Color')
 
         # if we've got here value must be a valid color
-        self._original = value
+        self._original = value if not isinstance(value, Color) else value._original
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -72,11 +72,12 @@ class Color(Representation):
             self._rgba = parse_str(value)
         elif isinstance(value, Color):
             self._rgba = value._rgba
+            value = value._original
         else:
-            raise ColorError(reason='value must be a tuple, list, string or pydantic.color.Color')
+            raise ColorError(reason='value must be a tuple, list, string')
 
         # if we've got here value must be a valid color
-        self._original = value._original if isinstance(value, Color) else value
+        self._original = value
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -76,7 +76,7 @@ class Color(Representation):
             raise ColorError(reason='value must be a tuple, list, string or pydantic.color.Color')
 
         # if we've got here value must be a valid color
-        self._original = value if not isinstance(value, Color) else value._original
+        self._original = value._original if isinstance(value, Color) else value
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -74,7 +74,7 @@ class Color(Representation):
             self._rgba = value._rgba
             value = value._original
         else:
-            raise ColorError(reason='value must be a tuple, list, or string')
+            raise ColorError(reason='value must be a tuple, list or string')
 
         # if we've got here value must be a valid color
         self._original = value

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -74,7 +74,7 @@ class Color(Representation):
             self._rgba = value._rgba
             value = value._original
         else:
-            raise ColorError(reason='value must be a tuple, list, string')
+            raise ColorError(reason='value must be a tuple, list, or string')
 
         # if we've got here value must be a valid color
         self._original = value

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -102,7 +102,7 @@ def test_model_validation():
         color: Color
 
     assert Model(color='red').color.as_hex() == '#f00'
-    assert Model(color=Color('red')).color.as_hex() == 'red'
+    assert Model(color=Color('red')).color.as_hex() == '#f00'
     with pytest.raises(ValidationError) as exc_info:
         Model(color='snot')
     assert exc_info.value.errors() == [

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -102,6 +102,7 @@ def test_model_validation():
         color: Color
 
     assert Model(color='red').color.as_hex() == '#f00'
+    assert Model(color=Color('red')).color.as_hex() == 'red'
     with pytest.raises(ValidationError) as exc_info:
         Model(color='snot')
     assert exc_info.value.errors() == [


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

If you pass a `pydantic.color.Color` object to a `Color` field, it will fail b/c the object 

This small edit allows for `Color` objects as acceptable input for Color fields.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
