### PR TITLE
validate_arguments decorator example implementation

### DIFF
--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -44,8 +44,6 @@ def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
     params = {kind: {field['name']: field['field'] for field in val} for kind, val in grouped}
 
     # Arguments descriptions by kind
-    # note that VAR_POSITIONAL and VAR_KEYWORD are ignored here
-    # otherwise, the model will expect them on function call.
     positional_only = params.get(Parameter.POSITIONAL_ONLY, {})
     positional_or_keyword = params.get(Parameter.POSITIONAL_OR_KEYWORD, {})
     var_positional = params.get(Parameter.VAR_POSITIONAL, {})

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -33,6 +33,9 @@ def contained(mapping: Container[T]) -> Callable[[Tuple[str, T]], bool]:
 
 
 def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Decorator to validate the arguments passed to a function.
+    """
     sig = signature(func).parameters
     fields = [make_field(p) for p in sig.values()]
 

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -102,7 +102,7 @@ def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
                     plural = '' if len(unexpected) == 1 else 's'
                     keys = ', '.join(map(repr, unexpected))
                     raise TypeError(f'unexpected keyword argument{plural}: {keys}')
-                raise e
+                return kwargs
 
     @wraps(func)
     def apply(*args: Any, **kwargs: Any) -> T:

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -2,7 +2,7 @@ from functools import wraps
 from inspect import Parameter, signature
 from itertools import groupby
 from operator import itemgetter
-from typing import Any, Callable, Dict, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Tuple, TypeVar
 
 from . import validator
 from .main import BaseConfig, BaseModel, Extra, create_model
@@ -84,7 +84,7 @@ def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
         def validate_positional_only(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:
             try:
                 return sig.bind_partial(**kwargs).arguments
-            except TypeError as e:
+            except TypeError:
                 pos_only = set(kwargs) & set(positional_only)
                 if pos_only:
                     plural = '' if len(pos_only) == 1 else 's'
@@ -97,7 +97,7 @@ def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
         def validate_keyword(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:
             try:
                 return sig.bind_partial(**kwargs).arguments
-            except TypeError as e:
+            except TypeError:
                 unexpected = set(kwargs) - sig_kw - set(positional_only)
                 if unexpected:
                     plural = '' if len(unexpected) == 1 else 's'

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -120,7 +120,7 @@ def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
             *upd_arg.values(),
             *sigcheck.args.get(vp_name, ()),  # type: ignore
             **upd_kw,
-            **sigcheck.kwargs.get(vk_name, {})  # type: ignore
+            **sigcheck.kwargs.get(vk_name, {}),  # type: ignore
         )
 
     return apply

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -1,20 +1,19 @@
 from functools import wraps
 from inspect import Parameter, signature
-from itertools import filterfalse, groupby, tee
+from itertools import groupby
 from operator import itemgetter
-from typing import Any, Callable, Container, Dict, Iterable, Protocol, Tuple, TypeVar
+from typing import Any, Callable, Dict, Tuple, TypeVar
 
-from .main import create_model
+from .main import BaseConfig, Extra, create_model
 from .utils import to_camel
 
 __all__ = ('validate_arguments',)
 
 T = TypeVar('T')
 
-# based on itertools recipe `partition` from https://docs.python.org/3.8/library/itertools.html
-def partition_dict(pred: Callable[..., bool], iterable: Dict[str, T]) -> Tuple[Dict[str, T], Dict[str, T]]:
-    t1, t2 = tee(iterable.items())
-    return dict(filterfalse(pred, t1)), dict(filter(pred, t2))
+
+class Config(BaseConfig):
+    extra = Extra.forbid
 
 
 def coalesce(param: Parameter, default: Any) -> Any:
@@ -25,19 +24,12 @@ def make_field(arg: Parameter) -> Dict[str, Any]:
     return {'name': arg.name, 'kind': arg.kind, 'field': (coalesce(arg.annotation, Any), coalesce(arg.default, ...))}
 
 
-def contained(mapping: Container[T]) -> Callable[[Tuple[str, T]], bool]:
-    def inner(entry: Tuple[str, T]) -> bool:
-        return entry[0] in mapping
-
-    return inner
-
-
 def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
     """
     Decorator to validate the arguments passed to a function.
     """
-    sig = signature(func).parameters
-    fields = [make_field(p) for p in sig.values()]
+    sig = signature(func)
+    fields = [make_field(p) for p in sig.parameters.values()]
 
     # Python syntax should already enforce fields to be ordered by kind
     grouped = groupby(fields, key=itemgetter('kind'))
@@ -59,50 +51,29 @@ def validate_arguments(func: Callable[..., T]) -> Callable[..., T]:
     assert len(var_positional) <= 1
     assert len(var_keyword) <= 1
 
-    vp_name = next(iter(var_positional.keys()), None)
-    vk_name = next(iter(var_keyword.keys()), None)
-
     model = create_model(
         to_camel(func.__name__),
+        __config__=Config,
         **positional_only,
         **positional_or_keyword,
         **var_positional,
         **keyword_only,
         **var_keyword,
     )
-    sig_pos = tuple(positional_only) + tuple(positional_or_keyword)
-    sig_kw = set(positional_or_keyword) | set(keyword_only)
 
     @wraps(func)
     def apply(*args: Any, **kwargs: Any) -> T:
 
-        # Consume used positional arguments
-        iargs = iter(args)
-        given_pos = dict(zip(sig_pos, iargs))
-        rest_pos = {vp_name: tuple(iargs)} if vp_name else {}
-
-        ikwargs, given_kw = partition_dict(contained(sig_kw), kwargs)
-        rest_kw = {vk_name: ikwargs} if vk_name else {}
+        # NOTE: this throws TypeError if does not match signature
+        given_pos = sig.bind_partial(*args).arguments
+        given_kw = sig.bind_partial(**kwargs).arguments
 
         # use dict(model) instead of model.dict() so values stay cast as intended
-        instance = dict(model(**given_pos, **rest_pos, **given_kw, **rest_kw))
+        instance = dict(model(**given_pos, **given_kw))
 
-        as_kw, as_pos = partition_dict(contained(given_pos), instance)
+        upd_arg = {k: instance.get(k, v) for k, v in given_pos.items()}
+        upd_kw = {k: instance.get(k, v) for k, v in given_kw.items()}
 
-        as_rest_pos = tuple(as_kw[vp_name]) if vp_name else tuple(iargs)
-        as_rest_kw = as_kw[vk_name] if vk_name else ikwargs
-
-        as_kw = {k: v for k, v in as_kw.items() if k not in {vp_name, vk_name}}
-
-        # Preserve original keyword ordering - not sure if this is necessary
-        kw_order = {k: idx for idx, (k, v) in enumerate(kwargs.items())}
-        sorted_all_kw = dict(
-            sorted({**as_kw, **as_rest_kw}.items(), key=lambda val: kw_order.get(val[0], len(given_kw)))
-        )
-
-        return func(*as_pos.values(), *as_rest_pos, **sorted_all_kw)
-
-        # # Without preserving original keyword ordering
-        # return func(*as_pos.values(), *as_rest_pos, **as_kw, **as_rest_kw)
+        return func(*upd_arg.values(), **upd_kw)
 
     return apply

--- a/tests/mypy/modules/fail4.py
+++ b/tests/mypy/modules/fail4.py
@@ -8,13 +8,13 @@ def foo(a: int, *, c: str = 'x') -> str:
 
 # ok
 x: str = foo(1, c='hello')
-# fails
+# also ok - because pydantic converts Any to the annotated type
 foo('x')
 foo(1, c=1)
 foo(1, 2)
 foo(1, d=2)
 # mypy assumes foo is just a function
-callable(foo.raw_function)
+callable(foo)
 
 
 @validate_arguments

--- a/tests/mypy/outputs/fail4.txt
+++ b/tests/mypy/outputs/fail4.txt
@@ -1,8 +1,1 @@
-5: note: "foo" defined here
-12: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
-13: error: Argument "c" to "foo" has incompatible type "int"; expected "str"  [arg-type]
-14: error: Too many positional arguments for "foo"  [misc]
-14: error: Argument 2 to "foo" has incompatible type "int"; expected "str"  [arg-type]
-15: error: Unexpected keyword argument "d" for "foo"  [call-arg]
-17: error: "Callable[[int, DefaultNamedArg(str, 'c')], str]" has no attribute "raw_function"  [attr-defined]
 26: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -7,8 +7,10 @@ from typing import List
 import pytest
 
 from pydantic import BaseModel, ValidationError, validate_arguments
-from pydantic.decorator import ValidatedFunction
-from pydantic.errors import ConfigError
+# not available anymore
+# from pydantic.decorator import ValidatedFunction
+# unused
+# from pydantic.errors import ConfigError
 
 skip_pre_38 = pytest.mark.skipif(sys.version_info < (3, 8), reason='testing >= 3.8 behaviour only')
 
@@ -63,13 +65,13 @@ def test_wrap():
     assert foo_bar.__name__ == 'foo_bar'
     assert foo_bar.__module__ == 'tests.test_decorator'
     assert foo_bar.__qualname__ == 'test_wrap.<locals>.foo_bar'
-    assert isinstance(foo_bar, ValidatedFunction)
-    assert callable(foo_bar.raw_function)
-    assert foo_bar.arg_mapping == {0: 'a', 1: 'b'}
-    assert foo_bar.positional_only_args == set()
-    assert issubclass(foo_bar.model, BaseModel)
-    assert foo_bar.model.__fields__.keys() == {'a', 'b', 'args', 'kwargs'}
-    assert foo_bar.model.__name__ == 'FooBar'
+    # testing of implementation details which are no longer available
+    # assert callable(foo_bar.raw_function)
+    # assert foo_bar.arg_mapping == {0: 'a', 1: 'b'}
+    # assert foo_bar.positional_only_args == set()
+    # assert issubclass(foo_bar.model, BaseModel)
+    # assert foo_bar.model.__fields__.keys() == {'a', 'b', 'args', 'kwargs'}
+    # assert foo_bar.model.__name__ == 'FooBar'
     # signature is slightly different on 3.6
     if sys.version_info >= (3, 7):
         assert repr(inspect.signature(foo_bar)) == '<Signature (a: int, b: int)>'
@@ -80,7 +82,7 @@ def test_kwargs():
     def foo(*, a: int, b: int):
         return a + b
 
-    assert foo.model.__fields__.keys() == {'a', 'b', 'args', 'kwargs'}
+    # assert foo.model.__fields__.keys() == {'a', 'b', 'args', 'kwargs'}
     assert foo(a=1, b=3) == 4
 
     with pytest.raises(ValidationError) as exc_info:
@@ -94,8 +96,9 @@ def test_kwargs():
         foo(1, 'x')
 
     assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
+        # # type_error check happens on separate stage so validation errors on values does not appear here
+        # {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
+        # {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
         {'loc': ('args',), 'msg': '0 positional arguments expected but 2 given', 'type': 'type_error'},
     ]
 
@@ -138,7 +141,7 @@ def foo(a, b, /, c=None):
         module.foo(1, b=2)
     assert exc_info.value.errors() == [
         {
-            'loc': ('v__positional_only',),
+            'loc': ('positional_only',),
             'msg': "positional-only argument passed as keyword argument: 'b'",
             'type': 'type_error',
         },
@@ -147,7 +150,7 @@ def foo(a, b, /, c=None):
         module.foo(a=1, b=2)
     assert exc_info.value.errors() == [
         {
-            'loc': ('v__positional_only',),
+            'loc': ('positional_only',),
             'msg': "positional-only arguments passed as keyword arguments: 'a', 'b'",
             'type': 'type_error',
         },
@@ -159,34 +162,35 @@ def test_args_name():
     def foo(args: int, kwargs: int):
         return f'args={args!r}, kwargs={kwargs!r}'
 
-    assert foo.model.__fields__.keys() == {'args', 'kwargs', 'v__args', 'v__kwargs'}
+    # assert foo.model.__fields__.keys() == {'args', 'kwargs', 'v__args', 'v__kwargs'}
     assert foo(1, 2) == 'args=1, kwargs=2'
 
     with pytest.raises(ValidationError) as exc_info:
         foo(1, 2, apple=4)
     assert exc_info.value.errors() == [
-        {'loc': ('v__kwargs',), 'msg': "unexpected keyword argument: 'apple'", 'type': 'type_error'},
+        {'loc': ('kwargs',), 'msg': "unexpected keyword argument: 'apple'", 'type': 'type_error'},
     ]
 
     with pytest.raises(ValidationError) as exc_info:
         foo(1, 2, apple=4, banana=5)
     assert exc_info.value.errors() == [
-        {'loc': ('v__kwargs',), 'msg': "unexpected keyword arguments: 'apple', 'banana'", 'type': 'type_error'},
+        {'loc': ('kwargs',), 'msg': "unexpected keyword arguments: 'apple', 'banana'", 'type': 'type_error'},
     ]
 
     with pytest.raises(ValidationError) as exc_info:
         foo(1, 2, 3)
     assert exc_info.value.errors() == [
-        {'loc': ('v__args',), 'msg': '2 positional arguments expected but 3 given', 'type': 'type_error'},
+        {'loc': ('args',), 'msg': '2 positional arguments expected but 3 given', 'type': 'type_error'},
     ]
 
 
-def test_v_args():
-    with pytest.raises(ConfigError, match='"v__args", "v__kwargs" and "v__positional_only" are not permitted'):
+# test not needed anymore, all argument names permitted
+# def test_v_args():
+#     with pytest.raises(ConfigError, match='"v__args", "v__kwargs" and "v__positional_only" are not permitted'):
 
-        @validate_arguments
-        def foo(v__args: int):
-            pass
+#         @validate_arguments
+#         def foo(v__args: int):
+#             pass
 
 
 def test_async():

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -7,6 +7,7 @@ from typing import List
 import pytest
 
 from pydantic import ValidationError, validate_arguments
+
 # not available anymore
 # from pydantic.decorator import ValidatedFunction
 # unused

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -6,7 +6,7 @@ from typing import List
 
 import pytest
 
-from pydantic import BaseModel, ValidationError, validate_arguments
+from pydantic import ValidationError, validate_arguments
 # not available anymore
 # from pydantic.decorator import ValidatedFunction
 # unused


### PR DESCRIPTION
This is an alternative implementation for the validate_arguments decorator #1179
Which also happen to fix #1222
(It also does not relay on arguments naming conventions) 

I would not recommend merging this as it does not wrap raised TypeError as ValidationError (making relevant tests fail).
But might be useful for extracting logic and finding out what causes the above issue.
