### PR TITLE
Support instance methods and class methods with @validate_arguments

### DIFF
--- a/changes/1222-samuelcolvin.md
+++ b/changes/1222-samuelcolvin.md
@@ -1,0 +1,1 @@
+Support instance methods and class methods with `@validate_arguments`


### PR DESCRIPTION
## Change Summary

Allow use of the `@validate_arguments` decorator with instance methods and class methods.

## Related issue number

fix #1222

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] ~~Documentation reflects the changes where applicable~~
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
