### PR TITLE
Fix typo breaking pydantic-only benchmarks when TestCAttrs not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,12 +102,19 @@ jobs:
     after_success: skip
 
   - stage: test
-    python: 3.7
+    python: 3.8
     name: 'Benchmarks'
     script:
     - pip install -r benchmarks/requirements.txt
     - make build-cython
     - BENCHMARK_REPEATS=1 make benchmark-all
+    after_success: skip
+
+  - stage: test
+    python: 3.8
+    name: 'Pydantic-Only Benchmarks'
+    script:
+    - BENCHMARK_REPEATS=1 make benchmark-pydantic
     after_success: skip
 
   - stage: build

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -168,7 +168,9 @@ def main():
     if 'pydantic-only' not in sys.argv:
         tests += other_tests
 
+    lpad = max([len(t.package) for t in tests]) + 4
     repeats = int(os.getenv('BENCHMARK_REPEATS', '5'))
+    print(f'testing {", ".join([t.package for t in tests])}, {repeats} times each')
     results = []
     csv_results = []
     for test_class in tests:
@@ -178,20 +180,20 @@ def main():
             count, pass_count = 0, 0
             start = datetime.now()
             test = test_class(True)
-            for i in range(3):
+            for j in range(3):
                 for case in cases:
                     passed, result = test.validate(case)
                     count += 1
                     pass_count += passed
             time = (datetime.now() - start).total_seconds()
             success = pass_count / count * 100
-            print(f'{p:>40} time={time:0.3f}s, success={success:0.2f}%')
+            print(f'{p:>{lpad}} ({i+1:>{len(str(repeats))}}/{repeats}) time={time:0.3f}s, success={success:0.2f}%')
             times.append(time)
-        print(f'{p:>40} best={min(times):0.3f}s, avg={mean(times):0.3f}s, stdev={stdev(times):0.3f}s')
+        print(f'{p:>{lpad}} best={min(times):0.3f}s, avg={mean(times):0.3f}s, stdev={stdev(times):0.3f}s')
         model_count = 3 * len(cases)
         avg = mean(times) / model_count * 1e6
         sd = stdev(times) / model_count * 1e6
-        results.append(f'{p:>40} best={min(times) / model_count * 1e6:0.3f}μs/iter '
+        results.append(f'{p:>{lpad}} best={min(times) / model_count * 1e6:0.3f}μs/iter '
                        f'avg={avg:0.3f}μs/iter stdev={sd:0.3f}μs/iter version={test_class.version}')
         csv_results.append([p, test_class.version, avg])
         print()

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -39,7 +39,7 @@ except Exception:
 try:
     from test_cattrs import TestCAttrs
 except Exception:
-    TestCAttr = None
+    TestCAttrs = None
 
 try:
     from test_cerberus import TestCerberus


### PR DESCRIPTION
## Change Summary

`TestCAttrs` was not getting set to `None`, instead `TestCAttr`, resulting in:
```py
❯ make benchmark-pydantic
python benchmarks/run.py pydantic-only
Traceback (most recent call last):
  File "benchmarks/run.py", line 58, in <module>
    [TestCAttrs, TestValideer, TestMarshmallow, TestTrafaret, TestDRF, TestCerberus]
NameError: name 'TestCAttrs' is not defined
make: *** [benchmark-pydantic] Error 1
```
This fix allows the benchmarks to run:
```sh
❯ git checkout fix_cattrs_benchmark
Switched to branch 'fix_cattrs_benchmark'
Your branch is up to date with 'mine/fix_cattrs_benchmark'.
❯ make benchmark-pydantic
python benchmarks/run.py pydantic-only
                                pydantic time=0.967s, success=50.10%
                                pydantic time=0.806s, success=50.10%
                                pydantic time=0.804s, success=50.10%
                                pydantic time=0.800s, success=50.10%
                                pydantic time=0.757s, success=50.10%
                                pydantic best=0.757s, avg=0.827s, stdev=0.081s

                                pydantic best=126.174μs/iter avg=137.777μs/iter stdev=13.471μs/iter version=1.4a1
```
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

**Not a _pydantic_ code change**

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
