### PR TITLE
Use __all__ to exclude fields from all elements of a list/tuple of submodels.  Raise more informative TypeError when passing bad exclude kwargs.

### DIFF
--- a/changes/1286-masalim2.md
+++ b/changes/1286-masalim2.md
@@ -1,0 +1,5 @@
+Raise more informative ``TypeError`` in ``pydantic.utils.ValueItems.__init__``
+when ``value`` is a list/tuple and the exclusion kwarg is improperly indexed.
+Added special handling for the exclusion key ``'__all__'``, which allows one to
+exclude fields from all elements of a list/tuple of submodels. Added example to
+Exporting Models docs.

--- a/changes/1286-masalim2.md
+++ b/changes/1286-masalim2.md
@@ -1,5 +1,1 @@
-Raise more informative ``TypeError`` in ``pydantic.utils.ValueItems.__init__``
-when ``value`` is a list/tuple and the exclusion kwarg is improperly indexed.
-Added special handling for the exclusion key ``'__all__'``, which allows one to
-exclude fields from all elements of a list/tuple of submodels. Added example to
-Exporting Models docs.
+Exclude exported fields from all elements of a list/tuple of submodels with `'__all__'`.

--- a/changes/1286-masalim2.md
+++ b/changes/1286-masalim2.md
@@ -1,1 +1,1 @@
-Exclude exported fields from all elements of a list/tuple of submodels with `'__all__'`.
+Exclude exported fields from all elements of a list/tuple of submodels/dicts with `'__all__'`.

--- a/docs/examples/exporting_models_exclude2.py
+++ b/docs/examples/exporting_models_exclude2.py
@@ -51,7 +51,7 @@ exclude_keys = {
     'second_name': ...,
     'address': {'post_code': ..., 'country': {'phone_code'}},
     'card_details': ...,
-    # You can exclude values from tuples and lists by indexes
+    # You can exclude fields from specific members of a tuple/list by index:
     'hobbies': {-1: {'info'}},
 }
 
@@ -63,3 +63,6 @@ include_keys = {
 
 # would be the same as user.dict(exclude=exclude_keys) in this case:
 print(user.dict(include=include_keys))
+
+# To exclude a field from all members of a nested list or tuple, use "__all__":
+print(user.dict(exclude={'hobbies': {'__all__': {'info'}}}))

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -113,13 +113,19 @@ sets or dictionaries. This allows nested selection of which fields to export:
 ```
 
 The ellipsis (``...``) indicates that we want to exclude or include an entire key, just as if we included it in a set.
-Of course, the same can be done at any depth level:
+Of course, the same can be done at any depth level.
+Special care must be taken when including or excluding fields from a list or tuple of submodels.  In this scenario,
+`dict` and related methods expect integer keys for element-wise inclusion or exclusion:
 
 ```py
 {!.tmp_examples/exporting_models_exclude2.py!}
 ```
 
 The same holds for the `json` and `copy` methods.
+
+
+```py
+{!.tmp_examples/exporting_models_exclude3
 
 ## Custom JSON (de)serialisation
 

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -124,9 +124,6 @@ Special care must be taken when including or excluding fields from a list or tup
 The same holds for the `json` and `copy` methods.
 
 
-```py
-{!.tmp_examples/exporting_models_exclude3
-
 ## Custom JSON (de)serialisation
 
 To improve the performance of encoding and decoding JSON, alternative JSON implementations

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -115,7 +115,7 @@ sets or dictionaries. This allows nested selection of which fields to export:
 The ellipsis (``...``) indicates that we want to exclude or include an entire key, just as if we included it in a set.
 Of course, the same can be done at any depth level.
 
-Special care must be taken when including or excluding fields from a list or tuple of submodels.  In this scenario,
+Special care must be taken when including or excluding fields from a list or tuple of submodels or dictionaries.  In this scenario,
 `dict` and related methods expect integer keys for element-wise inclusion or exclusion. To exclude a field from **every**
 member of a list or tuple, the dictionary key `'__all__'` can be used as follows:
 

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -117,14 +117,13 @@ Of course, the same can be done at any depth level.
 
 Special care must be taken when including or excluding fields from a list or tuple of submodels.  In this scenario,
 `dict` and related methods expect integer keys for element-wise inclusion or exclusion. To exclude a field from **every**
-member of a list or tuple, the dictionary key ``"__all__"`` can be used as follows:
+member of a list or tuple, the dictionary key `'__all__'` can be used as follows:
 
 ```py
 {!.tmp_examples/exporting_models_exclude2.py!}
 ```
 
 The same holds for the `json` and `copy` methods.
-
 
 ## Custom JSON (de)serialisation
 

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -114,8 +114,10 @@ sets or dictionaries. This allows nested selection of which fields to export:
 
 The ellipsis (``...``) indicates that we want to exclude or include an entire key, just as if we included it in a set.
 Of course, the same can be done at any depth level.
+
 Special care must be taken when including or excluding fields from a list or tuple of submodels.  In this scenario,
-`dict` and related methods expect integer keys for element-wise inclusion or exclusion:
+`dict` and related methods expect integer keys for element-wise inclusion or exclusion. To exclude a field from **every**
+member of a list or tuple, the dictionary key ``"__all__"`` can be used as follows:
 
 ```py
 {!.tmp_examples/exporting_models_exclude2.py!}

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -345,6 +345,11 @@ class ValueItems(Representation):
             raise TypeError(f'Unexpected type of exclude value {items.__class__}')
 
         if isinstance(value, (list, tuple)):
+            if any(not isinstance(item, int) for item in items):
+                raise TypeError(
+                    f'Excluding fields from a list or tuple of sub-models must be performed index-wise: '
+                    f'expected integer keys'
+                )
             items = self._normalize_indexes(items, len(value))
 
         self._items = items

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -350,7 +350,7 @@ class ValueItems(Representation):
             except TypeError as e:
                 raise TypeError(
                     f'Excluding fields from a list or tuple of sub-models must be performed index-wise: '
-                    f'expected integer keys or keyword __all__'
+                    f'expected integer keys or keyword "__all__"'
                 ) from e
 
         self._items = items

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -349,7 +349,7 @@ class ValueItems(Representation):
                 items = self._normalize_indexes(items, len(value))
             except TypeError as e:
                 raise TypeError(
-                    f'Excluding fields from a list or tuple of sub-models must be performed index-wise: '
+                    f'Excluding fields from a sequence of sub-models or dicts must be performed index-wise: '
                     f'expected integer keys or keyword "__all__"'
                 ) from e
 
@@ -403,6 +403,8 @@ class ValueItems(Representation):
         {0, 1, 2, 3}
         """
         if self._type is set:
+            if '__all__' in items and items != {'__all__'}:
+                raise ValueError('set with keyword "__all__" must not contain other elements')
             if '__all__' in items:
                 return {i for i in range(v_length)}
             return {v_length + i if i < 0 else i for i in items}

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -403,9 +403,9 @@ class ValueItems(Representation):
         {0, 1, 2, 3}
         """
         if self._type is set:
-            if '__all__' in items and items != {'__all__'}:
-                raise ValueError('set with keyword "__all__" must not contain other elements')
             if '__all__' in items:
+                if items != {'__all__'}:
+                    raise ValueError('set with keyword "__all__" must not contain other elements')
                 return {i for i in range(v_length)}
             return {v_length + i if i < 0 else i for i in items}
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -989,32 +989,16 @@ def test_model_export_nested_list():
         c: int
         foos: List[Foo]
 
-    m = Bar(c=3, foos=[Foo(), Foo()])
-    exclusion = {idx: {'a'} for idx in range(len(m.foos))}
-    assert m.dict(exclude={'foos': exclusion}) == {'c': 3, 'foos': [{'b': 2}, {'b': 2}]}
+    m = Bar(c=3, foos=[Foo(a=1, b=2), Foo(a=3, b=4)])
+
+    assert m.dict(exclude={'foos': {0: {'a'}, 1: {'a'}}}) == {'c': 3, 'foos': [{'b': 2}, {'b': 4}]}
 
     with pytest.raises(TypeError) as e:
         m.dict(exclude={'foos': {'a'}})
     assert 'expected integer keys' in str(e.value)
 
-
-def test_model_export_nested_list_with_all():
-    class Foo(BaseModel):
-        a: int = 1
-        b: int = 2
-
-    class Bar(BaseModel):
-        c: int
-        foos: List[Foo]
-
-    m = Bar(c=3, foos=[Foo(), Foo()])
-
-    exclusion = {0: {'b'}, '__all__': {'a'}}
-    assert m.dict(exclude={'foos': exclusion}) == {'c': 3, 'foos': [{}, {'b': 2}]}
-
-    exclusion = {'__all__': {'a'}}
-    assert m.dict(exclude={'foos': exclusion}) == {'c': 3, 'foos': [{'b': 2}, {'b': 2}]}
-
+    assert m.dict(exclude={'foos': {0: {'b'}, '__all__': {'a'}}}) == {'c': 3, 'foos': [{}, {'b': 4}]}
+    assert m.dict(exclude={'foos': {'__all__': {'a'}}}) == {'c': 3, 'foos': [{'b': 2}, {'b': 4}]}
     assert m.dict(exclude={'foos': {'__all__'}}) == {'c': 3, 'foos': []}
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -980,6 +980,24 @@ def test_model_iteration():
     assert dict(m) == {'c': 3, 'd': Foo()}
 
 
+def test_model_export_nested_list():
+    class Foo(BaseModel):
+        a: int = 1
+        b: int = 2
+
+    class Bar(BaseModel):
+        c: int
+        foos: List[Foo]
+
+    m = Bar(c=3, foos=[Foo(), Foo()])
+    exclusion = {idx: {'a'} for idx in range(len(m.foos))}
+    assert m.dict(exclude={'foos': exclusion}) == {'c': 3, 'foos': [{'b': 2}, {'b': 2}]}
+
+    with pytest.raises(TypeError) as e:
+        m.dict(exclude={'foos': {'a'}})
+    assert 'expected integer keys' in str(e.value)
+
+
 def test_custom_init_subclass_params():
     class DerivedModel(BaseModel):
         def __init_subclass__(cls, something):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -998,6 +998,26 @@ def test_model_export_nested_list():
     assert 'expected integer keys' in str(e.value)
 
 
+def test_model_export_nested_list_with_all():
+    class Foo(BaseModel):
+        a: int = 1
+        b: int = 2
+
+    class Bar(BaseModel):
+        c: int
+        foos: List[Foo]
+
+    m = Bar(c=3, foos=[Foo(), Foo()])
+
+    exclusion = {0: {'b'}, '__all__': {'a'}}
+    assert m.dict(exclude={'foos': exclusion}) == {'c': 3, 'foos': [{}, {'b': 2}]}
+
+    exclusion = {'__all__': {'a'}}
+    assert m.dict(exclude={'foos': exclusion}) == {'c': 3, 'foos': [{'b': 2}, {'b': 2}]}
+
+    assert m.dict(exclude={'foos': {'__all__'}}) == {'c': 3, 'foos': []}
+
+
 def test_custom_init_subclass_params():
     class DerivedModel(BaseModel):
         def __init_subclass__(cls, something):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -993,17 +993,15 @@ def test_model_export_nested_list():
 
     assert m.dict(exclude={'foos': {0: {'a'}, 1: {'a'}}}) == {'c': 3, 'foos': [{'b': 2}, {'b': 4}]}
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError, match='expected integer keys'):
         m.dict(exclude={'foos': {'a'}})
-    assert 'expected integer keys' in str(e.value)
 
     assert m.dict(exclude={'foos': {0: {'b'}, '__all__': {'a'}}}) == {'c': 3, 'foos': [{}, {'b': 4}]}
     assert m.dict(exclude={'foos': {'__all__': {'a'}}}) == {'c': 3, 'foos': [{'b': 2}, {'b': 4}]}
     assert m.dict(exclude={'foos': {'__all__'}}) == {'c': 3, 'foos': []}
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='set with keyword "__all__" must not contain other elements'):
         m.dict(exclude={'foos': {'a', '__all__'}})
-    assert 'set with keyword "__all__" must not contain other elements' in str(e.value)
 
 
 def test_model_export_dict_exclusion():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
1. Raise TypeError in ``pydantic.utils.ValueItems`` when ``value`` is a list or tuple and the provided exclusion dict is not keyed by index.
2. Add cautionary sentence to the **Advanced include and exclude** section of docs to point out correct usage of ``exclude`` in the following example. 
3. Use `'__all__'` keyword  to exclude fields from all elements of a sequence of submodels or dicts.

## Related issue number

This PR addresses a couple of my comments in #1283  -- adding a more detailed TypeError and a sentence pointing out the subtle example of correct usage.  Some logic has been added to enable usage of `'__all__'` in the `exclude` kwarg of model export methods.

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
