### PR TITLE
Add benchmark for voluptuous library

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -9,3 +9,4 @@ valideer
 attr
 cattrs
 cerberus
+voluptuous

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -46,6 +46,11 @@ try:
 except Exception:
     TestCerberus = None
 
+try:
+    from test_voluptuous import TestVoluptuous
+except Exception as e:
+    TestVoluptuous = None
+
 PUNCTUATION = ' \t\n!"#$%&\'()*+,-./'
 LETTERS = string.ascii_letters
 UNICODE = '\xa0\xad¡¢£¤¥¦§¨©ª«¬ ®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
@@ -55,7 +60,7 @@ random = random.SystemRandom()
 # in order of performance for csv
 other_tests = [
     t for t in
-    [TestCAttrs, TestValideer, TestMarshmallow, TestTrafaret, TestDRF, TestCerberus]
+    [TestCAttrs, TestValideer, TestMarshmallow, TestVoluptuous, TestTrafaret, TestDRF, TestCerberus]
     if t is not None
 ]
 

--- a/benchmarks/test_voluptuous.py
+++ b/benchmarks/test_voluptuous.py
@@ -1,0 +1,51 @@
+from dateutil.parser import parse as parse_datetime
+import voluptuous as v
+from voluptuous.humanize import humanize_error
+
+
+class TestVoluptuous:
+    package = 'voluptuous'
+    version = v.__version__
+
+    def __init__(self, allow_extra):
+        self.schema = v.Schema(
+            {
+                v.Required('id'): int,
+                v.Required('client_name'): v.All(str, v.Length(max=255)),
+                v.Required('sort_index'): float,
+                # v.Optional('client_email'): v.Maybe(v.Email),
+                v.Optional('client_phone'): v.Maybe(v.All(str, v.Length(max=255))),
+                v.Optional('location'): v.Maybe(
+                    v.Schema(
+                        {
+                            'latitude': v.Maybe(float),
+                            'longitude': v.Maybe(float)
+                        },
+                        required=True
+                    )
+                ),
+                v.Optional('contractor'): v.Maybe(v.All(v.Coerce(int), v.Range(min=1))),
+                v.Optional('upstream_http_referrer'): v.Maybe(v.All(str, v.Length(max=1023))),
+                v.Required('grecaptcha_response'): v.All(str, v.Length(min=20, max=1000)),
+                v.Optional('last_updated'): v.Maybe(parse_datetime),
+                v.Required('skills', default=[]): [
+                    v.Schema(
+                        {
+                            v.Required('subject'): str,
+                            v.Required('subject_id'): int,
+                            v.Required('category'): str,
+                            v.Required('qual_level'): str,
+                            v.Required('qual_level_id'): int,
+                            v.Required('qual_level_ranking', default=0): float,
+                        }
+                    )
+                ],
+            },
+            extra=allow_extra,
+        )
+
+    def validate(self, data):
+        try:
+            return True, self.schema(data)
+        except v.MultipleInvalid as e:
+            return False, humanize_error(data, e)


### PR DESCRIPTION
## Change Summary

Voluptuous, despite the name, is a Python data validation library. And, despite its "CONTRIBUTIONS ONLY" maintenance status, my team uses it widely and indiscriminately. I wanted to see how it compared to pydantic, and was not surprised it was twice as slow and much harder to grok.

- GitHub: https://github.com/alecthomas/voluptuous
- PyPi: https://pypi.org/project/voluptuous

When I ran the tests with `SAVE=1` on my MBP with the following specs:

```
             pydantic version: 1.4a1
            pydantic compiled: False
                 install path: /Users/step7212/git/hub/pydantic/pydantic
               python version: 3.8.1 (default, Jan 10 2020, 09:36:37)  [Clang 11.0.0 (clang-1100.0.33.16)]
                     platform: macOS-10.14.6-x86_64-i386-64bit
     optional deps. installed: ['typing-extensions', 'email-validator', 'devtools']
```

I got the following, slightly disappointing results:

Package | Version | Relative Performance | Mean validation time
--- | --- | --- | ---
valideer | `0.4.2` |  | 104.2μs
attrs + cattrs | `19.3.0` | 1.1x slower | 114.4μs
pydantic | `1.4a1` | 1.2x slower | 124.3μs
marshmallow | `3.5.0` | 1.8x slower | 190.1μs
voluptuous | `0.11.7` | 2.2x slower | 227.6μs
trafaret | `2.0.2` | 2.4x slower | 253.0μs
django-rest-framework | `3.11.0` | 8.5x slower | 881.8μs
cerberus | `1.3.2` | 19.1x slower | 1993.8μs

Then I realized I did not `make build-cython` before the run. Running that beforehand, got much more expected results for pydantic:

Package | Version | Relative Performance | Mean validation time
--- | --- | --- | ---
pydantic | `1.4a1` |  | 82.5μs
valideer | `0.4.2` | 1.5x slower | 123.5μs
attrs + cattrs | `19.3.0` | 1.6x slower | 130.3μs
voluptuous | `0.11.7` | 2.8x slower | 229.1μs
trafaret | `2.0.2` | 3.4x slower | 277.2μs
marshmallow | `3.5.0` | 3.4x slower | 281.8μs
django-rest-framework | `3.11.0` | 10.8x slower | 888.6μs
cerberus | `1.3.2` | 23.2x slower | 1914.6μs

## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
