### PR TITLE
Add MacOS and Windows build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ jobs:
     - 'PIP=pip'
     - 'CIBW_BUILD="cp36-manylinux1_x86_64 cp36-manylinux1_i686 cp37-manylinux1_x86_64 cp37-manylinux1_i686 cp38-manylinux1_x86_64 cp38-manylinux1_i686"'
     - 'CIBW_BEFORE_BUILD="pip install -U cython"'
-    - 'CIBW_TEST_REQUIRES=pytest==5.3.5'
+    - 'CIBW_TEST_REQUIRES="pytest==5.3.5"'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
     script:
     - ./tests/check_tag.py
@@ -155,7 +155,7 @@ jobs:
     - 'PIP="python3 -m pip"'
     - 'CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 pp36-macosx_x86_64"'
     - 'CIBW_BEFORE_BUILD="python3 -m pip install -U cython"'
-    - 'CIBW_TEST_REQUIRES=pytest==5.3.5'
+    - 'CIBW_TEST_REQUIRES="pytest==5.3.5"'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
     install: python3 -m pip install -U cibuildwheel wheel
     script: python3 -m cibuildwheel --output-dir dist
@@ -181,7 +181,7 @@ jobs:
     - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
     - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
     - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
-    - 'CIBW_TEST_REQUIRES=pytest==5.3.5'
+    - 'CIBW_TEST_REQUIRES="pytest==5.3.5"'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
     install: pip3 install --user -U cibuildwheel wheel
     script: python -m cibuildwheel --output-dir dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ jobs:
     install: pip3 install --user -U cibuildwheel wheel
     script: python -m cibuildwheel --output-dir dist
     after_success:
-    - dir /n dist
+    - dir dist
     # deploy:
     #   provider: pypi
     #   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,8 +152,8 @@ jobs:
     os: osx
     language: shell
     env:
-    - 'PIP=pip'
-    - 'CIBW_BEFORE_BUILD="pip install -U cython"'
+    - 'PIP="python3 -m pip"'
+    - 'CIBW_BEFORE_BUILD="python3 -m pip install -U cython"'
     - 'CIBW_TEST_REQUIRES=pytest'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
     install: python3 -m pip install -U cibuildwheel wheel
@@ -175,8 +175,9 @@ jobs:
     os: windows
     language: shell
     before_install: |
-      choco install python3 --params "/InstallDir:C:\\Python3"
-      export PATH="/c/Python3:/c/Python3/Scripts:$PATH"
+      choco install python3
+      refreshenv
+      echo %PATH:;=&echo.%
       export CIBW_BEFORE_BUILD="pip install -U cython"
       export CIBW_TEST_REQUIRES=pytest
       export CIBW_TEST_COMMAND="pytest {project}/tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ jobs:
     after_success: skip
 
   - stage: build
-    name: 'PyPI Build and Upload'
+    name: 'Build and deploy Linux wheels'
     python: 3.7
     services:
     - docker
@@ -139,6 +139,54 @@ jobs:
     deploy:
       provider: pypi
       skip_cleanup: true
+      skip_existing: true
+      user: samuelcolvin
+      password:
+        secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+      true:
+        tags: true
+        all_branches: true
+  - stage: build
+    name: 'Build and deploy macOS wheels'
+    os: osx
+    language: shell
+    env:
+    - 'PIP=pip'
+    - 'CIBW_BEFORE_BUILD="pip install -U cython"'
+    - 'CIBW_TEST_REQUIRES=pytest'
+    - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
+    install: python3 -m pip install -U cibuildwheel wheel
+    script: python3 -m cibuildwheel --output-dir dist
+    after_success:
+    - ls -lha dist
+    deploy:
+      provider: pypi
+      skip_cleanup: true
+      skip_existing: true
+      user: samuelcolvin
+      password:
+        secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+      true:
+        tags: true
+        all_branches: true
+  - stage: build
+    name: 'Build and deploy Windows wheels'
+    os: windows
+    language: shell
+    before_install: |
+      choco install python3 --params "/InstallDir:C:\\Python3"
+      export PATH="/c/Python3:/c/Python3/Scripts:$PATH"
+      export CIBW_BEFORE_BUILD="pip install -U cython"
+      export CIBW_TEST_REQUIRES=pytest
+      export CIBW_TEST_COMMAND="pytest {project}/tests"
+    install: python3 -m pip install -U cibuildwheel wheel
+    script: python3 -m cibuildwheel --output-dir dist
+    after_success:
+    - dir /n dist
+    deploy:
+      provider: pypi
+      skip_cleanup: true
+      skip_existing: true
       user: samuelcolvin
       password:
         secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,32 +171,32 @@ jobs:
     #   true:
     #     tags: true
     #     all_branches: true
-  # - stage: build
-  #   name: 'Build and deploy Windows wheels'
-  #   os: windows
-  #   language: shell
-  #   before_install:
-  #   - choco install python --version 3.8.2
-  #   env:
-  #   - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
-  #   - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
-  #   - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
-  #   - 'CIBW_TEST_REQUIRES=pytest'
-  #   - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
-  #   install: pip3 install --user -U cibuildwheel wheel
-  #   script: python -m cibuildwheel --output-dir dist
-  #   after_success:
-  #   - dir /n dist
-  #   # deploy:
-  #   #   provider: pypi
-  #   #   skip_cleanup: true
-  #   #   skip_existing: true
-  #   #   user: samuelcolvin
-  #   #   password:
-  #   #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
-  #   #   on:
-  #   #     tags: true
-  #   #     all_branches: true
+  - stage: build
+    name: 'Build and deploy Windows wheels'
+    os: windows
+    language: shell
+    before_install:
+    - choco install python --version 3.8.2
+    env:
+    - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
+    - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
+    - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
+    - 'CIBW_TEST_REQUIRES=pytest'
+    - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
+    install: pip3 install --user -U cibuildwheel wheel
+    script: python -m cibuildwheel --output-dir dist
+    after_success:
+    - dir /n dist
+    # deploy:
+    #   provider: pypi
+    #   skip_cleanup: true
+    #   skip_existing: true
+    #   user: samuelcolvin
+    #   password:
+    #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+    #   on:
+    #     tags: true
+    #     all_branches: true
 
   - stage: build
     name: 'Docs Build and Upload'

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ jobs:
     - 'PIP="python3 -m pip"'
     - 'CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 pp36-macosx_x86_64"'
     - 'CIBW_BEFORE_BUILD="python3 -m pip install -U cython"'
-    - 'CIBW_TEST_REQUIRES=pytest'
+    - 'CIBW_TEST_REQUIRES=pytest==5.3.5'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
     install: python3 -m pip install -U cibuildwheel wheel
     script: python3 -m cibuildwheel --output-dir dist
@@ -181,7 +181,7 @@ jobs:
     - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
     - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
     - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
-    - 'CIBW_TEST_REQUIRES=pytest'
+    - 'CIBW_TEST_REQUIRES=pytest==5.3.5'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
     install: pip3 install --user -U cibuildwheel wheel
     script: python -m cibuildwheel --output-dir dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ after_success:
 - bash <(curl -s https://codecov.io/bash) -e CYTHON,DEPS,TRAVIS_JOB_NAME
 
 stages:
-- name: test
-  if: type = pull_request OR branch = master OR tag IS present
+# - name: test
+#   if: type = pull_request OR branch = master OR tag IS present
 - name: build
   if: type = pull_request
   #if: type = push AND (branch = master OR tag IS present)

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,7 @@ jobs:
     language: shell
     env:
     - 'PIP="python3 -m pip"'
+    - 'CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 pp36-macosx_x86_64"'
     - 'CIBW_BEFORE_BUILD="python3 -m pip install -U cython"'
     - 'CIBW_TEST_REQUIRES=pytest'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
@@ -179,6 +180,7 @@ jobs:
       powershell -Command Update-SessionEnvironment
       echo $env:PATH
       echo %PATH%
+      export CIBW_BUILD="cp36-win32 cp36-win_amd64 cp37-win32 cp37-win_amd64 cp38-win32 cp38-win_amd64 pp36-win32"
       export CIBW_BEFORE_BUILD="pip install -U cython"
       export CIBW_TEST_REQUIRES=pytest
       export CIBW_TEST_COMMAND="pytest {project}/tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,14 +177,13 @@ jobs:
     language: shell
     before_install:
     - choco install python --version 3.8.2
-    - pip3 install --upgrade pip
     env:
     - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
     - 'CIBW_BUILD="cp36-win32 cp36-win_amd64 cp37-win32 cp37-win_amd64 cp38-win32 cp38-win_amd64 pp36-win32"'
-    - 'CIBW_BEFORE_BUILD="pip3 install -U cython"'
+    - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
     - 'CIBW_TEST_REQUIRES=pytest'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
-    install: pip3 install -U cibuildwheel wheel
+    install: pip3 install --user -U cibuildwheel wheel
     script: python -m cibuildwheel --output-dir dist
     after_success:
     - dir /n dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,8 +176,9 @@ jobs:
     language: shell
     before_install: |
       choco install python3
-      refreshenv
-      echo %PATH:;=&echo.%
+      powershell -Command Update-SessionEnvironment
+      echo $env:PATH
+      echo %PATH%
       export CIBW_BEFORE_BUILD="pip install -U cython"
       export CIBW_TEST_REQUIRES=pytest
       export CIBW_TEST_COMMAND="pytest {project}/tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,7 +179,7 @@ jobs:
     - choco install python --version 3.8.2
     env:
     - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
-    - 'CIBW_BUILD="cp36-win32 cp36-win_amd64 cp37-win32 cp37-win_amd64 cp38-win32 cp38-win_amd64 pp36-win32"'
+    - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
     - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
     - 'CIBW_TEST_REQUIRES=pytest'
     - 'CIBW_TEST_COMMAND="pytest {project}/tests"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ stages:
 - name: test
   if: type = pull_request OR branch = master OR tag IS present
 - name: build
-  if: type = push AND (branch = master OR tag IS present)
+  if: type = pull_request
+  #if: type = push AND (branch = master OR tag IS present)
 
 jobs:
   include:
@@ -136,16 +137,16 @@ jobs:
     - SKIP_CYTHON=1 python setup.py sdist bdist_wheel
     after_success:
     - ls -lha dist
-    deploy:
-      provider: pypi
-      skip_cleanup: true
-      skip_existing: true
-      user: samuelcolvin
-      password:
-        secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
-      true:
-        tags: true
-        all_branches: true
+    # deploy:
+    #   provider: pypi
+    #   skip_cleanup: true
+    #   skip_existing: true
+    #   user: samuelcolvin
+    #   password:
+    #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+    #   true:
+    #     tags: true
+    #     all_branches: true
   - stage: build
     name: 'Build and deploy macOS wheels'
     os: osx
@@ -159,16 +160,16 @@ jobs:
     script: python3 -m cibuildwheel --output-dir dist
     after_success:
     - ls -lha dist
-    deploy:
-      provider: pypi
-      skip_cleanup: true
-      skip_existing: true
-      user: samuelcolvin
-      password:
-        secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
-      true:
-        tags: true
-        all_branches: true
+    # deploy:
+    #   provider: pypi
+    #   skip_cleanup: true
+    #   skip_existing: true
+    #   user: samuelcolvin
+    #   password:
+    #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+    #   true:
+    #     tags: true
+    #     all_branches: true
   - stage: build
     name: 'Build and deploy Windows wheels'
     os: windows
@@ -183,16 +184,16 @@ jobs:
     script: python3 -m cibuildwheel --output-dir dist
     after_success:
     - dir /n dist
-    deploy:
-      provider: pypi
-      skip_cleanup: true
-      skip_existing: true
-      user: samuelcolvin
-      password:
-        secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
-      on:
-        tags: true
-        all_branches: true
+    # deploy:
+    #   provider: pypi
+    #   skip_cleanup: true
+    #   skip_existing: true
+    #   user: samuelcolvin
+    #   password:
+    #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+    #   on:
+    #     tags: true
+    #     all_branches: true
 
   - stage: build
     name: 'Docs Build and Upload'
@@ -200,8 +201,8 @@ jobs:
     script: make docs
     env:
     - secure: "vpTd8bkwPBP0CV3EJBAwSMNMnNK3m/71dvTvBd1T4YGuefyJvYhtA7wauA5xRL9jpK2mu5QR5eo0owTUJhKi4DjpafMMd1bc4PnXlrdZFzkn3VsGmlKt74D/aJgiuiNyhd/Qvq4OxMHrMhf4f6lKWoMM1vh6yT0yp3+51SexSh2Me0Q+npxbjXwoxX5XUHRcoSLtFk4GbYI88a2I+08XWI6v+Awo/giQ5QurUJhjAklbosrrQVr1FCOkU0em5jeyZvEbZSLmaMtbX1JlRdKoJm6WMU+y9I7zj35w6ue/vgfcLz7b/HDZrBx7/L9g1LxRo80briueX/IbHvN7DOVFKvaXVmnEa6lIDdCeOLOyESpIbmjqmDKi8JeexdPNxKq4Tvo2VEA9dL2w2aw+aALNtU2OF5iEMfPTUQyosu/CNu2PKtiuZkSOdvpYbSy1WUNHJRvomdR4Olzg8ZIScNsxU3IIPdrlG/LUA8auXcE9juFeZfD6D2hQZATqWeEe/C2J7amNSD+mLLaTf6nMQw8oNtKYOvYK17M7xyvi7HXDy711Bi18U3x6Ye0xGx8CDbFwl0ICNzIk9rrSAh9hEHTvfdUUkk35pxifvO0Hrh4SArCA20ozcH/hHWBhyqGdxoIQ6KoDgNbIFIGQ6/vugxL/pt8z1sJwPfJnq8tRDAyWZvE="
-    deploy:
-      provider: script
-      script: make publish
-      on:
-        tags: true
+    # deploy:
+    #   provider: script
+    #   script: make publish
+    #   on:
+    #     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -175,17 +175,17 @@ jobs:
     name: 'Build and deploy Windows wheels'
     os: windows
     language: shell
-    before_install: |
-      choco install python3
-      powershell -Command Update-SessionEnvironment
-      echo $env:PATH
-      echo %PATH%
-      export CIBW_BUILD="cp36-win32 cp36-win_amd64 cp37-win32 cp37-win_amd64 cp38-win32 cp38-win_amd64 pp36-win32"
-      export CIBW_BEFORE_BUILD="pip install -U cython"
-      export CIBW_TEST_REQUIRES=pytest
-      export CIBW_TEST_COMMAND="pytest {project}/tests"
-    install: python3 -m pip install -U cibuildwheel wheel
-    script: python3 -m cibuildwheel --output-dir dist
+    before_install:
+    - choco install python --version 3.8.2
+    - pip3 install --upgrade pip
+    env:
+    - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
+    - 'CIBW_BUILD="cp36-win32 cp36-win_amd64 cp37-win32 cp37-win_amd64 cp38-win32 cp38-win_amd64 pp36-win32"'
+    - 'CIBW_BEFORE_BUILD="pip3 install -U cython"'
+    - 'CIBW_TEST_REQUIRES=pytest'
+    - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
+    install: pip3 install -U cibuildwheel wheel
+    script: python -m cibuildwheel --output-dir dist
     after_success:
     - dir /n dist
     # deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,32 +171,32 @@ jobs:
     #   true:
     #     tags: true
     #     all_branches: true
-  - stage: build
-    name: 'Build and deploy Windows wheels'
-    os: windows
-    language: shell
-    before_install:
-    - choco install python --version 3.8.2
-    env:
-    - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
-    - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
-    - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
-    - 'CIBW_TEST_REQUIRES=pytest'
-    - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
-    install: pip3 install --user -U cibuildwheel wheel
-    script: python -m cibuildwheel --output-dir dist
-    after_success:
-    - dir /n dist
-    # deploy:
-    #   provider: pypi
-    #   skip_cleanup: true
-    #   skip_existing: true
-    #   user: samuelcolvin
-    #   password:
-    #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
-    #   on:
-    #     tags: true
-    #     all_branches: true
+  # - stage: build
+  #   name: 'Build and deploy Windows wheels'
+  #   os: windows
+  #   language: shell
+  #   before_install:
+  #   - choco install python --version 3.8.2
+  #   env:
+  #   - 'PATH=/c/Python38:/c/Python38/Scripts:$PATH'
+  #   - 'CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"'
+  #   - 'CIBW_BEFORE_BUILD="pip3 install --user -U cython"'
+  #   - 'CIBW_TEST_REQUIRES=pytest'
+  #   - 'CIBW_TEST_COMMAND="pytest {project}/tests"'
+  #   install: pip3 install --user -U cibuildwheel wheel
+  #   script: python -m cibuildwheel --output-dir dist
+  #   after_success:
+  #   - dir /n dist
+  #   # deploy:
+  #   #   provider: pypi
+  #   #   skip_cleanup: true
+  #   #   skip_existing: true
+  #   #   user: samuelcolvin
+  #   #   password:
+  #   #     secure: 'QbXFF2puEWjhFUpD0yu2R+wP4QI1IKIomBkMizsiCyMutlexERElranyYB8bsakvjPaJ+zU14ufffh2u7UA7Zhep/iE4skRHq4XWxnnRLHGu5nyGf3+zSM3F9MOzV32eZ4CDLJtFb6I0ensjTpodJH2EsIYHYxTgndIZn56Qbh6CStj7Xg1zm0Ujxdzm4ZLgcS28SOF/tpjsDW9+GXwc6L1mAZWYiS98gVgzL1vBd9tL9uFbbuFwGz9uhFMzFJko7vXSl8urWB4qeCspKXa9iKH7/AOYSwXTCwcg8U2hhC9UsOapnga2BubZKlU5HRfSs9fQcpnzcP2lwhSmkrEFa8VOw83hX6+bL564xK1Q4kanfGZ1fLU4FYge3iOnqjH7ajO7xEcUrcOEYUPfxM4EfdiDw0xnAzE1ITGH1/pZikF+wjlu+ez7RmmnejgK7quT1WU7keo7pSlRSfQtNgNl6xu818x0xZ1TScfN6e9npNy4TYyIooMOOeI4tMdfcR4JClkjGKhAtBk81DH7isZgPv3uwocGnKZ2S7La97CE3ADzU3MTA9xVIOSOjzwuvAe72uS2nwzqXkS9KATdATkC9QCvheJ9jIBB4UcqnHbD8L1gkqdmZwXZqHZldq8wcqNYZb+81lumy5EZ6xSoEzlLDpXHe80EjMUOBkb5fz3D44s='
+  #   #   on:
+  #   #     tags: true
+  #   #     all_branches: true
 
   - stage: build
     name: 'Docs Build and Upload'

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
 import os
 import re
 import sys
+from distutils.command import build_ext
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 from setuptools import setup
+
+if os.name == 'nt':
+
+    def pass_ges(self, ext):
+        pass
+
+    build_ext.get_export_symbols = pass_ges
 
 
 class ReplaceLinks:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if os.name == 'nt':
         except UnicodeEncodeError:
             suffix = 'U' + suffix.encode('punycode').replace(b'-', b'_').decode('ascii')
 
-        initfunc_name = "PyInit_" + suffix
+        initfunc_name = 'PyInit_' + suffix
         if initfunc_name not in ext.export_symbols:
             ext.export_symbols.append(initfunc_name)
         return ext.export_symbols

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,46 @@
 import os
 import re
 import sys
-from distutils.command import build_ext
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 from setuptools import setup
 
 if os.name == 'nt':
+    from distutils.command import build_ext
 
-    def pass_ges(self, ext):
-        pass
+    def get_export_symbols(self, ext):
+        """Return the list of symbols that a shared extension has to
+        export.  This either uses 'ext.export_symbols' or, if it's not
+        provided, "PyInit_" + module_name.  Only relevant on Windows, where
+        the .pyd file (DLL) must export the module "PyInit_" function.
 
-    build_ext.get_export_symbols = pass_ges
+        Source: https://github.com/python/cpython/blob/8849e5962ba481d5d414b3467a256aba2134b4da\
+                /Lib/distutils/command/build_ext.py#L686-L703
+        """
+        # Patch from: https://bugs.python.org/issue35893
+        parts = ext.name.split('.')
+        print('parts', parts)
+        if parts[-1] == '__init__':
+            suffix = parts[-2]
+        else:
+            suffix = parts[-1]
 
+        try:
+            # Unicode module name support as defined in PEP-489
+            # https://www.python.org/dev/peps/pep-0489/#export-hook-name
+            suffix.encode('ascii')
+        except UnicodeEncodeError:
+            suffix = 'U' + suffix.encode('punycode').replace(b'-', b'_').decode('ascii')
+
+        print('ext.export_symbols', ext.export_symbols)
+        initfunc_name = "PyInit_" + suffix
+        print('initfunc_name', initfunc_name)
+        if initfunc_name not in ext.export_symbols:
+            ext.export_symbols.append(initfunc_name)
+        return ext.export_symbols
+
+    build_ext.build_ext.get_export_symbols = get_export_symbols
 
 class ReplaceLinks:
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ if os.name == 'nt':
         """
         # Patch from: https://bugs.python.org/issue35893
         parts = ext.name.split('.')
-        print('parts', parts)
         if parts[-1] == '__init__':
             suffix = parts[-2]
         else:
@@ -33,9 +32,7 @@ if os.name == 'nt':
         except UnicodeEncodeError:
             suffix = 'U' + suffix.encode('punycode').replace(b'-', b'_').decode('ascii')
 
-        print('ext.export_symbols', ext.export_symbols)
         initfunc_name = "PyInit_" + suffix
-        print('initfunc_name', initfunc_name)
         if initfunc_name not in ext.export_symbols:
             ext.export_symbols.append(initfunc_name)
         return ext.export_symbols


### PR DESCRIPTION
## Change Summary

As of about a week ago, the cibuildwheel repository has new examples for Travis on Mac and Windows: https://github.com/joerick/cibuildwheel/blob/master/examples/travis-ci-test-and-deploy.yml

This adds those targets to .travis.yml to hopefully resolve #555 .

If this passes (which I can't test myself, since you should handle the releases), I can edit https://github.com/samuelcolvin/pydantic/blob/8727914ced9d4546f0f95a453aff78f03b778275/docs/install.md#L19-L21 to reflect it.

## Related issue number

#555 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
