### PR TITLE
Use __class__ attribute for 5% speed gain.

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -50,7 +50,7 @@ def setattr_validate_assignment(self: 'DataclassType', name: str, value: Any) ->
         if known_field:
             value, error_ = known_field.validate(value, d, loc=name, cls=self.__class__)
             if error_:
-                raise ValidationError([error_], type(self))
+                raise ValidationError([error_], self.__class__)
 
     object.__setattr__(self, name, value)
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -96,7 +96,7 @@ class BaseSettings(BaseModel):
                 raise TypeError(f'invalid field env: {env!r} ({display_as_type(env)}); should be string, list or set')
 
             if not cls.case_sensitive:
-                env_names = type(env_names)(n.lower() for n in env_names)
+                env_names = env_names.__class__(n.lower() for n in env_names)
             field.field_info.extra['env_names'] = env_names
 
     __config__: Config  # type: ignore

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -107,7 +107,7 @@ def flatten_errors(
 
 
 def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> Dict[str, Any]:
-    type_ = get_exc_type(type(exc))
+    type_ = get_exc_type(exc.__class__)
     msg_template = config.error_msg_templates.get(type_) or getattr(exc, 'msg_template', None)
     ctx = exc.__dict__
     if msg_template:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -343,7 +343,7 @@ class ModelField(Representation):
         """
         default_value = self.get_default()
         if default_value is not None and self.type_ is None:
-            self.type_ = self.default.__class__
+            self.type_ = default_value.__class__
             self.outer_type_ = self.type_
 
         if self.type_ is None:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -343,13 +343,13 @@ class ModelField(Representation):
         """
         default_value = self.get_default()
         if default_value is not None and self.type_ is None:
-            self.type_ = type(default_value)
+            self.type_ = self.default.__class__
             self.outer_type_ = self.type_
 
         if self.type_ is None:
             raise errors_.ConfigError(f'unable to infer type for attribute "{self.name}"')
 
-        if type(self.type_) == ForwardRef:
+        if self.type_.__class__ == ForwardRef:
             # self.type_ is currently a ForwardRef and there's nothing we can do now,
             # user will need to call model.update_forward_refs()
             return

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -407,7 +407,7 @@ class ModelField(Representation):
         if origin is Union:
             types_ = []
             for type_ in self.type_.__args__:
-                if type_ is NoneType:  # type: ignore
+                if type_ is NoneType:
                     if self.required is Undefined:
                         self.required = False
                     self.allow_none = True
@@ -714,7 +714,7 @@ class ModelField(Representation):
         """
         False if this is a simple field just allowing None as used in Unions/Optional.
         """
-        return self.type_ != NoneType  # type: ignore
+        return self.type_ != NoneType
 
     def is_complex(self) -> bool:
         """

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -54,7 +54,7 @@ def pydantic_encoder(obj: Any) -> Any:
         return asdict(obj)
 
     try:
-        encoder = ENCODERS_BY_TYPE[type(obj)]
+        encoder = ENCODERS_BY_TYPE[obj.__class__]
     except KeyError:
         raise TypeError(f"Object of type '{obj.__class__.__name__}' is not JSON serializable")
     else:
@@ -62,7 +62,7 @@ def pydantic_encoder(obj: Any) -> Any:
 
 
 def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]], obj: Any) -> Any:
-    encoder = type_encoders.get(type(obj))
+    encoder = type_encoders.get(obj.__class__)
     if encoder:
         return encoder(obj)
     else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -111,7 +111,7 @@ class BaseConfig:
         if field_info.get('alias_priority', 0) <= 1 and cls.alias_generator:
             alias = cls.alias_generator(name)
             if not isinstance(alias, str):
-                raise TypeError(f'Config.alias_generator must return str, not {type(alias)}')
+                raise TypeError(f'Config.alias_generator must return str, not {alias.__class__}')
             field_info.update(alias=alias, alias_priority=1)
         return field_info
 
@@ -336,7 +336,7 @@ class BaseModel(metaclass=ModelMetaclass):
             if known_field:
                 value, error_ = known_field.validate(value, self.dict(exclude={name}), loc=name, cls=self.__class__)
                 if error_:
-                    raise ValidationError([error_], type(self))
+                    raise ValidationError([error_], self.__class__)
         self.__dict__[name] = value
         self.__fields_set__.add(name)
 
@@ -428,7 +428,7 @@ class BaseModel(metaclass=ModelMetaclass):
             try:
                 obj = dict(obj)
             except (TypeError, ValueError) as e:
-                exc = TypeError(f'{cls.__name__} expected dict not {type(obj).__name__}')
+                exc = TypeError(f'{cls.__name__} expected dict not {obj.__class__.__name__}')
                 raise ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], cls) from e
         return cls(**obj)
 
@@ -622,7 +622,7 @@ class BaseModel(metaclass=ModelMetaclass):
             }
 
         elif sequence_like(v):
-            return type(v)(
+            return v.__class__(
                 cls._get_value(
                     v_,
                     to_dict=to_dict,
@@ -838,7 +838,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
             return {}, set(), ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], cls_)
 
     for name, field in model.__fields__.items():
-        if type(field.type_) == ForwardRef:
+        if field.type_.__class__ == ForwardRef:
             raise ConfigError(
                 f'field "{field.name}" not yet prepared so type is still a ForwardRef, '
                 f'you might need to call {cls_.__name__}.update_forward_refs().'

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -127,7 +127,7 @@ def from_orm_callback(ctx: MethodContext) -> Type:
     elif isinstance(ctx.type, Instance):
         model_type = ctx.type  # called on an instance (unusual, but still valid)
     else:  # pragma: no cover
-        detail = f'ctx.type: {ctx.type} (of type {type(ctx.type).__name__})'
+        detail = f'ctx.type: {ctx.type} (of type {ctx.type.__class__.__name__})'
         error_unexpected_behavior(detail, ctx.api, ctx.context)
         return ctx.default_return_type
     pydantic_metadata = model_type.type.metadata.get(METADATA_KEY)
@@ -407,7 +407,7 @@ class PydanticModelTransformer:
         if isinstance(expr, CallExpr) and isinstance(expr.callee, RefExpr) and expr.callee.fullname == FIELD_FULLNAME:
             # The "default value" is a call to `Field`; at this point, the field is
             # only required if default is Ellipsis (i.e., `field_name: Annotation = Field(...)`)
-            return len(expr.args) > 0 and type(expr.args[0]) is EllipsisExpr
+            return len(expr.args) > 0 and expr.args[0].__class__ is EllipsisExpr
         # Only required if the "default value" is Ellipsis (i.e., `field_name: Annotation = ...`)
         return isinstance(expr, EllipsisExpr)
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -170,7 +170,7 @@ class AnyUrl(str):
 
     @classmethod
     def validate(cls, value: Any, field: 'ModelField', config: 'BaseConfig') -> 'AnyUrl':
-        if type(value) == cls:
+        if value.__class__ == cls:
             return value
         value = str_validator(value)
         if cls.strip_whitespace:
@@ -341,7 +341,7 @@ class NameEmail(Representation):
 
     @classmethod
     def validate(cls, value: Any) -> 'NameEmail':
-        if type(value) == cls:
+        if value.__class__ == cls:
             return value
         value = str_validator(value)
         return cls(*validate_email(value))

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -630,7 +630,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
             ref_prefix=ref_prefix,
             known_models=known_models,
         )
-    if field.type_ is Any or type(field.type_) == TypeVar:
+    if field.type_ is Any or field.type_.__class__ == TypeVar:
         return {}, definitions, nested_models  # no restrictions
     if is_callable_type(field.type_):
         raise SkipField(f'Callable {field.name} was excluded from schema since JSON schema has no equivalent type.')
@@ -651,7 +651,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
                 known_models=known_models,
             )
         literal_value = values[0]
-        field_type = type(literal_value)
+        field_type = literal_value.__class__
         f_schema['const'] = literal_value
 
     if issubclass(field_type, Enum):
@@ -715,7 +715,7 @@ def encode_default(dft: Any) -> Any:
     if isinstance(dft, (int, float, str)):
         return dft
     elif sequence_like(dft):
-        t = type(dft)
+        t = dft.__class__
         return t(encode_default(v) for v in dft)
     elif isinstance(dft, dict):
         return {encode_default(k): encode_default(v) for k, v in dft.items()}

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -107,12 +107,12 @@ __all__ = (
 
 
 AnyType = Type[Any]
-NoneType = type(None)
+NoneType = None.__class__
 
 
 def display_as_type(v: AnyType) -> str:
     if not isinstance(v, typing_base) and not isinstance(v, type):
-        v = type(v)
+        v = v.__class__
 
     if isinstance(v, type) and issubclass(v, Enum):
         if issubclass(v, int):
@@ -181,7 +181,7 @@ test_type = NewType('test_type', str)
 
 
 def is_new_type(type_: AnyType) -> bool:
-    return isinstance(type_, type(test_type)) and hasattr(type_, '__supertype__')
+    return isinstance(type_, test_type.__class__) and hasattr(type_, '__supertype__')  # type: ignore
 
 
 def new_type_supertype(type_: AnyType) -> AnyType:
@@ -191,7 +191,7 @@ def new_type_supertype(type_: AnyType) -> AnyType:
 
 
 def _check_classvar(v: AnyType) -> bool:
-    return type(v) == type(ClassVar) and (sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
+    return v.__class__ == ClassVar.__class__ and (sys.version_info < (3, 7) or getattr(v, '_name', None) == 'ClassVar')
 
 
 def is_classvar(ann_type: AnyType) -> bool:
@@ -202,7 +202,7 @@ def update_field_forward_refs(field: 'ModelField', globalns: Any, localns: Any) 
     """
     Try to update ForwardRefs on fields based on this ModelField, globalns and localns.
     """
-    if type(field.type_) == ForwardRef:
+    if field.type_.__class__ == ForwardRef:
         field.type_ = evaluate_forwardref(field.type_, globalns, localns or None)
         field.prepare()
     if field.sub_fields:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -78,7 +78,7 @@ def truncate(v: Union[str], *, max_len: int = 80) -> str:
     try:
         v = v.__repr__()
     except TypeError:
-        v = type(v).__repr__(v)  # in case v is a type
+        v = v.__class__.__repr__(v)  # in case v is a type
     if len(v) > max_len:
         v = v[: max_len - 1] + '…'
     return v
@@ -342,7 +342,7 @@ class ValueItems(Representation):
         elif isinstance(items, AbstractSet):
             self._type = set
         else:
-            raise TypeError(f'Unexpected type of exclude value {type(items)}')
+            raise TypeError(f'Unexpected type of exclude value {items.__class__}')
 
         if isinstance(value, (list, tuple)):
             items = self._normalize_indexes(items, len(value))

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -533,7 +533,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
 ) -> Generator[AnyCallable, None, None]:
     if type_ is Any:
         return
-    type_type = type(type_)
+    type_type = type_.__class__
     if type_type == ForwardRef or type_type == TypeVar:
         return
     if type_ is Pattern:


### PR DESCRIPTION
## Change Summary

Updates https://github.com/samuelcolvin/pydantic/tree/use-class-attribute on top of current master. It isn't 2x faster, which may be why the branch hasn't been merged yet, but it is faster, about 5% on average, as demonstrated below (avg=117.592μs/iter on master vs avg=111.204μs/iter on use-class-attribute):

```
# On branch master
❯ BENCHMARK_REPEATS=100 make benchmark-pydantic
python benchmarks/run.py pydantic-only
                                pydantic time=0.674s, success=50.10%
                                ...
                                pydantic time=0.670s, success=50.10%
                                pydantic best=0.647s, avg=0.706s, stdev=0.111s

                                pydantic best=107.908μs/iter avg=117.592μs/iter stdev=18.569μs/iter version=1.4a1

❯ git checkout use-class-attribute
Switched to branch 'use-class-attribute'
Your branch is up to date with 'mine/use-class-attribute'.

❯ BENCHMARK_REPEATS=100 make benchmark-pydantic
python benchmarks/run.py pydantic-only
                                pydantic time=0.824s, success=50.10%
                                ...
                                pydantic time=0.660s, success=50.10%
                                pydantic best=0.637s, avg=0.667s, stdev=0.032s

                                pydantic best=106.111μs/iter avg=111.204μs/iter stdev=5.374μs/iter version=1.4a1
```

## Related issue number

None

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
