### PR TITLE
Add datetime field to default_factory example

### DIFF
--- a/changes/1301-StephenBrown2.md
+++ b/changes/1301-StephenBrown2.md
@@ -1,1 +1,1 @@
-Add datetime field to default_factory example
+Add `datetime` field to `default_factory` example

--- a/changes/1301-StephenBrown2.md
+++ b/changes/1301-StephenBrown2.md
@@ -1,0 +1,1 @@
+Add datetime field to default_factory example

--- a/docs/examples/dataclasses_initvars.py
+++ b/docs/examples/dataclasses_initvars.py
@@ -10,12 +10,12 @@ class PathData:
     base_path: InitVar[Optional[Path]]
 
     def __post_init__(self, base_path):
-        print(f"Received path={self.path!r}, base_path={base_path!r}")
+        print(f'Received path={self.path!r}, base_path={base_path!r}')
 
     def __post_init_post_parse__(self, base_path):
         if base_path is not None:
             self.path = base_path / self.path
 
-path_data = PathData('world', base_path="/hello")
+path_data = PathData('world', base_path='/hello')
 # Received path='world', base_path='/hello'
 assert path_data.path == Path('/hello/world')

--- a/docs/examples/exporting_models_exclude1.py
+++ b/docs/examples/exporting_models_exclude1.py
@@ -11,11 +11,11 @@ class Transaction(BaseModel):
     value: int
 
 t = Transaction(
-    id="1234567890",
+    id='1234567890',
     user=User(
         id=42,
-        username="JohnDoe",
-        password="hashedpassword"
+        username='JohnDoe',
+        password='hashedpassword'
     ),
     value=9876543210
 )

--- a/docs/examples/models_default_factory.py
+++ b/docs/examples/models_default_factory.py
@@ -1,9 +1,12 @@
-from pydantic import BaseModel, Field
+from datetime import datetime
 from uuid import UUID, uuid4
+from pydantic import BaseModel, Field
 
 class Model(BaseModel):
     uid: UUID = Field(default_factory=uuid4)
+    updated: datetime = Field(default_factory=datetime.utcnow)
 
 m1 = Model()
 m2 = Model()
-assert m1.uid != m2.uid
+print(f'{m1.uid} != {m2.uid}')
+print(f'{m1.updated} != {m2.updated}')

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,9 @@ filterwarnings =
 [flake8]
 max-line-length = 120
 max-complexity = 14
-inline-quotes = '
-multiline-quotes = """
+inline-quotes = single
+multiline-quotes = double
+avoid-escape = False
 ignore = E203, W503
 
 [bdist_wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ max-line-length = 120
 max-complexity = 14
 inline-quotes = single
 multiline-quotes = double
-avoid-escape = False
 ignore = E203, W503
 
 [bdist_wheel]


### PR DESCRIPTION
## Change Summary

While looking through the docs, I was happy to find that `default_factory` will be added to 1.5 provisionally, however, I was specifically searching for an example where `datetime` was being used, and my searches came up fruitless until I checked the closed issues. This adds an example for searchability purposes (and works as expected in my tests)

## Related issue number

None

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
