### PR TITLE
Allow schema_extra to be a classmethod

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -21,6 +21,7 @@ from typing import (
     Union,
     cast,
     no_type_check,
+    overload,
 )
 
 from .class_validators import ROOT_KEY, ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
@@ -44,6 +45,7 @@ from .utils import (
 
 if TYPE_CHECKING:
     from inspect import Signature
+    import typing_extensions
     from .class_validators import ValidatorListDict
     from .types import ModelOrDc
     from .typing import CallableGenerator, TupleGenerator, DictStrAny, DictAny, SetStr
@@ -51,6 +53,19 @@ if TYPE_CHECKING:
 
     ConfigType = Type['BaseConfig']
     Model = TypeVar('Model', bound='BaseModel')
+
+    class SchemaExtraCallable(typing_extensions.Protocol):
+        @overload
+        def __call__(self, schema: Dict[str, Any]) -> None:
+            pass
+
+        @overload
+        def __call__(self, schema: Dict[str, Any], model: Type['Model']) -> None:
+            pass
+
+        def __call__(self, schema: Dict[str, Any], model: Type['Model'] = None) -> None:
+            pass
+
 
 try:
     import cython  # type: ignore
@@ -89,7 +104,7 @@ class BaseConfig:
     getter_dict: Type[GetterDict] = GetterDict
     alias_generator: Optional[Callable[[str], str]] = None
     keep_untouched: Tuple[type, ...] = ()
-    schema_extra: Union[Dict[str, Any], Callable[[Dict[str, Any]], None]] = {}
+    schema_extra: Union[Dict[str, Any], 'SchemaExtraCallable'] = {}
     json_loads: Callable[[str], Any] = json.loads
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[AnyType, AnyCallable] = {}

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
         def __call__(self, schema: Dict[str, Any]) -> None:
             pass
 
-        @overload
+        @overload  # noqa: F811
         def __call__(self, schema: Dict[str, Any], model_class: Type['Model']) -> None:  # noqa: F811
             pass
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -60,10 +60,10 @@ if TYPE_CHECKING:
             pass
 
         @overload  # noqa: F811
-        def __call__(self, schema: Dict[str, Any], model: Type['Model']) -> None:
+        def __call__(self, schema: Dict[str, Any], model_class: Type['Model']) -> None:
             pass
 
-        def __call__(self, schema: Dict[str, Any], model: Type['Model'] = None) -> None:  # noqa: F811
+        def __call__(self, schema: Dict[str, Any], model_class: Type['Model'] = None) -> None:  # noqa: F811
             pass
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
             pass
 
         @overload  # noqa: F811
-        def __call__(self, schema: Dict[str, Any], model_class: Type['Model']) -> None:
+        def __call__(self, schema: Dict[str, Any], model_class: Type['Model']) -> None:  # noqa: F811
             pass
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -63,9 +63,6 @@ if TYPE_CHECKING:
         def __call__(self, schema: Dict[str, Any], model_class: Type['Model']) -> None:
             pass
 
-        def __call__(self, schema: Dict[str, Any], model_class: Type['Model'] = None) -> None:  # noqa: F811
-            pass
-
 
 try:
     import cython  # type: ignore

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -44,8 +44,8 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from inspect import Signature
     import typing_extensions
+    from inspect import Signature
     from .class_validators import ValidatorListDict
     from .types import ModelOrDc
     from .typing import CallableGenerator, TupleGenerator, DictStrAny, DictAny, SetStr
@@ -59,11 +59,11 @@ if TYPE_CHECKING:
         def __call__(self, schema: Dict[str, Any]) -> None:
             pass
 
-        @overload
+        @overload  # noqa: F811
         def __call__(self, schema: Dict[str, Any], model: Type['Model']) -> None:
             pass
 
-        def __call__(self, schema: Dict[str, Any], model: Type['Model'] = None) -> None:
+        def __call__(self, schema: Dict[str, Any], model: Type['Model'] = None) -> None:  # noqa: F811
             pass
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
         def __call__(self, schema: Dict[str, Any]) -> None:
             pass
 
-        @overload  # noqa: F811
+        @overload
         def __call__(self, schema: Dict[str, Any], model_class: Type['Model']) -> None:  # noqa: F811
             pass
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -467,8 +466,6 @@ def model_process_schema(
     s.update(m_schema)
     schema_extra = model.__config__.schema_extra
     if callable(schema_extra):
-        if not isinstance(schema_extra, FunctionType):
-            raise TypeError(f'{model.__name__}.Config.schema_extra callable is expected to be a staticmethod')
         if len(signature(schema_extra).parameters) == 1:
             schema_extra(s)
         else:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1534,6 +1534,22 @@ def test_model_with_schema_extra_callable_no_model_class():
     assert Model.schema() == {'title': 'Model', 'type': 'override'}
 
 
+def test_model_with_schema_extra_callable_classmethod():
+    class Model(BaseModel):
+        name: str = None
+
+        class Config:
+            type = 'foo'
+
+            @classmethod
+            def schema_extra(cls, schema, model_class):
+                schema.pop('properties')
+                schema['type'] = cls.type
+                assert model_class is Model
+
+    assert Model.schema() == {'title': 'Model', 'type': 'foo'}
+
+
 def test_model_with_extra_forbidden():
     class Model(BaseModel):
         a: str

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1534,20 +1534,6 @@ def test_model_with_schema_extra_callable_no_model_class():
     assert Model.schema() == {'title': 'Model', 'type': 'override'}
 
 
-def test_model_with_schema_extra_callable_classmethod_asserts():
-    class Model(BaseModel):
-        name: str = None
-
-        class Config:
-            @classmethod
-            def schema_extra(cls, schema, model_class):
-                schema.pop('properties')
-                schema['type'] = 'override'
-
-    with pytest.raises(TypeError, match='Model.Config.schema_extra callable is expected to be a staticmethod'):
-        Model.schema()
-
-
 def test_model_with_extra_forbidden():
     class Model(BaseModel):
         a: str

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1550,6 +1550,19 @@ def test_model_with_schema_extra_callable_classmethod():
     assert Model.schema() == {'title': 'Model', 'type': 'foo'}
 
 
+def test_model_with_schema_extra_callable_instance_method():
+    class Model(BaseModel):
+        name: str = None
+
+        class Config:
+            def schema_extra(schema, model_class):
+                schema.pop('properties')
+                schema['type'] = 'override'
+                assert model_class is Model
+
+    assert Model.schema() == {'title': 'Model', 'type': 'override'}
+
+
 def test_model_with_extra_forbidden():
     class Model(BaseModel):
         a: str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Allow `schema_extra` to be a classmethod.

<!-- Please give a short summary of the changes. -->

## Related issue number
Resolves #1305

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
