### PR TITLE
accept None as value for all optional fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ env37/
 env38/
 *.py[cod]
 *.egg-info/
+.python-version
 /build/
 dist/
 .cache/

--- a/changes/1307-prettywood.md
+++ b/changes/1307-prettywood.md
@@ -1,0 +1,1 @@
+Allow `None` as input to all optional list fields

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     from .dataclasses import DataclassType  # noqa: F401
     from .main import BaseModel, BaseConfig  # noqa: F401
     from .typing import CallableGenerator
+    from .fields import ModelField
 
     ModelOrDc = Type[Union['BaseModel', 'DataclassType']]
 
@@ -129,7 +130,7 @@ class ConstrainedList(list):  # type: ignore
         update_not_none(field_schema, minItems=cls.min_items, maxItems=cls.max_items)
 
     @classmethod
-    def list_length_validator(cls, v: 'Optional[List[T]]', field: 'ModelField') -> 'Optional[List[T]]':  # type: ignore[name-defined] # noqa: E501,F821
+    def list_length_validator(cls, v: 'Optional[List[T]]', field: 'ModelField') -> 'Optional[List[T]]':
         if v is None and not field.required:
             return None
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -122,7 +122,6 @@ class ConstrainedList(list):  # type: ignore
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
-        yield list_validator
         yield cls.list_length_validator
 
     @classmethod
@@ -130,7 +129,11 @@ class ConstrainedList(list):  # type: ignore
         update_not_none(field_schema, minItems=cls.min_items, maxItems=cls.max_items)
 
     @classmethod
-    def list_length_validator(cls, v: 'List[T]') -> 'List[T]':
+    def list_length_validator(cls, v: 'Optional[List[T]]', field: 'ModelField') -> 'Optional[List[T]]':  # type: ignore[name-defined] # noqa: E501,F821
+        if v is None and not field.required:
+            return None
+
+        v = list_validator(v)
         v_len = len(v)
 
         if cls.min_items is not None and v_len < cls.min_items:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import sys
 from enum import Enum
 from typing import Any, Callable, ClassVar, List, Mapping, Type
 from uuid import UUID, uuid4
@@ -1027,6 +1028,7 @@ def test_default_factory():
     assert m.uid is uuid4
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='field constraints are set but not enforced with python 3.6')
 def test_none_min_max_items():
     # None default
     class Foo(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1025,3 +1025,20 @@ def test_default_factory():
 
     m = FunctionModel()
     assert m.uid is uuid4
+
+
+def test_none_min_max_items():
+    # None default
+    class Foo(BaseModel):
+        foo: List = Field(None)
+        bar: List = Field(None, min_items=0)
+        baz: List = Field(None, max_items=10)
+
+    f1 = Foo()
+    f2 = Foo(bar=None)
+    f3 = Foo(baz=None)
+    f4 = Foo(bar=None, baz=None)
+    for f in (f1, f2, f3, f4):
+        assert f.foo is None
+        assert f.bar is None
+        assert f.baz is None


### PR DESCRIPTION
## Change Summary

All optional list fields with `None` as value should be valid except if there is a custom validation
to handle this case.

ℹ️  **Test skipped on python 3.6**
```
        if unused_constraints:
            raise ValueError(
>               f'On field "{field_name}" the following field constraints are set but not enforced: '
                f'{", ".join(unused_constraints)}. '
                f'\nFor more details see https://pydantic-docs.helpmanual.io/usage/schema/#unenforced-field-constraints'
            )
E           ValueError: On field "bar" the following field constraints are set but not enforced: min_items. 
E           For more details see https://pydantic-docs.helpmanual.io/usage/schema/#unenforced-field-constraints
```

## Related issue number

closes #1295

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
