### PR TITLE
Fix for pytest 5.4.X

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,8 +7,8 @@ isort==4.3.21
 mypy==0.770
 pycodestyle==2.5.0
 pyflakes==2.1.1
-pytest==5.3.5
+pytest==5.4.1
 pytest-cov==2.8.1
 pytest-mock==3.1.0
-pytest-sugar==0.9.2
+pytest-sugar==0.9.3
 twine==3.1.1

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -713,7 +713,7 @@ def test_assert_raises_validation_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    injected_by_pytest = "\nassert 'snap' == 'a'\n  - snap\n  + a"
+    injected_by_pytest = "\nassert 'snap' == 'a'\n  - a\n  + snap"
     assert exc_info.value.errors() == [
         {'loc': ('a',), 'msg': f'invalid a{injected_by_pytest}', 'type': 'assertion_error'}
     ]


### PR DESCRIPTION
## Change Summary

PyTest 5.4.0 changed a couple things that break current tests.

- The first, noted with https://github.com/samuelcolvin/pydantic/pull/1308#issuecomment-599005987 , is that Pytest flipped the plus/minus signs for it's extended diffs,
- The second, is that it changed the API slightly, which means running pytest-sugar 0.9.2 (Released 2018-11-08!) results in an `AttributeError`:

```
❯ pytest
INTERNALERROR> Traceback (most recent call last):
...
INTERNALERROR>   File "/Users/step7212/.pyenv/versions/pydantic-test/lib/python3.8/site-packages/pytest_sugar.py", line 214, in __init__
INTERNALERROR>     self.writer = self._tw
INTERNALERROR> AttributeError: can't set attribute
```

The open PR [#188](https://github.com/Teemu/pytest-sugar/pull/188) fixes that, and it has been released as 0.9.3, so the reference has been updated.

## Related issue number

Supersedes #1308/Closes #1314

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
