### PR TITLE
add SecretStr and SecretBytes to the default json encoder.

### DIFF
--- a/changes/1313-atheuz.md
+++ b/changes/1313-atheuz.md
@@ -1,0 +1,1 @@
+add SecretStr and SecretBytes to the default json encoder.

--- a/docs/examples/types_secret_types.py
+++ b/docs/examples/types_secret_types.py
@@ -9,6 +9,9 @@ sm = SimpleModel(password='IAmSensitive', password_bytes=b'IAmSensitiveBytes')
 # Standard access methods will not display the secret
 print(sm)
 print(sm.password)
+print(sm.dict())
+
+# json() will however display the secret:
 print(sm.json())
 
 # Use get_secret_value method to see the secret's content.

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -50,6 +50,10 @@ def pydantic_encoder(obj: Any) -> Any:
         return obj.value
     elif isinstance(obj, Path):
         return str(obj)
+    elif isinstance(obj, SecretStr):
+        return obj.get_secret_value() if obj else None
+    elif isinstance(obj, SecretBytes):
+        return obj.get_secret_value() if obj else None
     elif is_dataclass(obj):
         return asdict(obj)
 


### PR DESCRIPTION
## Change Summary

* add SecretStr and SecretBytes to the default json encoder.

#596 discusses making SecretStr, SecretBytes .json() dumpable such that we get the proper value out of it when calling it.
This PR changes the default json encoder such that it properly output SecretStr and SecretBytes.
Further also updates the documentation.

## Related issue number

#596 

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/1313-atheuz.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
