### PR TITLE
Fix: Passing generator when recreating sequence-like field value

### DIFF
--- a/changes/1316-hongquan.md
+++ b/changes/1316-hongquan.md
@@ -1,0 +1,1 @@
+Fix: Passing generator when recreating sequence-like field value

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -621,19 +621,21 @@ class BaseModel(metaclass=ModelMetaclass):
 
         elif sequence_like(v):
             return type(v)(
-                cls._get_value(
-                    v_,
-                    to_dict=to_dict,
-                    by_alias=by_alias,
-                    exclude_unset=exclude_unset,
-                    exclude_defaults=exclude_defaults,
-                    include=value_include and value_include.for_element(i),
-                    exclude=value_exclude and value_exclude.for_element(i),
-                    exclude_none=exclude_none,
+                tuple(
+                    cls._get_value(
+                        v_,
+                        to_dict=to_dict,
+                        by_alias=by_alias,
+                        exclude_unset=exclude_unset,
+                        exclude_defaults=exclude_defaults,
+                        include=value_include and value_include.for_element(i),
+                        exclude=value_exclude and value_exclude.for_element(i),
+                        exclude_none=exclude_none,
+                    )
+                    for i, v_ in enumerate(v)
+                    if (not value_exclude or not value_exclude.is_excluded(i))
+                    and (not value_include or value_include.is_included(i))
                 )
-                for i, v_ in enumerate(v)
-                if (not value_exclude or not value_exclude.is_excluded(i))
-                and (not value_include or value_include.is_included(i))
             )
 
         else:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,6 +15,7 @@ from typing import (
     Iterator,
     List,
     MutableSet,
+    NamedTuple,
     NewType,
     Optional,
     Pattern,
@@ -2100,3 +2101,20 @@ def test_bytesize_raises():
     m = Model(size='1MB')
     with pytest.raises(errors.InvalidByteSizeUnit, match='byte unit'):
         m.size.to('bad_unit')
+
+
+def test_export_namedtuple_enum():
+    class Province(NamedTuple):
+        name: str
+        code: int
+
+    class ProvinceEnum(Province, Enum):
+        P_1 = Province(name='Hà Nội', code=1)
+        P_77 = Province(name='Bà Rịa - Vũng Tàu', code=77)
+
+    class Address(BaseModel):
+        province: ProvinceEnum
+
+    a = Address(province=ProvinceEnum.P_77)
+    export = a.dict()
+    assert export == {'province': ProvinceEnum.P_77}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Before this fix, calling `obj.dict()` where an attribute of `obj` is namedtuple raise error like this:

```py
ValueError: <generator object BaseModel._get_value.<locals>.<genexpr> at 0x7f54af603a50> is not a valid XXX
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
