### PR TITLE
Have BaseModel inherit from Representation

### DIFF
--- a/changes/1310-FuegoFro.md
+++ b/changes/1310-FuegoFro.md
@@ -1,0 +1,1 @@
+Have `BaseModel` inherit from `Representation` to make mypy happy when overriding `__str__`.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -307,7 +307,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         __signature__: 'Signature'
 
     Config = BaseConfig
-    __slots__ = ('__fields_set__',)
+    __slots__ = ('__dict__', '__fields_set__')
     __doc__ = ''  # Null out the Representation docstring
 
     def __init__(__pydantic_self__, **data: Any) -> None:

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -220,6 +220,8 @@ class Representation:
     of objects.
     """
 
+    __slots__: Tuple[str, ...] = tuple()
+
     def __repr_args__(self) -> 'ReprArgs':
         """
         Returns the attributes to show in __str__, __repr__, and __pretty__ this is generally overridden.

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -16,6 +16,9 @@ from pydantic.generics import GenericModel
 class Flags(BaseModel):
     strict_bool: StrictBool = False
 
+    def __str__(self) -> str:
+        return f'flag={self.strict_bool}'
+
 
 class Model(BaseModel):
     age: int


### PR DESCRIPTION
This changes the inheritance so that `BaseModel` *actually* inherits from `Representation`, rather than just having the same methods as it. While this doesn't actually affect the runtime, it does make mypy happier.

Fixes https://github.com/samuelcolvin/pydantic/issues/1310

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)