### PR TITLE
document making secret types dumpable using the json method

### DIFF
--- a/changes/1328-atheuz.md
+++ b/changes/1328-atheuz.md
@@ -1,0 +1,1 @@
+document making secret types dumpable using the json method

--- a/docs/examples/types_secret_types.py
+++ b/docs/examples/types_secret_types.py
@@ -9,6 +9,7 @@ sm = SimpleModel(password='IAmSensitive', password_bytes=b'IAmSensitiveBytes')
 # Standard access methods will not display the secret
 print(sm)
 print(sm.password)
+print(sm.dict())
 print(sm.json())
 
 # Use get_secret_value method to see the secret's content.
@@ -19,3 +20,26 @@ try:
     SimpleModel(password=[1, 2, 3], password_bytes=[1, 2, 3])
 except ValidationError as e:
     print(e)
+
+# If you want the secret to be dumped as plain-text using the json method,
+# you can use json_encoders in the Config class.
+class SimpleModelDumpable(BaseModel):
+    password: SecretStr
+    password_bytes: SecretBytes
+
+    class Config:
+        json_encoders = {
+            SecretStr: lambda v: v.get_secret_value() if v else None,
+            SecretBytes: lambda v: v.get_secret_value() if v else None,
+        }
+
+sm2 = SimpleModelDumpable(password='IAmSensitive', 
+                          password_bytes=b'IAmSensitiveBytes')
+
+# Standard access methods will not display the secret
+print(sm2)
+print(sm2.password)
+print(sm2.dict())
+
+# But the json method will
+print(sm2.json())


### PR DESCRIPTION
## Change Summary

document making secret types dumpable using the json method, 
using json_encoders in the Config class.

## Related issue number
It will partially resolve #596

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/1328-atheuz.md` file added describing change
