### PR TITLE
Remove typing-extension dependency on python 3.8

### DIFF
--- a/changes/1342-prettywood.md
+++ b/changes/1342-prettywood.md
@@ -1,0 +1,1 @@
+Remove `typing_extensions` dependency for python 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@
 devtools==0.5.1
 email-validator==1.0.5
 dataclasses==0.6; python_version < '3.7'
-typing-extensions==3.7.4.1
+typing-extensions==3.7.4.1; python_version < '3.8'
 python-dotenv==0.12.0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -61,11 +61,6 @@ try:
 except ImportError:
     email_validator = None
 
-try:
-    import typing_extensions
-except ImportError:
-    typing_extensions = None
-
 
 def test_key():
     class ApplePie(BaseModel):
@@ -1459,7 +1454,7 @@ def test_new_type_schema():
     }
 
 
-@pytest.mark.skipif(not typing_extensions, reason='typing_extensions not installed')
+@pytest.mark.skipif(not Literal, reason='typing_extensions not installed and python version < 3.8')
 def test_literal_schema():
     class Model(BaseModel):
         a: Literal[1]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Remove `typing_extensions` dependency for python 3.8

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
