### PR TITLE
Add `many` argument to `parse_*` methods to serialize lists easily

### DIFF
--- a/changes/1225-prettywood.md
+++ b/changes/1225-prettywood.md
@@ -1,0 +1,1 @@
+Add `many` argument to `parse_*` methods to serialize lists easily

--- a/docs/examples/models_parse.py
+++ b/docs/examples/models_parse.py
@@ -10,6 +10,13 @@ class User(BaseModel):
 m = User.parse_obj({'id': 123, 'name': 'James'})
 print(m)
 
+users = [
+    {'id': 123, 'name': 'James'},
+    {'id': 17, 'name': 'Bob'}
+]
+m = User.parse_obj(users, many=True)
+print(m[1])
+
 try:
     User.parse_obj(['not', 'a', 'dict'])
 except ValidationError as e:

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -225,6 +225,8 @@ _(This script is complete, it should run "as is")_
 * **`parse_file`**: this reads a file and passes the contents to `parse_raw`. If `content_type` is omitted,
   it is inferred from the file's extension.
 
+If you want to parse a list of objects, just set `many=True`.
+
 ```py
 {!.tmp_examples/models_parse.py!}
 ```


### PR DESCRIPTION
## Change Summary
Just add a `many` argument to the parsers to serialize lists

## Related issue number

closes #1225

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
