### PR TITLE
Replace exception to silent passing in mypy plugin for non-Var attributes

### DIFF
--- a/changes/1345-b0g3r.md
+++ b/changes/1345-b0g3r.md
@@ -1,0 +1,1 @@
+Replace raising of exception to silent passing  for non-Var attributes in mypy plugin

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -246,7 +246,8 @@ class PydanticModelTransformer:
                 # Basically, it is an edge case when dealing with complex import logic
                 # This is the same logic used in the dataclasses plugin
                 continue
-            assert isinstance(node, Var)
+            if not isinstance(node, Var):
+                continue
 
             # x: ClassVar[int] is ignored by dataclasses.
             if node.is_classvar:

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Union
 
 from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass
@@ -119,3 +119,7 @@ class AddProject:
 
 
 p = AddProject(name='x', slug='y', description='z')
+
+
+class TypeAliasAsAttribute(BaseModel):
+    __type_alias_attribute__ = Union[str, bytes]

--- a/tests/mypy/outputs/plugin-success-strict.txt
+++ b/tests/mypy/outputs/plugin-success-strict.txt
@@ -1,3 +1,4 @@
 29: error: Unexpected keyword argument "z" for "Model"  [call-arg]
 64: error: Untyped fields disallowed  [pydantic-field]
 79: error: Argument "x" to "OverrideModel" has incompatible type "float"; expected "int"  [arg-type]
+125: error: Untyped fields disallowed  [pydantic-field]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Mypy plugin breaks with an exception if I store TypeAlias in model attributes, e.g.:

```python
from typing import Union
from pydantic import BaseModel

class NotTrivialAttrubute(BaseModel):
    trivial: str
    __internal__ = Union[str, bytes]
```


<!-- Please give a short summary of the changes. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
