### PR TITLE
Fix argument name collision

### DIFF
--- a/changes/1367-kittipatv.md
+++ b/changes/1367-kittipatv.md
@@ -1,0 +1,1 @@
+Renaming `model_name` argument of `main.create_model()` to `__model_name` to allow using `model_name` as a field name.

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -48,7 +48,7 @@ class GenericModel(BaseModel):
         created_model = cast(
             Type[GenericModel],  # casting ensures mypy is aware of the __concrete__ and __parameters__ attributes
             create_model(
-                model_name=model_name,
+                __model_name=model_name,
                 __module__=cls.__module__,
                 __base__=cls,
                 __config__=None,

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -48,7 +48,7 @@ class GenericModel(BaseModel):
         created_model = cast(
             Type[GenericModel],  # casting ensures mypy is aware of the __concrete__ and __parameters__ attributes
             create_model(
-                __model_name=model_name,
+                model_name,
                 __module__=cls.__module__,
                 __base__=cls,
                 __config__=None,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -757,7 +757,7 @@ class BaseModel(metaclass=ModelMetaclass):
 
 
 def create_model(
-    model_name: str,
+    __model_name: str,
     *,
     __config__: Type[BaseConfig] = None,
     __base__: Type[BaseModel] = None,
@@ -767,7 +767,7 @@ def create_model(
 ) -> Type[BaseModel]:
     """
     Dynamically create a model.
-    :param model_name: name of the created model
+    :param __model_name: name of the created model
     :param __config__: config class to use for the new model
     :param __base__: base class for the new model to inherit from
     :param __validators__: a dict of method names and @validator class methods
@@ -809,7 +809,7 @@ def create_model(
     if __config__:
         namespace['Config'] = inherit_config(__config__, BaseConfig)
 
-    return type(model_name, (__base__,), namespace)
+    return type(__model_name, (__base__,), namespace)
 
 
 _missing = object()

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -23,6 +23,17 @@ def test_simple():
     assert d.b == 10
 
 
+def test_model_name():
+    @pydantic.dataclasses.dataclass
+    class MyDataClass:
+        model_name: str
+
+    d = MyDataClass("foo")
+    assert d.model_name == "foo"
+    d = MyDataClass(model_name="foo")
+    assert d.model_name == "foo"
+
+
 def test_value_error():
     @pydantic.dataclasses.dataclass
     class MyDataclass:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -28,10 +28,10 @@ def test_model_name():
     class MyDataClass:
         model_name: str
 
-    d = MyDataClass("foo")
-    assert d.model_name == "foo"
-    d = MyDataClass(model_name="foo")
-    assert d.model_name == "foo"
+    d = MyDataClass('foo')
+    assert d.model_name == 'foo'
+    d = MyDataClass(model_name='foo')
+    assert d.model_name == 'foo'
 
 
 def test_value_error():


### PR DESCRIPTION
## Change Summary

Renaming `model_name` argument of `main.create_model()` to `__model_name` to allow using `model_name` as a field name.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/1366

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
