### PR TITLE
docs: add hint for custom root types

### DIFF
--- a/docs/examples/models_custom_root_access.py
+++ b/docs/examples/models_custom_root_access.py
@@ -1,0 +1,15 @@
+from typing import List, Dict
+from pydantic import BaseModel, ValidationError
+
+class Pets(BaseModel):
+    __root__: List[str]
+
+    def __iter__(self):
+        return iter(self.__root__)
+
+    def __getitem__(self, item):
+        return self.__root__[item]
+
+pets = Pets.parse_obj(['dog', 'cat'])
+print(pets[0])
+print([pet for pet in pets])

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -385,6 +385,12 @@ This is demonstrated in the following example:
 !!! warning
     Calling the `parse_obj` method on a dict with the single key `"__root__"` for non-mapping custom root types
     is currently supported for backwards compatibility, but is not recommended and may be dropped in a future version.
+    
+If you want to access items in the `__root__` field directly or to iterate over the items, you can implement custom `__iter__` and `__getitem__` functions, as shown in the following example.
+
+```py
+{!.tmp_examples/models_custom_root_access.py!}
+```
 
 ## Faux Immutability
 


### PR DESCRIPTION
## Change Summary

Updated docs regarding the access of `__root__` with custom root types.

## Related issue number

#1372 

## Checklist

* ~Unit tests for the changes exist~
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* ~`changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)~
