### PR TITLE
Update constr regex example to include start and end lines

### DIFF
--- a/changes/1396-lmcnearney.md
+++ b/changes/1396-lmcnearney.md
@@ -1,0 +1,1 @@
+Update constr regex example to include start and end lines

--- a/docs/examples/types_constrained.py
+++ b/docs/examples/types_constrained.py
@@ -20,7 +20,7 @@ class Model(BaseModel):
     strip_bytes: conbytes(strip_whitespace=True)
 
     short_str: constr(min_length=2, max_length=10)
-    regex_str: constr(regex='apple (pie|tart|sandwich)')
+    regex_str: constr(regex='^apple (pie|tart|sandwich)$')
     strip_str: constr(strip_whitespace=True)
 
     big_int: conint(gt=1000, lt=1024)


### PR DESCRIPTION
## Change Summary

This is due to the regex using `re.match()` which allows for only a partial match.

## Related issue number

#1396 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)