### PR TITLE
Fix :: avoid mutating Field default value

### DIFF
--- a/changes/1412-prettywood.md
+++ b/changes/1412-prettywood.md
@@ -1,0 +1,1 @@
+Avoid mutating `Field` default value

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -302,7 +302,7 @@ class ModelField(Representation):
         required: 'BoolUndefined' = Undefined
         if value is Required:
             required = True
-            field_info.default = None
+            value = None
         elif value is not Undefined:
             required = False
         field_info.alias = field_info.alias or field_info_from_config.get('alias')
@@ -312,7 +312,7 @@ class ModelField(Representation):
             type_=annotation,
             alias=field_info.alias,
             class_validators=class_validators,
-            default=field_info.default,
+            default=value,
             default_factory=field_info.default_factory,
             required=required,
             model_config=config,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1095,3 +1095,18 @@ def test_none_min_max_items():
         assert f.foo is None
         assert f.bar is None
         assert f.baz is None
+
+
+def test_reuse_same_field():
+    required_field = Field(...)
+
+    class Model1(BaseModel):
+        required: str = required_field
+
+    class Model2(BaseModel):
+        required: str = required_field
+
+    with pytest.raises(ValidationError):
+        Model1.parse_obj({})
+    with pytest.raises(ValidationError):
+        Model2.parse_obj({})


### PR DESCRIPTION
## Change Summary

#1210 introduced a regression by mutating `default` value of a field.

## Related issue number

fix #1412

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
