### PR TITLE
Fix :: Signature generation with `extra: allow` never uses a field name

### DIFF
--- a/changes/1418-prettywood.md
+++ b/changes/1418-prettywood.md
@@ -1,0 +1,1 @@
+Signature generation with `extra: allow` never uses a field name

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -174,7 +174,9 @@ def generate_model_signature(
 
             # TODO: replace annotation with actual expected types once #1055 solved
             kwargs = {'default': field.default} if not field.required else {}
-            merged_params[param_name] = Parameter(param_name, Parameter.KEYWORD_ONLY, annotation=field.type_, **kwargs)
+            merged_params[param_name] = Parameter(
+                param_name, Parameter.KEYWORD_ONLY, annotation=field.outer_type_, **kwargs
+            )
 
     if config.extra is config.extra.allow:
         use_var_kw = True

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -180,7 +180,12 @@ def generate_model_signature(
         use_var_kw = True
 
     if var_kw and use_var_kw:
-        merged_params[var_kw.name] = var_kw
+        # Make sure the parameter for extra kwargs
+        # does not have the same name as a field
+        var_kw_name = 'extra_data'
+        while var_kw_name in fields:
+            var_kw_name += '_'
+        merged_params[var_kw_name] = var_kw.replace(name=var_kw_name)
 
     return Signature(parameters=list(merged_params.values()), return_annotation=None)
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -184,7 +184,18 @@ def generate_model_signature(
     if var_kw and use_var_kw:
         # Make sure the parameter for extra kwargs
         # does not have the same name as a field
-        var_kw_name = 'extra_data'
+        default_model_signature = [
+            ('__pydantic_self__', Parameter.POSITIONAL_OR_KEYWORD),
+            ('data', Parameter.VAR_KEYWORD),
+        ]
+        if [(p.name, p.kind) for p in present_params] == default_model_signature:
+            # if this is the standard model signature, use extra_data as the extra args name
+            var_kw_name = 'extra_data'
+        else:
+            # else start from var_kw
+            var_kw_name = var_kw.name
+
+        # generate a name that's definitely unique
         while var_kw_name in fields:
             var_kw_name += '_'
         merged_params[var_kw_name] = var_kw.replace(name=var_kw_name)

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -1,5 +1,5 @@
 from inspect import signature
-from typing import Any, Iterable, Union
+from typing import Any, Dict, Iterable, Union
 
 from pydantic import BaseModel, Extra, Field, create_model
 
@@ -99,10 +99,10 @@ def test_extra_allow():
     assert _equals(str(signature(Model)), '(*, data: str, foo: str, **extra_data: Any) -> None')
 
     class Model(BaseModel):
-        extra_data: str
+        extra_data: Dict[str, str]
         foo: str
 
         class Config:
             extra = Extra.allow
 
-    assert _equals(str(signature(Model)), '(*, extra_data: str, foo: str, **extra_data_: Any) -> None')
+    assert _equals(str(signature(Model)), '(*, extra_data: Dict[str, str], foo: str, **extra_data_: Any) -> None')


### PR DESCRIPTION
## Change Summary
When a model was created with `extra: allow`, the `generate_model_signature` would add the `kwargs` parameter with name `data` coming from `BaseModel.__init__`.
This fix makes the name a bit more explicit (`extra_data` by default) and adds as many trailing `_` as needed to be sure the name is available.

## Related issue number
fix #1418

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
