### PR TITLE
ConstrainedFloat schema: differences between IEEE floats and json

### DIFF
--- a/changes/1417-vdwees.md
+++ b/changes/1417-vdwees.md
@@ -1,0 +1,4 @@
+
+Modify schema constraints on ConstrainedFloat so that exclusiveMinimum and
+minimum are not included in the schema if they are equal to `-math.inf` and
+exclusiveMaximum and maximum are not included if they are equal to `math.inf.

--- a/changes/1417-vdwees.md
+++ b/changes/1417-vdwees.md
@@ -1,3 +1,3 @@
 Modify schema constraints on `ConstrainedFloat` so that `exclusiveMinimum` and
 minimum are not included in the schema if they are equal to `-math.inf` and
-exclusiveMaximum and maximum are not included if they are equal to `math.inf.
+`exclusiveMaximum` and `maximum` are not included if they are equal to `math.inf`.

--- a/changes/1417-vdwees.md
+++ b/changes/1417-vdwees.md
@@ -1,3 +1,3 @@
-Modify schema constraints on ConstrainedFloat so that exclusiveMinimum and
+Modify schema constraints on `ConstrainedFloat` so that `exclusiveMinimum` and
 minimum are not included in the schema if they are equal to `-math.inf` and
 exclusiveMaximum and maximum are not included if they are equal to `math.inf.

--- a/changes/1417-vdwees.md
+++ b/changes/1417-vdwees.md
@@ -1,4 +1,3 @@
-
 Modify schema constraints on ConstrainedFloat so that exclusiveMinimum and
 minimum are not included in the schema if they are equal to `-math.inf` and
 exclusiveMaximum and maximum are not included if they are equal to `math.inf.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -234,7 +234,7 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
         f_schema['const'] = field.default
     if field.field_info.extra:
         f_schema.update(field.field_info.extra)
-    modify_schema = getattr(field.outer_type_, '__modify_schema__', None)
+    modify_schema = getattr(field.type_, '__modify_schema__', None)
     if modify_schema:
         modify_schema(f_schema)
     return f_schema

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -234,6 +234,9 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
         f_schema['const'] = field.default
     if field.field_info.extra:
         f_schema.update(field.field_info.extra)
+    modify_schema = getattr(field.outer_type_, '__modify_schema__', None)
+    if modify_schema:
+        modify_schema(f_schema)
     return f_schema
 
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -340,7 +340,7 @@ class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
             maximum=cls.le,
             multipleOf=cls.multiple_of,
         )
-        # Modify constraints to account for differences between IEEE floats and json
+        # Modify constraints to account for differences between IEEE floats and JSON
         if field_schema.get('exclusiveMinimum') == -math.inf:
             del field_schema['exclusiveMinimum']
         if field_schema.get('minimum') == -math.inf:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -340,25 +340,7 @@ class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
             maximum=cls.le,
             multipleOf=cls.multiple_of,
         )
-        cls._schema_ieee_compatibility_transform(field_schema)
-
-    @classmethod
-    def __get_validators__(cls) -> 'CallableGenerator':
-        yield strict_float_validator if cls.strict else float_validator
-        yield number_size_validator
-        yield number_multiple_validator
-
-    @classmethod
-    def _schema_ieee_compatibility_transform(cls, field_schema: Dict[Any, Any]) -> None:
-        """
-        Modify constraints to account for differences between IEEE floats and json
-
-        Transformations applied:
-        - remove field exclusiveMinimum if it is equal to `-math.inf`
-        - remove field minimum if it is equal to `-math.inf`
-        - remove field exclusiveMaximum if it is equal to `math.inf`
-        - remove field maximum if it is equal to `math.inf`
-        """
+        # Modify constraints to account for differences between IEEE floats and json
         if field_schema.get('exclusiveMinimum') == -math.inf:
             del field_schema['exclusiveMinimum']
         if field_schema.get('minimum') == -math.inf:
@@ -367,6 +349,12 @@ class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
             del field_schema['exclusiveMaximum']
         if field_schema.get('maximum') == math.inf:
             del field_schema['maximum']
+
+    @classmethod
+    def __get_validators__(cls) -> 'CallableGenerator':
+        yield strict_float_validator if cls.strict else float_validator
+        yield number_size_validator
+        yield number_multiple_validator
 
 
 def confloat(

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -350,7 +350,8 @@ class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
 
     @classmethod
     def _schema_ieee_compatibility_transform(cls, field_schema: Dict[Any, Any]) -> None:
-        """Modify constraints to account for differences between IEEE floats and json
+        """
+        Modify constraints to account for differences between IEEE floats and json
 
         Transformations applied:
         - remove field exclusiveMinimum if it is equal to `-math.inf`

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,4 @@
+import math
 import os
 import sys
 import tempfile
@@ -1119,6 +1120,10 @@ def test_dict_default():
         ({'lt': 5}, float, {'type': 'number', 'exclusiveMaximum': 5}),
         ({'ge': 2}, float, {'type': 'number', 'minimum': 2}),
         ({'le': 5}, float, {'type': 'number', 'maximum': 5}),
+        ({'gt': -math.inf}, float, {'type': 'number'}),
+        ({'lt': math.inf}, float, {'type': 'number'}),
+        ({'ge': -math.inf}, float, {'type': 'number'}),
+        ({'le': math.inf}, float, {'type': 'number'}),
         ({'multiple_of': 5}, float, {'type': 'number', 'multipleOf': 5}),
         ({'gt': 2}, Decimal, {'type': 'number', 'exclusiveMinimum': 2}),
         ({'lt': 5}, Decimal, {'type': 'number', 'exclusiveMaximum': 5}),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Modify constraints on ConstrainedFloat schema to account for differences between IEEE floats and json

Transformations applied:
- remove field exclusiveMinimum if it is equal to `-math.inf`
- remove field minimum if it is equal to `-math.inf`
- remove field exclusiveMaximum if it is equal to `math.inf`
- remove field maximum if it is equal to `math.inf`


## Related issue number

#1417 

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
