### PR TITLE
include format with secret types

### DIFF
--- a/changes/1424-atheuz.md
+++ b/changes/1424-atheuz.md
@@ -1,0 +1,1 @@
+include format with secret types #546

--- a/changes/1424-atheuz.md
+++ b/changes/1424-atheuz.md
@@ -1,1 +1,1 @@
-include format with secret types #546
+include `'format': 'password'` in the schema for secret types

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -531,6 +531,7 @@ class SecretStr:
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         field_schema.update(type='string', writeOnly=True)
+        field_schema.update(type='string', format='password')
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
@@ -567,6 +568,7 @@ class SecretBytes:
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         field_schema.update(type='string', writeOnly=True)
+        field_schema.update(type='string', format='password')
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -530,8 +530,7 @@ class Json(metaclass=JsonMeta):
 class SecretStr:
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
-        field_schema.update(type='string', writeOnly=True)
-        field_schema.update(type='string', format='password')
+        field_schema.update(type='string', writeOnly=True, format='password')
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
@@ -567,8 +566,7 @@ class SecretStr:
 class SecretBytes:
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
-        field_schema.update(type='string', writeOnly=True)
-        field_schema.update(type='string', format='password')
+        field_schema.update(type='string', writeOnly=True, format='password')
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -579,7 +579,7 @@ def test_secret_types(field_type, inner_type):
     base_schema = {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': inner_type, 'writeOnly': True}},
+        'properties': {'a': {'title': 'A', 'type': inner_type, 'writeOnly': True, 'format': 'password'}},
         'required': ['a'],
     }
 


### PR DESCRIPTION
## Change Summary

include 'format': 'password' in the schema for secret types.

## Related issue number

#546 

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/1424-atheuz.md` file added describing change
