### PR TITLE
Fix/model instance signature

### DIFF
--- a/changes/1419-prettywood.md
+++ b/changes/1419-prettywood.md
@@ -1,0 +1,1 @@
+fix `BaseModel` instance signature

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -544,8 +544,8 @@ The generated signature will also respect custom `__init__` functions:
 To be included in the signature, a field's alias or name must be a valid python identifier. 
 *pydantic* prefers aliases over names, but may use field names if the alias is not a valid python identifier. 
 
-If a field's alias and name are both invalid identifiers, a `**data` argument will be added.
-In addition, the `**data` argument will always be present in the signature if `Config.extra` is `Extra.allow`.
+If a field's alias and name are both invalid identifiers, a `**extra_data` argument will be added.
+In addition, the `**extra_data` argument will always be present in the signature if `Config.extra` is `Extra.allow`.
 
 !!! note
     Types in the model signature are the same as declared in model annotations, 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -340,6 +340,13 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         object.__setattr__(__pydantic_self__, '__fields_set__', fields_set)
 
     @no_type_check
+    def __getattribute__(self, name):
+        """Avoid using the __signature__, which was set for the BaseModel class (not the instance)"""
+        if name == '__signature__':
+            raise AttributeError()
+        return super().__getattribute__(name)
+
+    @no_type_check
     def __setattr__(self, name, value):
         if self.__config__.extra is not Extra.allow and name not in self.__fields__:
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -1,6 +1,8 @@
 from inspect import signature
 from typing import Any, Iterable, Union
 
+import pytest
+
 from pydantic import BaseModel, Extra, Field, create_model
 
 
@@ -25,6 +27,8 @@ def test_model_signature():
     assert sig != signature(BaseModel)
     assert _equals(map(str, sig.parameters.values()), ('a: float', 'b: int = 10'))
     assert _equals(str(sig), '(*, a: float, b: int = 10) -> None')
+    with pytest.raises(TypeError):
+        signature(Model(a=1.2))
 
 
 def test_custom_init_signature():
@@ -126,3 +130,14 @@ def test_extra_allow_conflict_custom_signature():
             extra = Extra.allow
 
     assert _equals(str(signature(Model)), '(extra_data: int = 1, **foobar: Any) -> None')
+
+
+def test_callable_model():
+    class Model(BaseModel):
+        foo: str
+
+        def __call__(self, bar: int) -> int:
+            return bar
+
+    assert _equals(str(signature(Model)), '(*, foo: str) -> None')
+    assert _equals(str(signature(Model(foo='pika'))), '(bar: int) -> int')


### PR DESCRIPTION
## Change Summary
When setting `__signature__` on the model class, it would also be used by model instances even if the model instance is not by default a callable. As `__signature__` has the biggest priority in `inspect._signature_from_callable`, the signature would be wrong (it should not exist by default or be the one of `__call__` method if set)

I first had in mind a [solution](https://github.com/PrettyWood/pydantic/commit/e190d71456ff5ba3872157ccfc8488d5e662bd75) to work directly on the metaclass but it was a mess to rebind the main class and it would do a lot of extra work "just" for a signature.
Other libs like `attrs` chose not to rely on `__signature__` but to create on the fly an `__init__` method. It's hacky but it allows `inspect` to keep digging and find either an `__init__` or a `__call__` method and to properly set the signature (this is why the signature is exactly the same as a `dataclass`).

Here is a quick fix that imo is a good solution in the meantime.
It's not heavy, doesn't break anything and still fixes the biggest issue.
I would be glad to have some feedback on this matter ! Is it enough? Should we refacto the way signature is set (soon, in v2, never...) ?

Note: there is a remark in the linked issue about `'self'` missing in `fullargspec`. Unfortunetaly it can't be directly fixed as we use `__signature__`. Usually `inspect._signature_from_callable` can remove `self` thanks to the `skip_bound_arg` argument.
But as we use `__signature__`, it's the same in both cases (`signature` or `fullargspec`)

## Comparison
```python
from dataclasses import dataclass
from inspect import signature, getfullargspec

import attr

from pydantic import BaseModel


@dataclass
class MyDataClass:
    foo: str

    def __call__(self, bar: str):
        pass


@attr.s(kw_only=True)
class MyAttr:
    foo = attr.ib(type=str)

    def __call__(self, bar: str):
        pass


class MyModel(BaseModel):
    foo: str

    def __call__(self, bar: str):
        pass
```
```
------- DATACLASS -------
Class signature         (foo: str) -> None
Instance signature      (bar: str)
Class fullargspec       FullArgSpec(args=['self', 'foo'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={'return': None, 'foo': <class 'str'>})
Instance fullargspec    FullArgSpec(args=['self', 'bar'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={'bar': <class 'str'>})
------- ATTRS -------
Class signature         (*, foo: str) -> None
Instance signature      (bar: str)
Class fullargspec       FullArgSpec(args=['self'], varargs=None, varkw=None, defaults=None, kwonlyargs=['foo'], kwonlydefaults=None, annotations={'return': None, 'foo': <class 'str'>})
Instance fullargspec    FullArgSpec(args=['self', 'bar'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={'bar': <class 'str'>})
------- PYDANTIC -------
Class signature         (*, foo: str) -> None
Instance signature      (bar: str)
Class fullargspec       FullArgSpec(args=[], varargs=None, varkw=None, defaults=None, kwonlyargs=['foo'], kwonlydefaults=None, annotations={'return': None, 'foo': <class 'str'>})
Instance fullargspec    FullArgSpec(args=['self', 'bar'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={'bar': <class 'str'>})
```

## Related issue number

fix #1419

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
