### PR TITLE
Issue1414: wrong behavior of json() method with nested models containing custom root

### DIFF
--- a/changes/1414-silversurfer34.md
+++ b/changes/1414-silversurfer34.md
@@ -1,2 +1,1 @@
-Fix proposal for the issue 1414, wrong behavior of json method when there are nested models with custom root.
-Once the dict is generated, it is parsed and each time an item has the __root__ key, its associated value is attached to the parent key
+Change the behavior of json() method to remove the extra `__root__` keys in the result when using nested models with custom root types

--- a/changes/1414-silversurfer34.md
+++ b/changes/1414-silversurfer34.md
@@ -1,0 +1,2 @@
+Fix proposal for the issue 1414, wrong behavior of json method when there are nested models with custom root.
+Once the dict is generated, it is parsed and each time an item has the __root__ key, its associated value is attached to the parent key

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -438,10 +438,9 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             for k, v in d.items():
                 if isinstance(v, dict):
                     if k is not ROOT_KEY:
-                        if k is not None:
-                            result[k] = reparent_root(v)
-                        else:
-                            return reparent_root(v)
+                        result[k] = reparent_root(v)
+                    else:
+                        return reparent_root(v)
                 else:
                     if k is not ROOT_KEY:
                         result[k] = v
@@ -449,8 +448,8 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                         return v
             return result
 
-        data = reparent_root(data)
-
+        res = reparent_root(data)
+        data = res
         return self.__config__.json_dumps(data, default=encoder, **dumps_kwargs)
 
     @classmethod

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -218,6 +218,23 @@ def test_encode_nested_root():
     )
 
 
+def test_encode_several_nested_root():
+    class PetsAlias(BaseModel):
+        __root__: List[str]
+
+    class Pets(BaseModel):
+        __root__: PetsAlias
+
+    class PetHouse(BaseModel):
+        Animals: Pets
+        Location: str
+
+    assert (
+        PetHouse(**{'Animals': ['dog', 'cat'], 'Location': 'Montpellier'}).json()
+        == '{"Animals": ["dog", "cat"], "Location": "Montpellier"}'
+    )
+
+
 def test_custom_decode_encode():
     load_calls, dump_calls = 0, 0
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -204,6 +204,20 @@ def test_encode_custom_root():
     assert Model(__root__=['a', 'b']).json() == '["a", "b"]'
 
 
+def test_encode_nested_root():
+    class Pets(BaseModel):
+        __root__: List[str]
+
+    class PetHouse(BaseModel):
+        Animals: Pets
+        Location: str
+
+    assert (
+        PetHouse(**{'Animals': ['dog', 'cat'], 'Location': 'Montpellier'}).json()
+        == '{"Animals": ["dog", "cat"], "Location": "Montpellier"}'
+    )
+
+
 def test_custom_decode_encode():
     load_calls, dump_calls = 0, 0
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1432,6 +1432,23 @@ def test_root_nested_model():
     }
 
 
+def test_nested_root_model():
+    class Pets(BaseModel):
+        __root__: List[str]
+
+    class PetHouse(BaseModel):
+        Animals: Pets
+        Location: str
+
+    assert PetHouse.schema() == {
+        'title': 'PetHouse',
+        'type': 'object',
+        'properties': {'Animals': {'$ref': '#/definitions/Pets'}, 'Location': {'title': 'Location', 'type': 'string'}},
+        'required': ['Animals', 'Location'],
+        'definitions': {'Pets': {'title': 'Pets', 'type': 'array', 'items': {'type': 'string'}}},
+    }
+
+
 def test_new_type_schema():
     a_type = NewType('a_type', int)
     b_type = NewType('b_type', a_type)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## 1414
https://github.com/samuelcolvin/pydantic/issues/1414
Fix proposal for the issue 1414, wrong behavior of json method when there are nested models with custom root.
Once the dict is generated, it is parsed and each time an item has the __root__ key, its associated value is attached to the parent key
(Maybe this can be done in a more pythonic way, but with 15 years of C++ I still have bad habits)
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
