### PR TITLE
Fix type checking for TypedDict fields

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -402,8 +402,11 @@ class ModelField(Representation):
         if origin is None:
             # field is not "typing" object eg. Union, Dict, List etc.
             # allow None for virtual superclasses of NoneType, e.g. Hashable
-            if isinstance(self.type_, type) and isinstance(None, self.type_):
-                self.allow_none = True
+            try:
+                if isinstance(self.type_, type) and isinstance(None, self.type_):
+                    self.allow_none = True
+            except TypeError:
+                pass
             return
         if origin is Callable:
             return

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -20,6 +20,12 @@ from pydantic import (
 )
 from pydantic.fields import Field, Schema
 
+try:
+    from typing import TypedDict
+except ImportError:
+    # TypedDict was part of typing-extensions for python<=3.6
+    from typing_extensions import TypedDict
+
 
 def test_str_bytes():
     class Model(BaseModel):
@@ -1531,3 +1537,13 @@ def test_hashable_optional(default):
 
     Model(v=None)
     Model()
+
+
+def test_typeddict():
+    TD = TypedDict('TD', {'a': int})
+
+    class Model(BaseModel):
+        t: TD
+
+    m = Model(t={'a': 42})
+    assert m.t == TD({'a': 42})


### PR DESCRIPTION
## Change Summary

Wraps virtual superclass of NoneType check in try/except to allow for TypedDict fields and adds a corresponding test case.

## Related issue number

Fixes #1430 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
