### PR TITLE
Enums as separate models

### DIFF
--- a/changes/1173-calvinwyoung.md
+++ b/changes/1173-calvinwyoung.md
@@ -1,0 +1,3 @@
+Updates OpenAPI schema generation to output all enums as separate models.
+Instead of inlining the enum values in the model schema, models now use a `$ref`
+property to point to the enum definition.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -240,8 +240,8 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
 
 def get_model_name_map(unique_models: Set[Type['BaseModel']]) -> Dict[Type['BaseModel'], str]:
     """
-    Process a set of models or enums and generate unique names for them to be used as keys in the JSON Schema
-    definitions. By default the names are the same as the class name. But if two models / enums in different Python
+    Process a set of models and generate unique names for them to be used as keys in the JSON Schema
+    definitions. By default the names are the same as the class name. But if two models in different Python
     modules have the same name (e.g. "users.Model" and "items.Model"), the generated names will be
     based on the Python module path for those conflicting models to prevent name collisions.
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -2,7 +2,7 @@ import re
 import warnings
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum, EnumMeta
+from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from typing import (
@@ -523,7 +523,7 @@ def model_type_schema(
     return out_schema, definitions, nested_models
 
 
-def enum_process_schema(enum: EnumMeta) -> Dict[str, Any]:
+def enum_process_schema(enum: Type[Enum]) -> Dict[str, Any]:
     """
     Take a single `enum` and generate its schema.
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -522,7 +522,7 @@ def enum_process_schema(enum: EnumMeta) -> Dict[str, Any]:
 
     This is similar to the ``model_process_schema`` function, but applies to ``Enum`` objects.
     """
-    from inspect import getdoc, signature
+    from inspect import getdoc
 
     schema: Dict[str, Any] = {'title': enum.__name__}
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -2,7 +2,7 @@ import re
 import warnings
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, EnumMeta
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from typing import (
@@ -11,6 +11,7 @@ from typing import (
     Callable,
     Dict,
     FrozenSet,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -89,8 +90,7 @@ def schema(
     clean_models = [get_model(model) for model in models]
     ref_prefix = ref_prefix or default_prefix
     flat_models = get_flat_models_from_models(clean_models)
-    enums = get_enums_from_models(flat_models)
-    model_name_map = get_model_name_map(flat_models | enums)
+    model_name_map = get_model_name_map(flat_models)
     definitions = {}
     output_schema: Dict[str, Any] = {}
     if title:
@@ -128,8 +128,7 @@ def model_schema(
     model = get_model(model)
     ref_prefix = ref_prefix or default_prefix
     flat_models = get_flat_models_from_model(model)
-    enums = get_enums_from_models(flat_models)
-    model_name_map = get_model_name_map(flat_models | enums)
+    model_name_map = get_model_name_map(flat_models)
     model_name = model_name_map[model]
     m_schema, m_definitions, nested_models = model_process_schema(
         model, by_alias=by_alias, model_name_map=model_name_map, ref_prefix=ref_prefix
@@ -239,7 +238,7 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
     return f_schema
 
 
-def get_model_name_map(unique_models: Set[Union[Type['BaseModel'], Enum]]) -> Dict[Union[Type['BaseModel'], Enum], str]:
+def get_model_name_map(unique_models: Set[Type['BaseModel']]) -> Dict[Type['BaseModel'], str]:
     """
     Process a set of models or enums and generate unique names for them to be used as keys in the JSON Schema
     definitions. By default the names are the same as the class name. But if two models / enums in different Python
@@ -252,8 +251,7 @@ def get_model_name_map(unique_models: Set[Union[Type['BaseModel'], Enum]]) -> Di
     name_model_map = {}
     conflicting_names: Set[str] = set()
     for model in unique_models:
-        model_name = model.__name__
-        model_name = re.sub(r'[^a-zA-Z0-9.\-_]', '_', model_name)
+        model_name = normalize_model_name(model.__name__)
         if model_name in conflicting_names:
             model_name = get_long_model_name(model)
             name_model_map[model_name] = model
@@ -345,18 +343,6 @@ def get_flat_models_from_models(models: Sequence[Type['BaseModel']]) -> Set[Type
     for model in models:
         flat_models |= get_flat_models_from_model(model)
     return flat_models
-
-
-def get_enums_from_models(models: Sequence[Type['BaseModel']]) -> Set[Enum]:
-    """
-    Take a list of ``models`` and generate a set with all of the enums in those models.
-    """
-    enums: Set[Type['BaseModel']] = set()
-    for model in models:
-        for field in model.__fields__.values():
-            if lenient_issubclass(field.type_, Enum):
-                enums.add(field.type_)
-    return enums
 
 
 def get_long_model_name(model: Type['BaseModel']) -> str:
@@ -530,7 +516,7 @@ def model_type_schema(
     return out_schema, definitions, nested_models
 
 
-def enum_process_schema(enum: Enum) -> Dict[str, Any]:
+def enum_process_schema(enum: EnumMeta) -> Dict[str, Any]:
     """
     Take a single ``enum`` and generate its schema.
 
@@ -538,15 +524,17 @@ def enum_process_schema(enum: Enum) -> Dict[str, Any]:
     """
     from inspect import getdoc, signature
 
-    s = {'title': enum.__name__}
+    schema: Dict[str, Any] = {'title': enum.__name__}
+
     doc = getdoc(enum)
     if doc:
-        s['description'] = doc
+        schema['description'] = doc
 
     # Add enum values and the enum field type to the schema.
-    s.update({'enum': [item.value for item in enum]})
-    add_field_type_to_schema(enum, s)
-    return s
+    schema.update({'enum': [item.value for item in cast(Iterable[Enum], enum)]})
+    add_field_type_to_schema(enum, schema)
+
+    return schema
 
 
 def field_singleton_sub_fields_schema(
@@ -624,7 +612,7 @@ field_class_to_schema: Tuple[Tuple[Any, Dict[str, Any]], ...] = (
 json_scheme = {'type': 'string', 'format': 'json-string'}
 
 
-def add_field_type_to_schema(field_type: Any, schema: Dict[str, Any]):
+def add_field_type_to_schema(field_type: Any, schema: Dict[str, Any]) -> None:
     """
     Update the given ``schema`` with the type-specific metadata for the given ``field_type``.
 
@@ -687,8 +675,8 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         field_type = literal_value.__class__
         f_schema['const'] = literal_value
 
-    if issubclass(field_type, Enum):
-        model_name = model_name_map[field_type]
+    if isinstance(field_type, EnumMeta):
+        model_name = normalize_model_name(field_type.__name__)
         f_schema = {'$ref': ref_prefix + model_name}
         definitions[model_name] = enum_process_schema(field_type)
     else:
@@ -849,6 +837,11 @@ def get_annotation_from_field_info(annotation: Any, field_info: FieldInfo, field
         )
 
     return ans
+
+
+def normalize_model_name(name: str) -> str:
+    """Normalizes the given model name."""
+    return re.sub(r'[^a-zA-Z0-9.\-_]', '_', name)
 
 
 class SkipField(Exception):

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -526,9 +526,9 @@ def enum_process_schema(enum: EnumMeta) -> Dict[str, Any]:
 
     schema: Dict[str, Any] = {'title': enum.__name__}
 
-    doc = getdoc(enum)
-    if doc:
-        schema['description'] = doc
+    # Python assigns all enums a default docstring value of 'An enumeration', so
+    # all enums will have a description field even if not explicitly provided.
+    schema['description'] = getdoc(enum)
 
     # Add enum values and the enum field type to the schema.
     schema.update({'enum': [item.value for item in cast(Iterable[Enum], enum)]})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -19,6 +19,7 @@ from pydantic.schema import (
     get_flat_models_from_model,
     get_flat_models_from_models,
     get_model_name_map,
+    model_process_schema,
     model_schema,
     schema,
 )
@@ -1776,6 +1777,16 @@ def test_schema_attributes():
             }
         },
     }
+
+
+def test_model_process_schema_enum():
+    class SpamEnum(str, Enum):
+        foo = 'f'
+        bar = 'b'
+
+    model_schema, _, _ = model_process_schema(SpamEnum, model_name_map={})
+    print(model_schema)
+    assert model_schema == {'title': 'SpamEnum', 'description': 'An enumeration.', 'type': 'string', 'enum': ['f', 'b']}
 
 
 def test_path_modify_schema():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1750,6 +1750,8 @@ def test_dataclass():
 
 def test_schema_attributes():
     class ExampleEnum(Enum):
+        """This is a test description."""
+
         gt = 'GT'
         lt = 'LT'
         ge = 'GE'
@@ -1769,7 +1771,7 @@ def test_schema_attributes():
         'definitions': {
             'ExampleEnum': {
                 'title': 'ExampleEnum',
-                'description': 'An enumeration.',
+                'description': 'This is a test description.',
                 'enum': ['GT', 'LT', 'GE', 'LE', 'ML', 'MO', 'RE'],
             }
         },

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -16,7 +16,6 @@ from pydantic.color import Color
 from pydantic.dataclasses import dataclass
 from pydantic.networks import AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, NameEmail, stricturl
 from pydantic.schema import (
-    get_enums_from_models,
     get_flat_models_from_model,
     get_flat_models_from_models,
     get_model_name_map,
@@ -927,26 +926,6 @@ def test_model_name_maps():
         ModelB: 'pydantic_schema_test__moduleb__modelb__Model',
         ModelC: 'pydantic_schema_test__modulec__modelc__Model',
     }
-
-
-def test_get_enums_from_models():
-    class Foo(str, Enum):
-        A = 'A'
-        B = 'B'
-
-    class Bar(str, Enum):
-        C = 'C'
-        D = 'D'
-
-    class ModelA(BaseModel):
-        foo: Foo
-        bar: Bar
-
-    class ModelB(BaseModel):
-        foo: Foo
-
-    enums = get_enums_from_models([ModelA, ModelB])
-    assert enums == set([Foo, Bar])
 
 
 def test_schema_overrides():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This PR updates the OpenAPI schema generation behavior so that all enums are outputted as separate models, following the recipe for [reusable enums](https://swagger.io/docs/specification/data-models/enums/). The primary benefit is to improve support for OpenAPI code generation tools — more on this below.

To illustrate the changes, suppose we have the following models:

```python
class Foo(str, enum.Enum):
    A = 'A'
    B = 'B'

class ModelA(pydantic.BaseModel):
    foo: Foo    

class ModelB(pydantic.BaseModel):
    foo: Foo
```

Prior to this PR, the generated schema would look like the following:

```json
{
    "definitions": {
        "ModelA": {
            "title": "ModelA",
            "type": "object",
            "properties": {
                "foo": {
                    "title": "Foo",
                    "enum": [
                        "A",
                        "B"
                    ],
                    "type": "string"
                }
            },
            "required": [
                "foo"
            ]
        },
        "ModelB": {
            "title": "ModelB",
            "type": "object",
            "properties": {
                "foo": {
                    "title": "Foo",
                    "enum": [
                        "A",
                        "B"
                    ],
                    "type": "string"
                }
            },
            "required": [
                "foo"
            ]
        }
    }
}
```

Notice how the enum values are duplicated in both the `Foo` and `Bar` definitions. As a result, an OpenAPI code generation tool will create 2 definitions of the enum — one for `ModelAFoo` and one for `ModelBFoo`. This is obviously not ideal as it makes it harder to reuse the enum definition in the client code.

With this PR, the generated schema will instead look like this:

```json
{
    "definitions": {
        "Foo": {
            "title": "Foo",
            "enum": [
                "A",
                "B"
            ],
            "type": "string"
        },
        "ModelA": {
            "title": "ModelA",
            "type": "object",
            "properties": {
                "foo": {
                    "$ref": "#/definitions/Foo"
                }
            },
            "required": [
                "foo"
            ]
        },
        "ModelB": {
            "title": "ModelB",
            "type": "object",
            "properties": {
                "foo": {
                    "$ref": "#/definitions/Foo"
                }
            },
            "required": [
                "foo"
            ]
        }
    }
}
```

As a result, an OpenAPI code generation tool will output a single `Foo` enum definition that's referenced by both `ModelA` and `ModelB`.

This PR works seamlessly with fastapi v0.54.1 and with openapi-generator-cli via the `openapitools/openapi-generator-cli` docker image v4.3.0.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/1173

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
