### PR TITLE
1421 Validation: preserve invalid data

### DIFF
--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -81,6 +81,9 @@ not be included in the model schemas. **Note**: this means that attributes on th
 **`json_encoders`**
 : a `dict` used to customise the way types are encoded to JSON; see [JSON Serialisation](exporting_models.md#modeljson)
 
+**`show_input_data`**
+: whether to display invalid input data in case of validation error (default: `False`)
+
 ```py
 {!.tmp_examples/model_config_main.py!}
 ```

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -106,6 +106,7 @@ class BaseConfig:
     json_loads: Callable[[str], Any] = json.loads
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[AnyType, AnyCallable] = {}
+    show_input_data = False
 
     @classmethod
     def get_field_info(cls, name: str) -> Dict[str, Any]:
@@ -854,7 +855,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
         try:
             input_data = validator(cls_, input_data)
         except (ValueError, TypeError, AssertionError) as exc:
-            return {}, set(), ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], cls_)
+            return {}, set(), ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], cls_, input_data)
 
     for name, field in model.__fields__.items():
         if field.type_.__class__ == ForwardRef:
@@ -916,6 +917,6 @@ def validate_model(  # noqa: C901 (ignore complexity)
             break
 
     if errors:
-        return values, fields_set, ValidationError(errors, cls_)
+        return values, fields_set, ValidationError(errors, cls_, input_data)
     else:
         return values, fields_set, None

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -307,6 +307,25 @@ x
     )
 
 
+def test_single_error_with_input_data():
+    class Model(BaseModel):
+        x: int
+
+        class Config:
+            show_input_data = True
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(x='x')
+
+    expected = """\
+1 validation error for Model
+x
+  value is not a valid integer (type=type_error.integer)
+input data
+  {'x': 'x'}"""
+    assert str(exc_info.value) == expected
+
+
 def test_nested_error():
     class NestedModel3(BaseModel):
         x: str
@@ -323,6 +342,31 @@ def test_nested_error():
     expected = [{'loc': ('data1', 0, 'data2', 0, 'x'), 'msg': 'field required', 'type': 'value_error.missing'}]
 
     assert exc_info.value.errors() == expected
+
+
+def test_nested_error_with_input_data():
+    class NestedModel3(BaseModel):
+        x: int
+
+    class NestedModel2(BaseModel):
+        data2: List[NestedModel3]
+
+    class NestedModel1(BaseModel):
+        class Config:
+            show_input_data = True
+
+        data1: List[NestedModel2]
+
+    with pytest.raises(ValidationError) as exc_info:
+        NestedModel1(data1=[{'data2': [{'x': 'x'}]}])
+
+        expected = """\
+    1 validation error for Model
+    x
+      value is not a valid integer (type=type_error.integer)
+    input data
+      {'x': 'x'}"""
+        assert str(exc_info.value) == expected
 
 
 def test_validate_assignment_error():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
## Change Summary

<!-- Please give a short summary of the changes. -->
We introduce a new Model config attribute `show_input_data` (`False` by default) which is the case of being set to True enables invalid data output, i.e.:
```
2 validation errors for TestModel
id
  value is not a valid integer (type=type_error.integer)
age
  value is not a valid integer (type=type_error.integer)
input data
  {'age': 'QQQ', 'id': 'AAA', 'name': 'John'}
```
```
"""
>>> check_exception()
"{'age': 'QQQ', 'id': 'AAA', 'name': 'John'}"
"""

from pydantic import BaseModel, ValidationError

import pytest


class TestModel(BaseModel):
    id: int
    name: str
    age: int

    class Config:
        show_input_data = True


invalid_data = {
    "id": "AAA",
    "name": "John",
    "age": "QQQ"
}


def check_exception():
    with pytest.raises(ValidationError) as exc_info:
        TestModel(**invalid_data)
    return str(exc_info.value).split("input data")[1].strip()
```
## Related issue number
#1421 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
