### PR TITLE
Remove extra allOf keys in schema

### DIFF
--- a/changes/1209-mostaphaRoudsari.md
+++ b/changes/1209-mostaphaRoudsari.md
@@ -1,0 +1,1 @@
+Remove extra `allOf` from schema for fields with `Union` and custom `Field`.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -556,6 +556,11 @@ def field_singleton_sub_fields_schema(
                 known_models=known_models,
             )
             definitions.update(sub_definitions)
+            if schema_overrides and 'allOf' in sub_schema:
+                # if the sub_field is a referenced schema we only need the referenced
+                # object. Otherwise we will end up with several allOf inside anyOf.
+                # See https://github.com/samuelcolvin/pydantic/issues/1209
+                sub_schema = sub_schema['allOf'][0]
             sub_field_schemas.append(sub_schema)
             nested_models.update(sub_nested_models)
         return {'anyOf': sub_field_schemas}, definitions, nested_models

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -959,6 +959,22 @@ def test_schema_overrides():
     }
 
 
+def test_schema_overrides_w_union():
+    class Foo(BaseModel):
+        pass
+
+    class Bar(BaseModel):
+        pass
+
+    class Model_1(BaseModel):
+        a: Union[Foo, Bar]
+
+    class Model_2(BaseModel):
+        a: Union[Foo, Bar] = Field(...)
+
+    assert Model_1.schema()['properties'] == Model_2.schema()['properties']
+
+
 def test_schema_from_models():
     class Foo(BaseModel):
         a: str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
The current implementation of `schema` returns multiple `allOf`s inside `anyOf` when `Union` is used in combination with `Field`. It will work fine with no `Union` which is what is currently included in all the tests.

To address the issue I only collect the referenced object when the schema is generated for a case with multiple sub-fileds and overwrite is True.

See #1209 for a more detailed explanation of the problem.

## Related issue number
resolves #1209

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
