### PR TITLE
Untie a field type and required attrib

### DIFF
--- a/docs/examples/models_generics.py
+++ b/docs/examples/models_generics.py
@@ -1,6 +1,7 @@
 from typing import Generic, TypeVar, Optional, List
 
 from pydantic import BaseModel, validator, ValidationError
+from pydantic.fields import UndefinedType
 from pydantic.generics import GenericModel
 
 DataT = TypeVar('DataT')
@@ -19,10 +20,12 @@ class Response(GenericModel, Generic[DataT]):
 
     @validator('error', always=True)
     def check_consistency(cls, v, values):
-        if v is not None and values['data'] is not None:
-            raise ValueError('must not provide both data and error')
-        if v is None and values.get('data') is None:
-            raise ValueError('must provide data or error')
+        data = values.get('data', None)
+        if not isinstance(data, UndefinedType):
+            if data is None and v is None:
+                raise ValueError('Must provide data or error')
+            elif data is not None and v is not None:
+                raise ValueError('Must not provide both data and error')
         return v
 
 data = DataModel(numbers=[1, 2, 3], people=[])

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -96,7 +96,7 @@ class BaseConfig:
     allow_population_by_field_name = False
     use_enum_values = False
     fields: Dict[str, Union[str, Dict[str, str]]] = {}
-    required_fields: Union[Tuple[str], str] = ()
+    required_fields: Union[Tuple[str, ...], str] = ()
     validate_assignment = False
     error_msg_templates: Dict[str, str] = {}
     arbitrary_types_allowed = False
@@ -139,7 +139,7 @@ class BaseConfig:
             field.required = cls.field_required(field.name)
 
     @classmethod
-    def field_required(cls, field_name) -> bool:
+    def field_required(cls, field_name: str) -> bool:
         if cls.required_fields == ALL_FIELDS:
             return True
         return field_name in cls.required_fields
@@ -849,7 +849,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
     """
     validate data against a model.
     """
-    values = {}
+    values: DictStrAny = {}
     errors = []
     # input_data names, possibly alias
     names_used = set()

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -36,6 +36,7 @@ from .fields import (
     SHAPE_TUPLE_ELLIPSIS,
     FieldInfo,
     ModelField,
+    UndefinedType,
 )
 from .json import pydantic_encoder
 from .networks import AnyUrl, EmailStr
@@ -173,7 +174,10 @@ def field_schema(
         s['description'] = field.field_info.description
         schema_overrides = True
 
-    if not field.required and not field.field_info.const and field.default is not None:
+    if (
+            not field.required and not field.field_info.const
+            and (field.default is not None and not isinstance(field.default, UndefinedType))
+    ):
         s['default'] = encode_default(field.default)
         schema_overrides = True
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -175,8 +175,9 @@ def field_schema(
         schema_overrides = True
 
     if (
-            not field.required and not field.field_info.const
-            and (field.default is not None and not isinstance(field.default, UndefinedType))
+        not field.required
+        and not field.field_info.const
+        and (field.default is not None and not isinstance(field.default, UndefinedType))
     ):
         s['default'] = encode_default(field.default)
         schema_overrides = True

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -4,7 +4,7 @@ from typing import Any, List
 import pytest
 
 from pydantic import BaseModel
-from pydantic.fields import Undefined, UndefinedType
+from pydantic.fields import UndefinedType
 
 
 class Model(BaseModel):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -4,6 +4,7 @@ from typing import Any, List
 import pytest
 
 from pydantic import BaseModel
+from pydantic.fields import Undefined, UndefinedType
 
 
 class Model(BaseModel):
@@ -22,9 +23,8 @@ def test_simple_construct():
 def test_construct_misuse():
     m = Model.construct(b='foobar')
     assert m.b == 'foobar'
+    assert isinstance(m.a, UndefinedType)
     assert m.dict() == {'b': 'foobar'}
-    with pytest.raises(AttributeError, match="'Model' object has no attribute 'a'"):
-        print(m.a)
 
 
 def test_construct_fields_set():

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -19,8 +19,6 @@ def test_create_model_usage():
     assert m.foo == 'hello'
     assert m.bar == 123
     with pytest.raises(ValidationError):
-        model()
-    with pytest.raises(ValidationError):
         model(foo='hello', bar='xxx')
 
 
@@ -58,8 +56,6 @@ def test_custom_config():
     model = create_model('FooModel', foo=(int, ...), __config__=Config)
     assert model(**{'api-foo-field': '987'}).foo == 987
     assert issubclass(model.__config__, BaseModel.Config)
-    with pytest.raises(ValidationError):
-        model(foo=654)
 
 
 def test_custom_config_inherits():
@@ -69,12 +65,11 @@ def test_custom_config_inherits():
     model = create_model('FooModel', foo=(int, ...), __config__=Config)
     assert model(**{'api-foo-field': '987'}).foo == 987
     assert issubclass(model.__config__, BaseModel.Config)
-    with pytest.raises(ValidationError):
-        model(foo=654)
 
 
 def test_custom_config_extras():
     class Config(BaseModel.Config):
+        required_fields = ('foo', )
         extra = Extra.forbid
 
     model = create_model('FooModel', foo=(int, ...), __config__=Config)
@@ -128,11 +123,6 @@ def test_funky_name():
     model = create_model('FooModel', **{'this-is-funky': (int, ...)})
     m = model(**{'this-is-funky': '123'})
     assert m.dict() == {'this-is-funky': 123}
-    with pytest.raises(ValidationError) as exc_info:
-        model()
-    assert exc_info.value.errors() == [
-        {'loc': ('this-is-funky',), 'msg': 'field required', 'type': 'value_error.missing'}
-    ]
 
 
 def test_repeat_base_usage():

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -69,7 +69,7 @@ def test_custom_config_inherits():
 
 def test_custom_config_extras():
     class Config(BaseModel.Config):
-        required_fields = ('foo', )
+        required_fields = ('foo',)
         extra = Extra.forbid
 
     model = create_model('FooModel', foo=(int, ...), __config__=Config)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -23,13 +23,10 @@ def test_args():
     assert foo(*(1, 2)) == '1, 2'
     assert foo(*[1], 2) == '1, 2'
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         foo()
 
-    assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
+    assert exc_info.value.args[0] == 'foo() missing 2 required positional arguments: \'a\' and \'b\''
 
     with pytest.raises(ValidationError) as exc_info:
         foo(1, 'x')
@@ -94,8 +91,6 @@ def test_kwargs():
         foo(1, 'x')
 
     assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
         {'loc': ('args',), 'msg': '0 positional arguments expected but 2 given', 'type': 'type_error'},
     ]
 
@@ -200,9 +195,9 @@ def test_async():
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run())
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         loop.run_until_complete(foo('x'))
-    assert exc_info.value.errors() == [{'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'}]
+    assert exc_info.value.args[0] == 'foo() missing 1 required positional argument: \'b\''
 
 
 def test_string_annotation():
@@ -216,7 +211,6 @@ def test_string_annotation():
         foo(['x'])
     assert exc_info.value.errors() == [
         {'loc': ('a', 0), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
     ]
 
 
@@ -234,13 +228,10 @@ def test_item_method():
     assert x.foo(4, 2) == '4, 2'
     assert x.foo(*[4, 2]) == '4, 2'
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         x.foo()
 
-    assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
+    assert exc_info.value.args[0] == 'foo() missing 2 required positional arguments: \'a\' and \'b\''
 
 
 def test_class_method():
@@ -255,10 +246,7 @@ def test_class_method():
     assert x.foo(4, 2) == '4, 2'
     assert x.foo(*[4, 2]) == '4, 2'
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         x.foo()
 
-    assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
+    assert exc_info.value.args[0] == 'foo() missing 2 required positional arguments: \'a\' and \'b\''

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -197,7 +197,7 @@ def test_async():
     loop.run_until_complete(run())
     with pytest.raises(TypeError) as exc_info:
         loop.run_until_complete(foo('x'))
-    assert exc_info.value.args[0] == "foo() missing 2 required positional arguments: 'b'"
+    assert exc_info.value.args[0] == "foo() missing 1 required positional argument: 'b'"
 
 
 def test_string_annotation():

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -26,7 +26,7 @@ def test_args():
     with pytest.raises(TypeError) as exc_info:
         foo()
 
-    assert exc_info.value.args[0] == 'foo() missing 2 required positional arguments: \'a\' and \'b\''
+    assert exc_info.value.args[0] == "foo() missing 2 required positional arguments: 'a' and 'b'"
 
     with pytest.raises(ValidationError) as exc_info:
         foo(1, 'x')
@@ -197,7 +197,7 @@ def test_async():
     loop.run_until_complete(run())
     with pytest.raises(TypeError) as exc_info:
         loop.run_until_complete(foo('x'))
-    assert exc_info.value.args[0] == 'foo() missing 1 required positional argument: \'b\''
+    assert exc_info.value.args[0] == "foo() missing 2 required positional arguments: 'b'"
 
 
 def test_string_annotation():
@@ -231,7 +231,7 @@ def test_item_method():
     with pytest.raises(TypeError) as exc_info:
         x.foo()
 
-    assert exc_info.value.args[0] == 'foo() missing 2 required positional arguments: \'a\' and \'b\''
+    assert exc_info.value.args[0] == "foo() missing 2 required positional arguments: 'a' and 'b'"
 
 
 def test_class_method():
@@ -249,4 +249,4 @@ def test_class_method():
     with pytest.raises(TypeError) as exc_info:
         x.foo()
 
-    assert exc_info.value.args[0] == 'foo() missing 2 required positional arguments: \'a\' and \'b\''
+    assert exc_info.value.args[0] == "foo() missing 2 required positional arguments: 'a' and 'b'"

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -18,7 +18,7 @@ from pydantic import (
     validate_model,
     validator,
 )
-from pydantic.fields import Field, Schema, Undefined, UndefinedType
+from pydantic.fields import Field, Schema, UndefinedType
 
 
 def test_str_bytes():
@@ -267,7 +267,7 @@ def test_recursive_list_error():
         count: int = None
 
         class Config:
-            required_fields = ('name', )
+            required_fields = ('name',)
 
     class Model(BaseModel):
         v: List[SubModel] = []
@@ -864,7 +864,7 @@ def test_submodel_different_type():
         a: int
 
         class Config:
-            required_fields = ('a', )
+            required_fields = ('a',)
 
     class Bar(BaseModel):
         b: int
@@ -1364,7 +1364,7 @@ def test_required_any():
         nullable1: Any
 
         class Config:
-            required_fields = ('nullable1', )
+            required_fields = ('nullable1',)
 
     with pytest.raises(ValidationError) as exc_info:
         Model()
@@ -1508,7 +1508,7 @@ def test_hashable_required():
         v: Hashable
 
         class Config:
-            required_fields = ('v', )
+            required_fields = ('v',)
 
     Model(v=None)
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -304,7 +304,7 @@ def test_nested_error():
         x: str
 
         class Config:
-            required_fields = ('x', )
+            required_fields = ('x',)
 
     class NestedModel2(BaseModel):
         data2: List[NestedModel3]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -228,6 +228,9 @@ def test_validation_error(result, expected):
         y: int
         z: str
 
+        class Config:
+            required_fields = ('x', 'z')
+
     class Model(BaseModel):
         a: int
         b: SubModel
@@ -295,21 +298,13 @@ x
     assert str(exc_info.value) == expected
     assert str(exc_info.value) == expected  # to check lru cache doesn't break anything
 
-    with pytest.raises(ValidationError) as exc_info:
-        Model()
-
-    assert (
-        str(exc_info.value)
-        == """\
-1 validation error for Model
-x
-  field required (type=value_error.missing)"""
-    )
-
 
 def test_nested_error():
     class NestedModel3(BaseModel):
         x: str
+
+        class Config:
+            required_fields = ('x', )
 
     class NestedModel2(BaseModel):
         data2: List[NestedModel3]

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -35,7 +35,7 @@ class Model(BaseModel):
 """
     )
     assert module.Model(a='123').dict() == {'a': 123}
-    assert module.Model().dict() == {'a': None}
+    assert module.Model().dict() == {}
 
 
 def test_basic_forward_ref(create_module):
@@ -55,7 +55,7 @@ class Bar(BaseModel):
 """
     )
 
-    assert module.Bar().dict() == {'b': None}
+    assert module.Bar().dict() == {}
     assert module.Bar(b={'a': '123'}).dict() == {'b': {'a': 123}}
 
 
@@ -203,6 +203,9 @@ class Node(BaseModel):
     value: int
     left: TreeType
     right: TreeType
+    
+    class Config:
+        required_fields = ('value', 'left', 'right')
 
 
 Node.update_forward_refs()
@@ -282,7 +285,6 @@ Account.update_forward_refs()
                         'items': {'$ref': '#/definitions/Account'},
                     },
                 },
-                'required': ['name'],
             }
         },
     }
@@ -319,7 +321,6 @@ Account.update_forward_refs()
                         'items': {'$ref': '#/definitions/Account'},
                     },
                 },
-                'required': ['name'],
             }
         },
     }
@@ -360,13 +361,11 @@ Owner.update_forward_refs()
                         'items': {'$ref': '#/definitions/Account'},
                     },
                 },
-                'required': ['name', 'owner'],
             },
             'Owner': {
                 'title': 'Owner',
                 'type': 'object',
                 'properties': {'account': {'$ref': '#/definitions/Account'}},
-                'required': ['account'],
             },
         },
     }
@@ -409,13 +408,11 @@ Owner.update_forward_refs()
                         'items': {'$ref': '#/definitions/Account'},
                     },
                 },
-                'required': ['name', 'owner'],
             },
             'Owner': {
                 'title': 'Owner',
                 'type': 'object',
                 'properties': {'account': {'$ref': '#/definitions/Account'}},
-                'required': ['account'],
             },
         },
     }

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -203,7 +203,7 @@ class Node(BaseModel):
     value: int
     left: TreeType
     right: TreeType
-    
+
     class Config:
         required_fields = ('value', 'left', 'right')
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, Ty
 import pytest
 
 from pydantic import BaseModel, Field, ValidationError, root_validator, validator
-from pydantic.fields import Undefined, UndefinedType
+from pydantic.fields import UndefinedType
 from pydantic.generics import GenericModel, _generic_types_cache
 
 skip_36 = pytest.mark.skipif(sys.version_info < (3, 7), reason='generics only supported for python 3.7 and above')
@@ -328,13 +328,15 @@ def test_generic():
 
     success1 = Result[Data, Error](data=[Data(number=1, text='a')], positive_number=1)
     assert success1.dict() == {'data': [{'number': 1, 'text': 'a'}], 'positive_number': 1}
-    assert repr(success1) == ("Result[Data, Error](data=[Data(number=1, text='a')],"
-                              " error=PydanticUndefined, positive_number=1)")
+    assert repr(success1) == (
+        "Result[Data, Error](data=[Data(number=1, text='a')], error=PydanticUndefined, positive_number=1)"
+    )
 
     success2 = Result[Data, Error](error=Error(message='error'), positive_number=1)
     assert success2.dict() == {'error': {'message': 'error'}, 'positive_number': 1}
-    assert repr(success2) == ("Result[Data, Error](data=PydanticUndefined,"
-                              " error=Error(message='error'), positive_number=1)")
+    assert repr(success2) == (
+        "Result[Data, Error](data=PydanticUndefined, error=Error(message='error'), positive_number=1)"
+    )
     with pytest.raises(ValidationError) as exc_info:
         Result[Data, Error](error=Error(message='error'), positive_number=-1)
     assert exc_info.value.errors() == [{'loc': ('positive_number',), 'msg': '', 'type': 'value_error'}]
@@ -389,7 +391,7 @@ def test_required_value():
         a: int
 
         class Config:
-            required_fields = ('a', )
+            required_fields = ('a',)
 
     with pytest.raises(ValidationError) as exc_info:
         MyModel[int]()

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, Ty
 import pytest
 
 from pydantic import BaseModel, Field, ValidationError, root_validator, validator
+from pydantic.fields import Undefined, UndefinedType
 from pydantic.generics import GenericModel, _generic_types_cache
 
 skip_36 = pytest.mark.skipif(sys.version_info < (3, 7), reason='generics only supported for python 3.7 and above')
@@ -304,10 +305,12 @@ def test_generic():
 
         @validator('error', always=True)
         def validate_error(cls, v: Optional[error_type], values: Dict[str, Any]) -> Optional[error_type]:
-            if values.get('data', None) is None and v is None:
-                raise ValueError('Must provide data or error')
-            if values.get('data', None) is not None and v is not None:
-                raise ValueError('Must not provide both data and error')
+            data = values.get('data', None)
+            if not isinstance(data, UndefinedType):
+                if data is None and v is None:
+                    raise ValueError('Must provide data or error')
+                elif data is not None and v is not None:
+                    raise ValueError('Must not provide both data and error')
             return v
 
         @validator('positive_number')
@@ -324,12 +327,14 @@ def test_generic():
         text: str
 
     success1 = Result[Data, Error](data=[Data(number=1, text='a')], positive_number=1)
-    assert success1.dict() == {'data': [{'number': 1, 'text': 'a'}], 'error': None, 'positive_number': 1}
-    assert repr(success1) == "Result[Data, Error](data=[Data(number=1, text='a')], error=None, positive_number=1)"
+    assert success1.dict() == {'data': [{'number': 1, 'text': 'a'}], 'positive_number': 1}
+    assert repr(success1) == ("Result[Data, Error](data=[Data(number=1, text='a')],"
+                              " error=PydanticUndefined, positive_number=1)")
 
     success2 = Result[Data, Error](error=Error(message='error'), positive_number=1)
-    assert success2.dict() == {'data': None, 'error': {'message': 'error'}, 'positive_number': 1}
-    assert repr(success2) == "Result[Data, Error](data=None, error=Error(message='error'), positive_number=1)"
+    assert success2.dict() == {'error': {'message': 'error'}, 'positive_number': 1}
+    assert repr(success2) == ("Result[Data, Error](data=PydanticUndefined,"
+                              " error=Error(message='error'), positive_number=1)")
     with pytest.raises(ValidationError) as exc_info:
         Result[Data, Error](error=Error(message='error'), positive_number=-1)
     assert exc_info.value.errors() == [{'loc': ('positive_number',), 'msg': '', 'type': 'value_error'}]
@@ -382,6 +387,9 @@ def test_required_value():
 
     class MyModel(GenericModel, Generic[T]):
         a: int
+
+        class Config:
+            required_fields = ('a', )
 
     with pytest.raises(ValidationError) as exc_info:
         MyModel[int]()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from pydantic import BaseModel, Extra, Field, NoneBytes, NoneStr, Required, ValidationError, constr
+from pydantic import BaseModel, Extra, Field, NoneBytes, NoneStr, ValidationError, constr
 
 
 def test_success():
@@ -24,7 +24,7 @@ class UltraSimpleModel(BaseModel):
     b: int = 10
 
     class Config:
-        required_fields = ('a', )
+        required_fields = ('a',)
 
 
 def test_ultra_simple_missing():
@@ -328,7 +328,7 @@ def test_required():
         b: int = 10
 
         class Config:
-            required_fields = ('a', )
+            required_fields = ('a',)
 
     m = Model(a=10.2)
     assert m.dict() == dict(a=10.2, b=10)
@@ -419,11 +419,7 @@ def test_const_list():
     assert m.b == [SubModel(b=4), SubModel(b=5), SubModel(b=6)]
     assert m.schema() == {
         'definitions': {
-            'SubModel': {
-                'properties': {'b': {'title': 'B', 'type': 'integer'}},
-                'title': 'SubModel',
-                'type': 'object',
-            }
+            'SubModel': {'properties': {'b': {'title': 'B', 'type': 'integer'}}, 'title': 'SubModel', 'type': 'object'}
         },
         'properties': {
             'a': {
@@ -1105,13 +1101,13 @@ def test_reuse_same_field():
         required: str
 
         class Config:
-            required_fields = ('required', )
+            required_fields = ('required',)
 
     class Model2(BaseModel):
         required: str
 
         class Config:
-            required_fields = ('required', )
+            required_fields = ('required',)
 
     with pytest.raises(ValidationError):
         Model1.parse_obj({})

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -48,8 +48,9 @@ def test_custom_init_signature():
         ('id: int = 1', 'bar=2', 'baz: Any', "name: str = 'John Doe'", f'foo: str = {Undefined}', '**data'),
     )
 
-    assert _equals(str(sig), (f"(id: int = 1, bar=2, *, baz: Any, name: str = 'John Doe',"
-                              f" foo: str = {Undefined}, **data) -> None"))
+    assert _equals(
+        str(sig), f"(id: int = 1, bar=2, *, baz: Any, name: str = 'John Doe', foo: str = {Undefined}, **data) -> None",
+    )
 
 
 def test_custom_init_signature_with_no_var_kw():

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -366,7 +366,6 @@ def test_son():
         'title': 'Model',
         'type': 'object',
         'properties': {'v': {'title': 'V', 'minLength': 1, 'maxLength': 2083, 'type': 'string', 'format': 'uri'}},
-        'required': ['v'],
     }
 
 

--- a/tests/test_orm_mode.py
+++ b/tests/test_orm_mode.py
@@ -2,7 +2,7 @@ from typing import Any, List
 
 import pytest
 
-from pydantic import BaseModel, ConfigError, ValidationError, root_validator
+from pydantic import BaseModel, ConfigError, root_validator
 from pydantic.utils import GetterDict
 
 

--- a/tests/test_orm_mode.py
+++ b/tests/test_orm_mode.py
@@ -111,20 +111,11 @@ def test_object_with_getattr():
         class Config:
             orm_mode = True
 
-    class ModelInvalid(BaseModel):
-        foo: str
-        bar: int
-
-        class Config:
-            orm_mode = True
-
     foo = FooGetAttr()
     model = Model.from_orm(foo)
     assert model.foo == 'Foo'
     assert model.bar == 1
     assert model.dict(exclude_unset=True) == {'foo': 'Foo'}
-    with pytest.raises(ValidationError):
-        ModelInvalid.from_orm(foo)
 
 
 def test_properties():

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -12,7 +12,7 @@ class Model(BaseModel):
     b: int = 10
 
     class Config:
-        required_fields = ('a', )
+        required_fields = ('a',)
 
 
 def test_obj():

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -11,6 +11,9 @@ class Model(BaseModel):
     a: float
     b: int = 10
 
+    class Config:
+        required_fields = ('a', )
+
 
 def test_obj():
     m = Model.parse_obj(dict(a=10.2))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -242,12 +242,7 @@ def test_list_sub_model():
         'title': 'Bar',
         'type': 'object',
         'definitions': {
-            'Foo': {
-                'title': 'Foo',
-                'type': 'object',
-                'properties': {'a': {'type': 'number', 'title': 'A'}},
-
-            }
+            'Foo': {'title': 'Foo', 'type': 'object', 'properties': {'a': {'type': 'number', 'title': 'A'}}}
         },
         'properties': {'b': {'type': 'array', 'items': {'$ref': '#/definitions/Foo'}, 'title': 'B'}},
     }
@@ -385,25 +380,13 @@ class Foo(BaseModel):
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
-        (
-            Union[int, str],
-            {
-                'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
-            },
-        ),
-        (
-            List[int],
-            {'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'}}}},
-        ),
+        (Union[int, str], {'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}}},),
+        (List[int], {'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'}}}},),
         (
             Dict[str, Foo],
             {
                 'definitions': {
-                    'Foo': {
-                        'title': 'Foo',
-                        'type': 'object',
-                        'properties': {'a': {'title': 'A', 'type': 'number'}},
-                    }
+                    'Foo': {'title': 'Foo', 'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'number'}}}
                 },
                 'properties': {
                     'a': {'title': 'A', 'type': 'object', 'additionalProperties': {'$ref': '#/definitions/Foo'}}
@@ -414,11 +397,7 @@ class Foo(BaseModel):
             Union[None, Foo],
             {
                 'definitions': {
-                    'Foo': {
-                        'title': 'Foo',
-                        'type': 'object',
-                        'properties': {'a': {'title': 'A', 'type': 'number'}},
-                    }
+                    'Foo': {'title': 'Foo', 'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'number'}}}
                 },
                 'properties': {'a': {'$ref': '#/definitions/Foo'}},
             },
@@ -902,12 +881,7 @@ def test_schema_overrides():
         'title': 'Model',
         'type': 'object',
         'definitions': {
-            'Foo': {
-                'title': 'Foo',
-                'type': 'object',
-                'properties': {'a': {'title': 'A', 'type': 'string'}},
-
-            },
+            'Foo': {'title': 'Foo', 'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'string'}}},
             'Bar': {
                 'title': 'Bar',
                 'type': 'object',
@@ -957,38 +931,16 @@ def test_schema_from_models():
                         'items': {'$ref': '#/definitions/Ingredient'},
                     },
                 },
-
             },
             'Ingredient': {
                 'title': 'Ingredient',
                 'type': 'object',
                 'properties': {'name': {'title': 'Name', 'type': 'string'}},
-
             },
-            'Model': {
-                'title': 'Model',
-                'type': 'object',
-                'properties': {'d': {'$ref': '#/definitions/Baz'}},
-
-            },
-            'Baz': {
-                'title': 'Baz',
-                'type': 'object',
-                'properties': {'c': {'$ref': '#/definitions/Bar'}},
-
-            },
-            'Bar': {
-                'title': 'Bar',
-                'type': 'object',
-                'properties': {'b': {'$ref': '#/definitions/Foo'}},
-
-            },
-            'Foo': {
-                'title': 'Foo',
-                'type': 'object',
-                'properties': {'a': {'title': 'A', 'type': 'string'}},
-
-            },
+            'Model': {'title': 'Model', 'type': 'object', 'properties': {'d': {'$ref': '#/definitions/Baz'}}},
+            'Baz': {'title': 'Baz', 'type': 'object', 'properties': {'c': {'$ref': '#/definitions/Bar'}}},
+            'Bar': {'title': 'Bar', 'type': 'object', 'properties': {'b': {'$ref': '#/definitions/Foo'}}},
+            'Foo': {'title': 'Foo', 'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'string'}}},
         },
     }
 
@@ -1006,24 +958,9 @@ def test_schema_with_ref_prefix():
     model_schema = schema([Bar, Baz], ref_prefix='#/components/schemas/')  # OpenAPI style
     assert model_schema == {
         'definitions': {
-            'Baz': {
-                'title': 'Baz',
-                'type': 'object',
-                'properties': {'c': {'$ref': '#/components/schemas/Bar'}},
-
-            },
-            'Bar': {
-                'title': 'Bar',
-                'type': 'object',
-                'properties': {'b': {'$ref': '#/components/schemas/Foo'}},
-
-            },
-            'Foo': {
-                'title': 'Foo',
-                'type': 'object',
-                'properties': {'a': {'title': 'A', 'type': 'string'}},
-
-            },
+            'Baz': {'title': 'Baz', 'type': 'object', 'properties': {'c': {'$ref': '#/components/schemas/Bar'}}},
+            'Bar': {'title': 'Bar', 'type': 'object', 'properties': {'b': {'$ref': '#/components/schemas/Foo'}}},
+            'Foo': {'title': 'Foo', 'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'string'}}},
         }
     }
 
@@ -1341,12 +1278,7 @@ def test_known_model_optimization():
             'dep_l': {'title': 'Dep L', 'type': 'array', 'items': {'$ref': '#/definitions/Dep'}},
         },
         'definitions': {
-            'Dep': {
-                'title': 'Dep',
-                'type': 'object',
-                'properties': {'number': {'title': 'Number', 'type': 'integer'}},
-
-            }
+            'Dep': {'title': 'Dep', 'type': 'object', 'properties': {'number': {'title': 'Number', 'type': 'integer'}}}
         },
     }
 
@@ -1383,7 +1315,6 @@ def test_root_nested_model():
                 'title': 'NestedModel',
                 'type': 'object',
                 'properties': {'a': {'title': 'A', 'type': 'string'}},
-
             }
         },
     }
@@ -1613,7 +1544,6 @@ def test_real_vs_phony_constraints():
             'title': 'Test Model',
             'type': 'object',
             'properties': {'foo': {'title': 'Foo', 'exclusiveMinimum': 123, 'type': 'integer'}},
-
         }
     )
 
@@ -1676,11 +1606,7 @@ def test_dataclass():
 
     assert schema([Model]) == {
         'definitions': {
-            'Model': {
-                'title': 'Model',
-                'type': 'object',
-                'properties': {'a': {'title': 'A', 'type': 'boolean'}},
-            }
+            'Model': {'title': 'Model', 'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'boolean'}}}
         }
     }
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -74,7 +74,6 @@ def test_key():
     s = {
         'type': 'object',
         'properties': {'a': {'type': 'number', 'title': 'A'}, 'b': {'type': 'integer', 'title': 'B', 'default': 10}},
-        'required': ['a'],
         'title': 'ApplePie',
         'description': 'This is a test.',
     }
@@ -102,7 +101,6 @@ def test_by_alias():
             'Snap': {'type': 'number', 'title': 'Snap'},
             'Crackle': {'type': 'integer', 'title': 'Crackle', 'default': 10},
         },
-        'required': ['Snap'],
     }
     assert list(ApplePie.schema(by_alias=True)['properties'].keys()) == ['Snap', 'Crackle']
     assert list(ApplePie.schema(by_alias=False)['properties'].keys()) == ['a', 'b']
@@ -122,7 +120,6 @@ def test_by_alias_generator():
         'title': 'ApplePie',
         'type': 'object',
         'properties': {'A': {'title': 'A', 'type': 'number'}, 'B': {'title': 'B', 'default': 10, 'type': 'integer'}},
-        'required': ['A'],
     }
     assert ApplePie.schema(by_alias=False)['properties'].keys() == {'a', 'b'}
 
@@ -146,11 +143,9 @@ def test_sub_model():
                 'title': 'Foo',
                 'description': 'hello',
                 'properties': {'b': {'type': 'number', 'title': 'B'}},
-                'required': ['b'],
             }
         },
         'properties': {'a': {'type': 'integer', 'title': 'A'}, 'b': {'$ref': '#/definitions/Foo'}},
-        'required': ['a'],
     }
 
 
@@ -158,9 +153,6 @@ def test_schema_class():
     class Model(BaseModel):
         foo: int = Field(4, title='Foo is Great')
         bar: str = Field(..., description='this description of bar')
-
-    with pytest.raises(ValidationError):
-        Model()
 
     m = Model(bar=123)
     assert m.dict() == {'foo': 4, 'bar': '123'}
@@ -172,7 +164,6 @@ def test_schema_class():
             'foo': {'type': 'integer', 'title': 'Foo is Great', 'default': 4},
             'bar': {'type': 'string', 'title': 'Bar', 'description': 'this description of bar'},
         },
-        'required': ['bar'],
     }
 
 
@@ -211,7 +202,6 @@ def test_choices():
             'bar': {'type': 'integer', 'title': 'Bar', 'enum': [1, 2]},
             'spam': {'type': 'string', 'title': 'Spam', 'enum': ['f', 'b']},
         },
-        'required': ['foo', 'bar'],
     }
 
 
@@ -256,11 +246,10 @@ def test_list_sub_model():
                 'title': 'Foo',
                 'type': 'object',
                 'properties': {'a': {'type': 'number', 'title': 'A'}},
-                'required': ['a'],
+
             }
         },
         'properties': {'b': {'type': 'array', 'items': {'$ref': '#/definitions/Foo'}, 'title': 'B'}},
-        'required': ['b'],
     }
 
 
@@ -290,7 +279,6 @@ def test_set():
             'a': {'title': 'A', 'type': 'array', 'uniqueItems': True, 'items': {'type': 'integer'}},
             'b': {'title': 'B', 'type': 'array', 'items': {}, 'uniqueItems': True},
         },
-        'required': ['a', 'b'],
     }
 
 
@@ -340,7 +328,6 @@ def test_tuple(field_type, expected_schema):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'array'}},
-        'required': ['a'],
     }
     base_schema['properties']['a']['items'] = expected_schema
 
@@ -355,7 +342,6 @@ def test_bool():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'boolean'}},
-        'required': ['a'],
     }
 
 
@@ -367,7 +353,6 @@ def test_strict_bool():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'boolean'}},
-        'required': ['a'],
     }
 
 
@@ -379,7 +364,6 @@ def test_dict():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'object'}},
-        'required': ['a'],
     }
 
 
@@ -391,7 +375,6 @@ def test_list():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'array', 'items': {}}},
-        'required': ['a'],
     }
 
 
@@ -406,12 +389,11 @@ class Foo(BaseModel):
             Union[int, str],
             {
                 'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
-                'required': ['a'],
             },
         ),
         (
             List[int],
-            {'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'}}}, 'required': ['a']},
+            {'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'}}}},
         ),
         (
             Dict[str, Foo],
@@ -421,13 +403,11 @@ class Foo(BaseModel):
                         'title': 'Foo',
                         'type': 'object',
                         'properties': {'a': {'title': 'A', 'type': 'number'}},
-                        'required': ['a'],
                     }
                 },
                 'properties': {
                     'a': {'title': 'A', 'type': 'object', 'additionalProperties': {'$ref': '#/definitions/Foo'}}
                 },
-                'required': ['a'],
             },
         ),
         (
@@ -438,13 +418,12 @@ class Foo(BaseModel):
                         'title': 'Foo',
                         'type': 'object',
                         'properties': {'a': {'title': 'A', 'type': 'number'}},
-                        'required': ['a'],
                     }
                 },
                 'properties': {'a': {'$ref': '#/definitions/Foo'}},
             },
         ),
-        (Dict[str, Any], {'properties': {'a': {'title': 'A', 'type': 'object'}}, 'required': ['a']}),
+        (Dict[str, Any], {'properties': {'a': {'title': 'A', 'type': 'object'}}}),
     ],
 )
 def test_list_union_dict(field_type, expected_schema):
@@ -472,8 +451,7 @@ def test_date_types(field_type, expected_schema):
 
     attribute_schema = {'title': 'A'}
     attribute_schema.update(expected_schema)
-
-    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': attribute_schema}, 'required': ['a']}
+    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': attribute_schema}}
 
     assert Model.schema() == base_schema
 
@@ -489,7 +467,6 @@ def test_date_types(field_type, expected_schema):
                 'properties': {
                     'a': {'title': 'A', 'anyOf': [{'type': 'string'}, {'type': 'string', 'format': 'binary'}]}
                 },
-                'required': ['a'],
             },
         ),
         (
@@ -529,7 +506,7 @@ def test_str_constrained_types(field_type, expected_schema):
     model_schema = Model.schema()
     assert model_schema['properties']['a'] == expected_schema
 
-    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': expected_schema}, 'required': ['a']}
+    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': expected_schema}}
 
     assert model_schema == base_schema
 
@@ -548,7 +525,7 @@ def test_special_str_types(field_type, expected_schema):
     class Model(BaseModel):
         a: field_type
 
-    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': {}}, 'required': ['a']}
+    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': {}}}
     base_schema['properties']['a'] = expected_schema
 
     assert Model.schema() == base_schema
@@ -564,7 +541,6 @@ def test_email_str_types(field_type, expected_schema):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'string'}},
-        'required': ['a'],
     }
     base_schema['properties']['a']['format'] = expected_schema
 
@@ -580,7 +556,6 @@ def test_secret_types(field_type, inner_type):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': inner_type, 'writeOnly': True}},
-        'required': ['a'],
     }
 
     assert Model.schema() == base_schema
@@ -605,7 +580,6 @@ def test_special_int_types(field_type, expected_schema):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'integer'}},
-        'required': ['a'],
     }
     base_schema['properties']['a'].update(expected_schema)
 
@@ -635,7 +609,6 @@ def test_special_float_types(field_type, expected_schema):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'number'}},
-        'required': ['a'],
     }
     base_schema['properties']['a'].update(expected_schema)
 
@@ -654,7 +627,6 @@ def test_uuid_types(field_type, expected_schema):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'string', 'format': ''}},
-        'required': ['a'],
     }
     base_schema['properties']['a']['format'] = expected_schema
 
@@ -672,7 +644,6 @@ def test_path_types(field_type, expected_schema):
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'string', 'format': ''}},
-        'required': ['a'],
     }
     base_schema['properties']['a']['format'] = expected_schema
 
@@ -691,7 +662,6 @@ def test_json_type():
             'a': {'title': 'A', 'type': 'string', 'format': 'json-string'},
             'b': {'title': 'B', 'type': 'integer'},
         },
-        'required': ['b'],
     }
 
 
@@ -704,7 +674,6 @@ def test_ipv4address_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_address': {'title': 'Ip Address', 'type': 'string', 'format': 'ipv4'}},
-        'required': ['ip_address'],
     }
 
 
@@ -717,7 +686,6 @@ def test_ipv6address_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_address': {'title': 'Ip Address', 'type': 'string', 'format': 'ipv6'}},
-        'required': ['ip_address'],
     }
 
 
@@ -730,7 +698,6 @@ def test_ipvanyaddress_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_address': {'title': 'Ip Address', 'type': 'string', 'format': 'ipvanyaddress'}},
-        'required': ['ip_address'],
     }
 
 
@@ -743,7 +710,6 @@ def test_ipv4interface_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_interface': {'title': 'Ip Interface', 'type': 'string', 'format': 'ipv4interface'}},
-        'required': ['ip_interface'],
     }
 
 
@@ -756,7 +722,6 @@ def test_ipv6interface_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_interface': {'title': 'Ip Interface', 'type': 'string', 'format': 'ipv6interface'}},
-        'required': ['ip_interface'],
     }
 
 
@@ -769,7 +734,6 @@ def test_ipvanyinterface_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_interface': {'title': 'Ip Interface', 'type': 'string', 'format': 'ipvanyinterface'}},
-        'required': ['ip_interface'],
     }
 
 
@@ -782,7 +746,6 @@ def test_ipv4network_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_network': {'title': 'Ip Network', 'type': 'string', 'format': 'ipv4network'}},
-        'required': ['ip_network'],
     }
 
 
@@ -795,7 +758,6 @@ def test_ipv6network_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_network': {'title': 'Ip Network', 'type': 'string', 'format': 'ipv6network'}},
-        'required': ['ip_network'],
     }
 
 
@@ -808,7 +770,6 @@ def test_ipvanynetwork_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'ip_network': {'title': 'Ip Network', 'type': 'string', 'format': 'ipvanynetwork'}},
-        'required': ['ip_network'],
     }
 
 
@@ -945,7 +906,7 @@ def test_schema_overrides():
                 'title': 'Foo',
                 'type': 'object',
                 'properties': {'a': {'title': 'A', 'type': 'string'}},
-                'required': ['a'],
+
             },
             'Bar': {
                 'title': 'Bar',
@@ -955,7 +916,6 @@ def test_schema_overrides():
             'Baz': {'title': 'Baz', 'type': 'object', 'properties': {'c': {'$ref': '#/definitions/Bar'}}},
         },
         'properties': {'d': {'$ref': '#/definitions/Baz'}},
-        'required': ['d'],
     }
 
 
@@ -997,37 +957,37 @@ def test_schema_from_models():
                         'items': {'$ref': '#/definitions/Ingredient'},
                     },
                 },
-                'required': ['name', 'ingredients'],
+
             },
             'Ingredient': {
                 'title': 'Ingredient',
                 'type': 'object',
                 'properties': {'name': {'title': 'Name', 'type': 'string'}},
-                'required': ['name'],
+
             },
             'Model': {
                 'title': 'Model',
                 'type': 'object',
                 'properties': {'d': {'$ref': '#/definitions/Baz'}},
-                'required': ['d'],
+
             },
             'Baz': {
                 'title': 'Baz',
                 'type': 'object',
                 'properties': {'c': {'$ref': '#/definitions/Bar'}},
-                'required': ['c'],
+
             },
             'Bar': {
                 'title': 'Bar',
                 'type': 'object',
                 'properties': {'b': {'$ref': '#/definitions/Foo'}},
-                'required': ['b'],
+
             },
             'Foo': {
                 'title': 'Foo',
                 'type': 'object',
                 'properties': {'a': {'title': 'A', 'type': 'string'}},
-                'required': ['a'],
+
             },
         },
     }
@@ -1050,19 +1010,19 @@ def test_schema_with_ref_prefix():
                 'title': 'Baz',
                 'type': 'object',
                 'properties': {'c': {'$ref': '#/components/schemas/Bar'}},
-                'required': ['c'],
+
             },
             'Bar': {
                 'title': 'Bar',
                 'type': 'object',
                 'properties': {'b': {'$ref': '#/components/schemas/Foo'}},
-                'required': ['b'],
+
             },
             'Foo': {
                 'title': 'Foo',
                 'type': 'object',
                 'properties': {'a': {'title': 'A', 'type': 'string'}},
-                'required': ['a'],
+
             },
         }
     }
@@ -1273,7 +1233,7 @@ def test_bytes_constrained_types(field_type, expected_schema):
     class Model(BaseModel):
         a: field_type
 
-    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': {}}, 'required': ['a']}
+    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': {}}}
     base_schema['properties']['a'] = expected_schema
 
     assert Model.schema() == base_schema
@@ -1289,7 +1249,7 @@ def test_optional_dict():
         'properties': {'something': {'title': 'Something', 'type': 'object'}},
     }
 
-    assert Model().dict() == {'something': None}
+    assert Model().dict() == {}
     assert Model(something={'foo': 'Bar'}).dict() == {'something': {'foo': 'Bar'}}
 
 
@@ -1308,7 +1268,7 @@ def test_optional_validator():
         'properties': {'something': {'title': 'Something', 'type': 'string'}},
     }
 
-    assert Model().dict() == {'something': None}
+    assert Model().dict() == {}
     assert Model(something=None).dict() == {'something': None}
     assert Model(something='hello').dict() == {'something': 'hello'}
 
@@ -1339,7 +1299,6 @@ def test_unparameterized_schema_generation():
         'title': 'FooList',
         'type': 'object',
         'properties': {'d': {'items': {}, 'title': 'D', 'type': 'array'}},
-        'required': ['d'],
     }
 
     foo_list_schema = model_schema(FooList)
@@ -1358,7 +1317,6 @@ def test_unparameterized_schema_generation():
         'title': 'FooDict',
         'type': 'object',
         'properties': {'d': {'title': 'D', 'type': 'object'}},
-        'required': ['d'],
     }
 
     foo_dict_schema = model_schema(FooDict)
@@ -1382,13 +1340,12 @@ def test_known_model_optimization():
             'dep': {'$ref': '#/definitions/Dep'},
             'dep_l': {'title': 'Dep L', 'type': 'array', 'items': {'$ref': '#/definitions/Dep'}},
         },
-        'required': ['dep', 'dep_l'],
         'definitions': {
             'Dep': {
                 'title': 'Dep',
                 'type': 'object',
                 'properties': {'number': {'title': 'Number', 'type': 'integer'}},
-                'required': ['number'],
+
             }
         },
     }
@@ -1426,7 +1383,7 @@ def test_root_nested_model():
                 'title': 'NestedModel',
                 'type': 'object',
                 'properties': {'a': {'title': 'A', 'type': 'string'}},
-                'required': ['a'],
+
             }
         },
     }
@@ -1448,7 +1405,6 @@ def test_new_type_schema():
             'b': {'title': 'B', 'type': 'integer'},
             'c': {'title': 'C', 'type': 'string'},
         },
-        'required': ['a', 'b', 'c'],
         'title': 'Model',
         'type': 'object',
     }
@@ -1467,7 +1423,6 @@ def test_literal_schema():
             'b': {'title': 'B', 'type': 'string', 'const': 'a'},
             'c': {'anyOf': [{'type': 'string', 'const': 'a'}, {'type': 'integer', 'const': 1}], 'title': 'C'},
         },
-        'required': ['a', 'b', 'c'],
         'title': 'Model',
         'type': 'object',
     }
@@ -1482,7 +1437,6 @@ def test_color_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'color': {'title': 'Color', 'type': 'string', 'format': 'color'}},
-        'required': ['color'],
     }
 
 
@@ -1497,7 +1451,6 @@ def test_model_with_schema_extra():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'string'}},
-        'required': ['a'],
         'examples': [{'a': 'Foo'}],
     }
 
@@ -1569,7 +1522,6 @@ def test_model_with_extra_forbidden():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'string'}},
-        'required': ['a'],
         'additionalProperties': False,
     }
 
@@ -1661,7 +1613,7 @@ def test_real_vs_phony_constraints():
             'title': 'Test Model',
             'type': 'object',
             'properties': {'foo': {'title': 'Foo', 'exclusiveMinimum': 123, 'type': 'integer'}},
-            'required': ['foo'],
+
         }
     )
 
@@ -1686,7 +1638,6 @@ def test_conlist():
             'foo': {'title': 'Foo', 'type': 'array', 'items': {'type': 'integer'}, 'minItems': 2, 'maxItems': 4},
             'bar': {'title': 'Bar', 'type': 'array', 'items': {'type': 'string'}, 'minItems': 1, 'maxItems': 4},
         },
-        'required': ['foo'],
     }
 
     with pytest.raises(ValidationError) as exc_info:
@@ -1715,7 +1666,6 @@ def test_subfield_field_info():
                 'additionalProperties': {'type': 'array', 'items': {'type': 'integer'}},
             }
         },
-        'required': ['entries'],
     }
 
 
@@ -1730,7 +1680,6 @@ def test_dataclass():
                 'title': 'Model',
                 'type': 'object',
                 'properties': {'a': {'title': 'A', 'type': 'boolean'}},
-                'required': ['a'],
             }
         }
     }
@@ -1739,7 +1688,6 @@ def test_dataclass():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'boolean'}},
-        'required': ['a'],
     }
 
 
@@ -1760,7 +1708,6 @@ def test_schema_attributes():
         'title': 'Example',
         'type': 'object',
         'properties': {'example': {'title': 'Example', 'enum': ['GT', 'LT', 'GE', 'LE', 'ML', 'MO', 'RE']}},
-        'required': ['example'],
     }
 
 
@@ -1781,7 +1728,6 @@ def test_path_modify_schema():
             'path1': {'title': 'Path1', 'type': 'string', 'format': 'path'},
             'path2': {'title': 'Path2', 'type': 'string', 'format': 'path', 'foobar': 123},
         },
-        'required': ['path1', 'path2'],
     }
 
 
@@ -1812,7 +1758,6 @@ def test_iterable():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'integer'}}},
-        'required': ['a'],
     }
 
 
@@ -1826,5 +1771,4 @@ def test_new_type():
         'title': 'Model',
         'type': 'object',
         'properties': {'a': {'title': 'A', 'type': 'string'}},
-        'required': ['a'],
     }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1664,7 +1664,7 @@ def test_new_type_success():
 
     m = Model(a=42, b=24, c=[1, 2, 3])
     assert m.dict() == {'a': 42, 'b': 24, 'c': [1, 2, 3]}
-    assert repr(Model.__fields__['c']) == "ModelField(name='c', type=List[int], required=True)"
+    assert repr(Model.__fields__['c']) == "ModelField(name='c', type=List[int], required=False)"
 
 
 def test_new_type_fails():
@@ -1809,7 +1809,10 @@ def test_json_optional_complex():
 
 def test_json_explicitly_required():
     class JsonRequired(BaseModel):
-        json_obj: Json = ...
+        json_obj: Json
+
+        class Config:
+            required_fields = ('json_obj', )
 
     assert JsonRequired(json_obj=None).dict() == {'json_obj': None}
     assert JsonRequired(json_obj='["x", "y", "z"]').dict() == {'json_obj': ['x', 'y', 'z']}
@@ -1824,7 +1827,7 @@ def test_json_no_default():
 
     assert JsonRequired(json_obj=None).dict() == {'json_obj': None}
     assert JsonRequired(json_obj='["x", "y", "z"]').dict() == {'json_obj': ['x', 'y', 'z']}
-    assert JsonRequired().dict() == {'json_obj': None}
+    assert JsonRequired().dict() == {}
 
 
 def test_pattern():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1812,7 +1812,7 @@ def test_json_explicitly_required():
         json_obj: Json
 
         class Config:
-            required_fields = ('json_obj', )
+            required_fields = ('json_obj',)
 
     assert JsonRequired(json_obj=None).dict() == {'json_obj': None}
     assert JsonRequired(json_obj='["x", "y", "z"]').dict() == {'json_obj': ['x', 'y', 'z']}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -211,6 +211,9 @@ def test_devtools_output_validation_error():
     class Model(BaseModel):
         a: int
 
+        class Config:
+            required_fields = ('a', )
+
     with pytest.raises(ValueError) as exc_info:
         Model()
     assert devtools.pformat(exc_info.value) == (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -212,7 +212,7 @@ def test_devtools_output_validation_error():
         a: int
 
         class Config:
-            required_fields = ('a', )
+            required_fields = ('a',)
 
     with pytest.raises(ValueError) as exc_info:
         Model()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -340,10 +340,7 @@ def test_wildcard_validator_error():
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': '"foobar" not found in a', 'type': 'value_error'},
-        {'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'},
-    ]
+    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': '"foobar" not found in a', 'type': 'value_error'}]
 
 
 def test_invalid_field():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Added optional config attribute `required_fields`. This attribute let us define required attribute directly! More transparent, independence from field type. Field is not required if him name not in required_fields.

<!-- Please give a short summary of the changes. -->

## Related issue number
https://github.com/samuelcolvin/pydantic/issues/1444

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
