### PR TITLE
Move const validator to post validators

### DIFF
--- a/changes/1410-selimb.md
+++ b/changes/1410-selimb.md
@@ -1,0 +1,1 @@
+Move `const` validator to post-validators so it validates the parsed value

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -48,7 +48,7 @@ It has the following arguments:
 * `title`: if omitted, `field_name.title()` is used
 * `description`: if omitted and the annotation is a sub-model,
     the docstring of the sub-model will be used
-* `const`: this argument *must* have be the same as the field's default value if present
+* `const`: this argument *must* be the same as the field's default value if present.
 * `gt`: for numeric values (``int``, `float`, `Decimal`), adds a validation of "greater than" and an annotation
   of `exclusiveMinimum` to the JSON Schema
 * `ge`: for numeric values, this adds a validation of "greater than or equal" and an annotation of `minimum` to the

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -510,11 +510,11 @@ class ModelField(Representation):
             )
             self.validators = prep_validators(v_funcs)
 
-        # Add const validator
         self.pre_validators = []
         self.post_validators = []
+
         if self.field_info and self.field_info.const:
-            self.pre_validators = [make_generic_validator(constant_validator)]
+            self.post_validators.append(make_generic_validator(constant_validator))
 
         if class_validators_:
             self.pre_validators += prep_validators(v.func for v in class_validators_ if not v.each_item and v.pre)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -383,6 +383,15 @@ def test_const_uses_default():
     assert m.a == 3
 
 
+def test_const_validates_after_type_validators():
+    # issue #1410
+    class Model(BaseModel):
+        a: int = Field(3, const=True)
+
+    m = Model(a='3')
+    assert m.a == 3
+
+
 def test_const_with_wrong_value():
     class Model(BaseModel):
         a: int = Field(3, const=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Move `const` validator to post validators so that it validates the *parsed* value, not the input value.

## Related issue number

Fixes #1410

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/changes/1410-selimb.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
