### PR TITLE
Avoid unintended type coercion of validation

### DIFF
--- a/changes/1447-prettywood.md
+++ b/changes/1447-prettywood.md
@@ -1,0 +1,1 @@
+Avoid to coerce the type of a `Field` value if possible

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -694,11 +694,12 @@ class ModelField(Representation):
         It is used to make sure we first validate a given value with the right sub_field
         to avoid an unintended type coercion
         """
+        sub_fields: List['ModelField'] = self.sub_fields or []
         try:
-            idx = [i for i, f in enumerate(self.sub_fields) if f.type_ == type_][0]
-            return [self.sub_fields[idx], *self.sub_fields[:idx], *self.sub_fields[idx + 1 :]]
+            idx = [i for i, f in enumerate(sub_fields) if f.type_ == type_][0]
+            return [sub_fields[idx], *sub_fields[:idx], *sub_fields[idx + 1 :]]
         except IndexError:
-            return self.sub_fields
+            return sub_fields
 
     def _validate_singleton(
         self, v: Any, values: Dict[str, Any], loc: 'LocStr', cls: Optional['ModelOrDc']

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -30,7 +30,7 @@ def test_str_bytes():
     assert repr(m.__fields__['v']) == "ModelField(name='v', type=Union[str, bytes], required=True)"
 
     m = Model(v=b'b')
-    assert m.v == 'b'
+    assert m.v == b'b'
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=None)
@@ -47,7 +47,7 @@ def test_str_bytes_none():
     assert m.v == 's'
 
     m = Model(v=b'b')
-    assert m.v == 'b'
+    assert m.v == b'b'
 
     m = Model(v=None)
     assert m.v is None
@@ -61,7 +61,7 @@ def test_union_int_str():
     assert m.v == 123
 
     m = Model(v='123')
-    assert m.v == 123
+    assert m.v == '123'
 
     m = Model(v=b'foobar')
     assert m.v == 'foobar'
@@ -84,7 +84,7 @@ def test_union_priority():
     class ModelTwo(BaseModel):
         v: Union[str, int] = ...
 
-    assert ModelOne(v='123').v == 123
+    assert ModelOne(v='123').v == '123'
     assert ModelTwo(v='123').v == '123'
 
 
@@ -280,7 +280,7 @@ def test_list_unions():
     class Model(BaseModel):
         v: List[Union[int, str]] = ...
 
-    assert Model(v=[123, '456', 'foobar']).v == [123, 456, 'foobar']
+    assert Model(v=[123, '456', 'foobar']).v == [123, '456', 'foobar']
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
When a `Field` value was validated, it would follow the order of the allowed types
(e.g with `Union[str, int]`, it would first check with `str` and then with `int`).
But as some validators coerce the value (for example `1` can be converted to `"1"` if a `str` is expected), a valid value could be changed because of the order of the validators.
To avoid this, we prioritize the right type if found before checking with the others

## Related issue number

fix #1447

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
