### PR TITLE
Added docs on dumping dataclasses to JSON

### DIFF
--- a/changes/1487-mikegrima.md
+++ b/changes/1487-mikegrima.md
@@ -1,0 +1,1 @@
+Added docs about dumping dataclasses to JSON.

--- a/docs/examples/dataclasses_json_dumps.py
+++ b/docs/examples/dataclasses_json_dumps.py
@@ -1,0 +1,15 @@
+import dataclasses
+import json
+from typing import List
+
+from pydantic.dataclasses import dataclass
+from pydantic.json import pydantic_encoder
+
+@dataclass
+class User:
+    id: int
+    name: str = 'John Doe'
+    friends: List[int] = dataclasses.field(default_factory=lambda: [0])
+
+user = User(id='42')
+print(json.dumps(user, indent=4, default=pydantic_encoder))

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -11,8 +11,8 @@ _(This script is complete, it should run "as is")_
 !!! note
     Keep in mind that `pydantic.dataclasses.dataclass` is a drop-in replacement for `dataclasses.dataclass`
     with validation, **not** a replacement for `pydantic.BaseModel` (with a small difference in how [initialization hooks](#initialize-hooks) work). There are cases where subclassing
-    `pydantic.BaseModel` is the better choice. 
-    
+    `pydantic.BaseModel` is the better choice.
+
     For more information and discussion see
     [samuelcolvin/pydantic#710](https://github.com/samuelcolvin/pydantic/issues/710).
 
@@ -33,7 +33,7 @@ keyword argument `config` which has the same meaning as [Config](model_config.md
 !!! warning
     After v1.2, [The Mypy plugin](/mypy_plugin.md) must be installed to type check pydantic dataclasses.
 
-For more information about combining validators with dataclasses, see 
+For more information about combining validators with dataclasses, see
 [dataclass validators](validators.md#dataclass-validators).
 
 ## Nested dataclasses
@@ -70,4 +70,12 @@ _(This script is complete, it should run "as is")_
 
 Note that the `dataclasses.dataclass` from python stdlib implements only the `__post_init__` method since it doesn't run a validation step.
 
-When substituting usage of `dataclasses.dataclass` with `pydantic.dataclasses.dataclass`, it is recommended to move the code executed in the `__post_init__` method to the `__post_init_post_parse__` method, and only leave behind part of code which needs to be executed before validation. 
+When substituting usage of `dataclasses.dataclass` with `pydantic.dataclasses.dataclass`, it is recommended to move the code executed in the `__post_init__` method to the `__post_init_post_parse__` method, and only leave behind part of code which needs to be executed before validation.
+
+## JSON Dumping
+
+Pydantic dataclasses do not feature a `.json()` function. To dump them as JSON, you will need to make use of the `pydantic_encoder` as follows:
+
+```py
+{!.tmp_examples/dataclasses_json_dumps.py!}
+```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Added docs about dumping dataclasses to JSON. I was frustrated by the lack of them :D

## Checklist

* [N/A] Unit tests for the changes exist
* [N/A] Tests pass on CI and coverage remains at 100%
* [Y] Documentation reflects the changes where applicable
* [Y] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
