### PR TITLE
Added a "Talks and video tutorials" section

### DIFF
--- a/changes/1499-hultner.md
+++ b/changes/1499-hultner.md
@@ -1,0 +1,1 @@
+Added a videos section with link to "Pydantic Introduction" video by Alexander Hultnér

--- a/changes/1499-hultner.md
+++ b/changes/1499-hultner.md
@@ -1,1 +1,1 @@
-Added a videos section with link to "Pydantic Introduction" video by Alexander Hultnér
+Added a "Discussion of Pydantic" section to the documentation, with a link to "Pydantic Introduction" video by Alexander Hultnér

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,13 +73,6 @@ So *pydantic* uses some cool new language features, but why should I actually go
   a [`dataclass`](usage/dataclasses.md) decorator which creates (almost) vanilla python dataclasses with input
   data parsing and validation.
 
-## Talks and video tutorials
-
-Talks and videos discussing and teaching pydantic.
-
-[Python pydantic Introduction – Give your data classes super powers](https://www.youtube.com/watch?v=WJmqgJn9TXg)
-: a talk by Alexander Hultnér originally for the Python Pizza Conference introducing new users to pydantic and walking through the core features of pydantic.
-
 ## Using Pydantic
 
 Hundreds of organisations and packages are using *pydantic*, including:
@@ -128,3 +121,11 @@ For a more comprehensive list of open-source projects using *pydantic* see the
 
 [Python Bytes Podcast](https://pythonbytes.fm/episodes/show/157/oh-hai-pandas-hold-my-hand)
 : "*This is a sweet simple framework that solves some really nice problems... Data validations and settings management using python type annotations, and it's the python type annotations that makes me really extra happy... It works automatically with all the IDE's you already have.*" --Michael Kennedy
+
+### Discussion of Pydantic
+
+Talks and videos discussing and teaching pydantic.
+
+[Python pydantic Introduction – Give your data classes super powers](https://www.youtube.com/watch?v=WJmqgJn9TXg)
+: a talk by Alexander Hultnér originally for the Python Pizza Conference introducing new users to pydantic and walking through the core features of pydantic.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,13 @@ So *pydantic* uses some cool new language features, but why should I actually go
   a [`dataclass`](usage/dataclasses.md) decorator which creates (almost) vanilla python dataclasses with input
   data parsing and validation.
 
+## Talks and video tutorials
+
+Talks and videos discussing and teaching pydantic.
+
+[Python pydantic Introduction – Give your data classes super powers](https://www.youtube.com/watch?v=WJmqgJn9TXg)
+: a talk by Alexander Hultnér originally for the Python Pizza Conference introducing new users to pydantic and walking through the core features of pydantic.
+
 ## Using Pydantic
 
 Hundreds of organisations and packages are using *pydantic*, including:


### PR DESCRIPTION
Added my "Python pydantic Introduction – Give your data classes super powers" talk YouTube video based on the talk for Python Pizza.

@samuelcolvin Were you thinking like this?

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Added a section for talks and videos, added my Pydantic introduction talk to the list.
<!-- Please give a short summary of the changes. -->

## Related issue number
N/A, discussed with @samuelcolvin on gitter.
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [N/A] ~Unit tests for the changes exist~
* [N/A] ~Tests pass on CI and coverage remains at 100%~
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
