### PR TITLE
fix(field): remove some side effects of `default_factory`

### DIFF
--- a/changes/1491-PrettyWood.md
+++ b/changes/1491-PrettyWood.md
@@ -1,0 +1,2 @@
+Avoid some side effects of `default_factory` by calling it only once
+if possible and by not setting a default value in the schema

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -492,6 +492,10 @@ _(This script is complete, it should run "as is")_
 
 Where `Field` refers to the [field function](schema.md#field-customisation).
 
+!!! warning
+    If you don't declare the type of the field or if you want to validate default values with `validate_all`,
+    *pydantic* will need to call the `default_factory`, which could lead to side effects !
+
 ## Parsing data into a specified type
 
 Pydantic includes a standalone utility function `parse_obj_as` that can be used to apply the parsing

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -493,8 +493,9 @@ _(This script is complete, it should run "as is")_
 Where `Field` refers to the [field function](schema.md#field-customisation).
 
 !!! warning
-    If you don't declare the type of the field or if you want to validate default values with `validate_all`,
-    *pydantic* will need to call the `default_factory`, which could lead to side effects !
+    The `default_factory` expects the field type to be set.
+    Moreover if you want to validate default values with `validate_all`,
+    *pydantic* will need to call the `default_factory`, which could lead to side effects!
 
 ## Parsing data into a specified type
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -342,10 +342,15 @@ class ModelField(Representation):
         e.g. calling it it multiple times may modify the field and configure it incorrectly.
         """
 
-        # to prevent side effects by calling the default_factory for nothing, we only call it
-        # when we want to validate the default value i.e. when `validate_all` is set to True
-        if self.default_factory is not None and self.type_ is not None and not self.model_config.validate_all:
-            return
+        # To prevent side effects by calling the `default_factory` for nothing, we only call it
+        # when we want to validate the default value i.e. when `validate_all` is set to True.
+        if self.default_factory is not None:
+            if self.type_ is None:
+                raise errors_.ConfigError(
+                    f'you need to set the type of field {self.name!r} when using `default_factory`'
+                )
+            if not self.model_config.validate_all:
+                return
 
         default_value = self.get_default()
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1531,3 +1531,23 @@ def test_hashable_optional(default):
 
     Model(v=None)
     Model()
+
+
+def test_default_factory_side_effect():
+    """It may call `default_factory` more than once when `validate_all` is set"""
+
+    v = 0
+
+    def factory():
+        nonlocal v
+        v += 1
+        return v
+
+    class MyModel(BaseModel):
+        id: int = Field(default_factory=factory)
+
+        class Config:
+            validate_all = True
+
+    m1 = MyModel()
+    assert m1.id == 2  # instead of 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1088,6 +1088,46 @@ def test_default_factory():
     assert m.uid is uuid4
 
 
+def test_default_factory_side_effect():
+    """It should call only once the given factory"""
+
+    class Seq:
+        def __init__(self):
+            self.v = 0
+
+        def __call__(self):
+            self.v += 1
+            return self.v
+
+    class MyModel(BaseModel):
+        id: int = Field(default_factory=Seq())
+
+    m1 = MyModel()
+    assert m1.id == 1
+    m2 = MyModel()
+    assert m2.id == 2
+    assert m1.id == 1
+
+
+def test_default_factory_side_effect_2():
+    """It should call only once the given factory"""
+
+    v = 0
+
+    def factory():
+        nonlocal v
+        v += 1
+        return v
+
+    class MyModel(BaseModel):
+        id: int = Field(default_factory=factory)
+
+    m1 = MyModel()
+    assert m1.id == 1
+    m2 = MyModel()
+    assert m2.id == 2
+
+
 @pytest.mark.skipif(sys.version_info < (3, 7), reason='field constraints are set but not enforced with python 3.6')
 def test_none_min_max_items():
     # None default


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Fix some side effects of `default_factory`:
- call it only once when no validation is needed
- remove default value of generated schema

## Related issue number

fix #1491 and #1520

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
