### PR TITLE
Add test coverage that default_factory doesn't copy its value

### DIFF
--- a/changes/1523-therefromhere.md
+++ b/changes/1523-therefromhere.md
@@ -1,0 +1,1 @@
+Add a test assertion that `default_factory` can return a singleton

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -431,6 +431,23 @@ def test_default_factory_field():
     assert fields['aliases'].default == {'John': 'Joey'}
 
 
+def test_default_factory_singleton_field():
+    class MySingleton:
+        pass
+
+    class MyConfig:
+        arbitrary_types_allowed = True
+
+    MY_SINGLETON = MySingleton()
+
+    @pydantic.dataclasses.dataclass(config=MyConfig)
+    class Foo:
+        singleton: MySingleton = dataclasses.field(default_factory=lambda: MY_SINGLETON)
+
+    # Returning a singleton from a default_factory is supported
+    assert Foo().singleton is Foo().singleton
+
+
 def test_schema():
     @pydantic.dataclasses.dataclass
     class User:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1087,6 +1087,20 @@ def test_default_factory():
     m = FunctionModel()
     assert m.uid is uuid4
 
+    # Returning a singleton from a default_factory is supported
+    class MySingleton:
+        pass
+
+    MY_SINGLETON = MySingleton()
+
+    class SingletonFieldModel(BaseModel):
+        singleton: MySingleton = Field(default_factory=lambda: MY_SINGLETON)
+
+        class Config:
+            arbitrary_types_allowed = True
+
+    assert SingletonFieldModel().singleton is SingletonFieldModel().singleton
+
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason='field constraints are set but not enforced with python 3.6')
 def test_none_min_max_items():


### PR DESCRIPTION
## Change Summary

Adds an assertion that `default_factory` can be used to return a singleton.

## Related issue number

Resolves #1489 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
