### PR TITLE
Fix NameEmail equality comparison

### DIFF
--- a/changes/1514-stephen-bunn.md
+++ b/changes/1514-stephen-bunn.md
@@ -1,0 +1,1 @@
+Add `NameEmail.__eq__` so duplicate `NameEmail` instances are evaluated as equal.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -330,10 +330,7 @@ class NameEmail(Representation):
         self.email = email
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, NameEmail):
-            return (self.name, self.email,) == (other.name, other.email,)
-        else:
-            return other == self
+        return isinstance(other, NameEmail) and (self.name, self.email) == (other.name, other.email)
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -329,6 +329,12 @@ class NameEmail(Representation):
         self.name = name
         self.email = email
 
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, NameEmail):
+            return (self.name, self.email,) == (other.name, other.email,)
+        else:
+            return other == self
+
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         field_schema.update(type='string', format='name-email')

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -453,5 +453,5 @@ def test_name_email():
 
     assert str(Model(v=NameEmail('foo bar', 'foobaR@example.com')).v) == 'foo bar <foobaR@example.com>'
     assert str(Model(v='foo bar  <foobaR@example.com>').v) == 'foo bar <foobaR@example.com>'
-    assert Model(v=NameEmail('foo bar', 'foobaR@example.com')) == Model(v=NameEmail('foo bar', 'foobaR@example.com'))
-    assert Model(v=NameEmail('foo bar', 'foobaR@example.com')) != 'foo bar <foobaR@example.com>'
+        assert NameEmail('foo bar', 'foobaR@example.com') == NameEmail('foo bar', 'foobaR@example.com')
+        assert NameEmail('foo bar', 'foobaR@example.com') != NameEmail('foo bar', 'different@example.com')

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -453,3 +453,5 @@ def test_name_email():
 
     assert str(Model(v=NameEmail('foo bar', 'foobaR@example.com')).v) == 'foo bar <foobaR@example.com>'
     assert str(Model(v='foo bar  <foobaR@example.com>').v) == 'foo bar <foobaR@example.com>'
+    assert Model(v=NameEmail('foo bar', 'foobaR@example.com')) == Model(v=NameEmail('foo bar', 'foobaR@example.com'))
+    assert Model(v=NameEmail('foo bar', 'foobaR@example.com')) != 'foo bar <foobaR@example.com>'

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -453,5 +453,5 @@ def test_name_email():
 
     assert str(Model(v=NameEmail('foo bar', 'foobaR@example.com')).v) == 'foo bar <foobaR@example.com>'
     assert str(Model(v='foo bar  <foobaR@example.com>').v) == 'foo bar <foobaR@example.com>'
-        assert NameEmail('foo bar', 'foobaR@example.com') == NameEmail('foo bar', 'foobaR@example.com')
-        assert NameEmail('foo bar', 'foobaR@example.com') != NameEmail('foo bar', 'different@example.com')
+    assert NameEmail('foo bar', 'foobaR@example.com') == NameEmail('foo bar', 'foobaR@example.com')
+    assert NameEmail('foo bar', 'foobaR@example.com') != NameEmail('foo bar', 'different@example.com')


### PR DESCRIPTION
## Change Summary

Introducing an `__eq__` for `networks.NameEmail` as two similar instances were not being correctly evaluated as equal.

```python
import pydantic

# previously this would raise an AssertionError
assert pydantic.NameEmail("test", "test@example.com") == pydantic.NameEmail("test", "test@example.com")1
```

## Related issue number

closes #1514

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
