### PR TITLE
Make assertion match message in simple validators example

### DIFF
--- a/docs/examples/validators_simple.py
+++ b/docs/examples/validators_simple.py
@@ -20,7 +20,7 @@ class UserModel(BaseModel):
 
     @validator('username')
     def username_alphanumeric(cls, v):
-        assert v.isalpha(), 'must be alphanumeric'
+        assert v.isalnum(), 'must be alphanumeric'
         return v
 
 print(UserModel(name='samuel colvin', username='scolvin', password1='zxcvbn',


### PR DESCRIPTION
## Change Summary

Noticed that the assertion in the UserModel example was wrong, checking only if the username was alphabetic, rather than allowing numbers as well.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
