### PR TITLE
1541 UUID bytes support for 16 byte strings / BINARY(16)

### DIFF
--- a/changes/1541-shawnwall.md
+++ b/changes/1541-shawnwall.md
@@ -1,0 +1,1 @@
+Added support for UUID instantiation through 16 byte strings such as `b'\x12\x34\x56\x78' * 4`. This was done to support `BINARY(16)` columns in sqlalchemy.

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -145,7 +145,7 @@ with custom properties and validation.
   see [Pydantic Types](#pydantic-types) for other more strict path types
 
 `uuid.UUID`
-: strings and bytes (converted to strings) are passed to `UUID(v)`;
+: strings and bytes (converted to strings) are passed to `UUID(v)`, with a fallback to `UUID(bytes=v)` for `bytes` and `bytearray`;
   see [Pydantic Types](#pydantic-types) for other stricter UUID types
 
 `ByteSize`

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -252,7 +252,12 @@ def uuid_validator(v: Any, field: 'ModelField') -> UUID:
         if isinstance(v, str):
             v = UUID(v)
         elif isinstance(v, (bytes, bytearray)):
-            v = UUID(v.decode())
+            try:
+                v = UUID(v.decode())
+            except ValueError:
+                # 16 bytes in big-endian order as the bytes argument fail
+                # the above check
+                v = UUID(bytes=v)
     except ValueError:
         raise errors.UUIDError()
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -392,6 +392,7 @@ class BoolCastable:
         ('uuid_check', 'ebcdab58-6eb8-46fb-a190-d07a33e9eac8', UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8')),
         ('uuid_check', UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8'), UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8')),
         ('uuid_check', b'ebcdab58-6eb8-46fb-a190-d07a33e9eac8', UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8')),
+        ('uuid_check', b'\x12\x34\x56\x78' * 4, UUID('12345678-1234-5678-1234-567812345678')),
         ('uuid_check', 'ebcdab58-6eb8-46fb-a190-', ValidationError),
         ('uuid_check', 123, ValidationError),
         ('decimal_check', 42.24, Decimal('42.24')),


### PR DESCRIPTION
## Change Summary

* Updated UUID validation to take into account 16 byte strings per python documentation
* Created new test for this byte string type

## Related issue number

Fixes #1541 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md]