### PR TITLE
check ModelField().validate_always when inheriting

### DIFF
--- a/changes/1545-dcHHH.md
+++ b/changes/1545-dcHHH.md
@@ -1,0 +1,1 @@
+Move the assignment of field.validate_always in fields.py to make 'always' parameter of validator works on inheritance.

--- a/changes/1545-dcHHH.md
+++ b/changes/1545-dcHHH.md
@@ -1,1 +1,1 @@
-Move the assignment of field.validate_always in fields.py to make 'always' parameter of validator works on inheritance.
+Move the assignment of `field.validate_always` in `fields.py` so the `always` parameter of validators work on inheritance.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -354,10 +354,6 @@ class ModelField(Representation):
             # user will need to call model.update_forward_refs()
             return
 
-        self.validate_always = getattr(self.type_, 'validate_always', False) or any(
-            v.always for v in self.class_validators.values()
-        )
-
         if self.required is False and default_value is None:
             self.allow_none = True
 
@@ -500,6 +496,10 @@ class ModelField(Representation):
         and class validators. This method should be idempotent, e.g. it should be safe to call multiple times
         without mis-configuring the field.
         """
+        self.validate_always = getattr(self.type_, 'validate_always', False) or any(
+            v.always for v in self.class_validators.values()
+        )
+
         class_validators_ = self.class_validators.values()
         if not self.sub_fields or self.shape == SHAPE_GENERIC:
             get_validators = getattr(self.type_, '__get_validators__', None)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -286,6 +286,25 @@ def test_validate_always():
     assert check_calls == 2
 
 
+def test_validate_always_on_inheritance():
+    check_calls = 0
+
+    class ParentModel(BaseModel):
+        a: str = None
+
+    class Model(ParentModel):
+        @validator('a', pre=True, always=True)
+        def check_a(cls, v):
+            nonlocal check_calls
+            check_calls += 1
+            return v or 'xxx'
+
+    assert Model().a == 'xxx'
+    assert check_calls == 1
+    assert Model(a='y').a == 'y'
+    assert check_calls == 2
+
+
 def test_validate_not_always():
     check_calls = 0
 


### PR DESCRIPTION
## Change Summary

Indeed, the bug is originated from the change main.py:169. The fields of C is a deepcopy of it's parent class, so C.value_b.validate_always = B.value_b.validate_always = False
https://github.com/samuelcolvin/pydantic/blob/1eeb225c67f1131f948c5f129f5c2e56a4c2c6b7/pydantic/main.py#L881-L883
So value_b is not validated. Just move the assignment of validate_always from self.prepare() to self.populate_validators(), then the bug is solved. 

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/1155

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
