### PR TITLE
fix(schema): use right type check for __modify_schema__

### DIFF
--- a/changes/1552-PrettyWood.md
+++ b/changes/1552-PrettyWood.md
@@ -1,0 +1,1 @@
+Call `__modify_schema__` only for the field schema

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -239,7 +239,7 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
         f_schema['const'] = field.default
     if field.field_info.extra:
         f_schema.update(field.field_info.extra)
-    modify_schema = getattr(field.type_, '__modify_schema__', None)
+    modify_schema = getattr(field.outer_type_, '__modify_schema__', None)
     if modify_schema:
         modify_schema(f_schema)
     return f_schema

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1822,6 +1822,7 @@ def test_path_modify_schema():
     class Model(BaseModel):
         path1: Path
         path2: MyPath
+        path3: List[MyPath]
 
     assert Model.schema() == {
         'title': 'Model',
@@ -1829,8 +1830,9 @@ def test_path_modify_schema():
         'properties': {
             'path1': {'title': 'Path1', 'type': 'string', 'format': 'path'},
             'path2': {'title': 'Path2', 'type': 'string', 'format': 'path', 'foobar': 123},
+            'path3': {'title': 'Path3', 'type': 'array', 'items': {'type': 'string', 'format': 'path', 'foobar': 123}},
         },
-        'required': ['path1', 'path2'],
+        'required': ['path1', 'path2', 'path3'],
     }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
As @therefromhere explains in #1552, `__modify_schema__` was called for the schema field but also for the list schema because `field.type_` would be the same in both cases.
Changed it to `field.outer_type_`
<!-- Please give a short summary of the changes. -->

## Related issue number
fix #1552

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
