### PR TITLE
Update benchmarks

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,6 +1,5 @@
 # no versions since benchmarks should always run with the most recent version of each package
 
-ciso8601
 trafaret
 django
 djangorestframework

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,6 +1,6 @@
 # no versions since benchmarks should always run with the most recent version of each package
 
-python-dateutil
+ciso8601
 trafaret
 django
 djangorestframework

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -105,8 +105,11 @@ def null_missing_email():
 
 
 def rand_date():
-    r = random.randrange
-    return f'{r(1900, 2020)}-{r(0, 12)}-{r(0, 32)}T{r(0, 24)}:{r(0, 60)}:{r(0, 60)}'
+    ts = random.randrange(
+        datetime(1900, 1, 1).timestamp(),
+        datetime(2021, 1, 1).timestamp(),
+    )
+    return datetime.fromtimestamp(ts).isoformat()
 
 
 def remove_missing(d):

--- a/benchmarks/test_cattrs.py
+++ b/benchmarks/test_cattrs.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import attr
 import cattr
-from dateutil.parser import parse
+from ciso8601 import parse_datetime as parse
 
 
 class TestCAttrs:

--- a/benchmarks/test_cattrs.py
+++ b/benchmarks/test_cattrs.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 
 import attr
 import cattr
-from ciso8601 import parse_datetime as parse
 
 
 class TestCAttrs:
@@ -33,7 +32,7 @@ class TestCAttrs:
                 raise ValueError()
             return i
 
-        cattr.register_structure_hook(datetime, lambda isostring, _: parse(isostring))
+        cattr.register_structure_hook(datetime, lambda isostring, _: datetime.fromisoformat(isostring))
         cattr.register_structure_hook(str, structure_str)
         cattr.register_structure_hook(int, structure_int)
         cattr.register_structure_hook(PositiveInt, structure_posint)

--- a/benchmarks/test_cerberus.py
+++ b/benchmarks/test_cerberus.py
@@ -1,6 +1,5 @@
 from cerberus import Validator, __version__
-from dateutil.parser import parse as datetime_parse
-
+from ciso8601 import parse_datetime
 
 class TestCerberus:
     package = 'cerberus'
@@ -20,7 +19,7 @@ class TestCerberus:
             'contractor': {'type': 'integer', 'min': 0, 'nullable': True, 'coerce': int},
             'upstream_http_referrer': {'type': 'string', 'maxlength': 1023, 'nullable': True},
             'grecaptcha_response': {'type': 'string', 'minlength': 20, 'maxlength': 1000, 'required': True},
-            'last_updated': {'type': 'datetime', 'nullable': True, 'coerce': datetime_parse},
+            'last_updated': {'type': 'datetime', 'nullable': True, 'coerce': parse_datetime},
             'skills': {
                 'type': 'list',
                 'default': [],

--- a/benchmarks/test_cerberus.py
+++ b/benchmarks/test_cerberus.py
@@ -1,5 +1,6 @@
+from datetime import datetime
 from cerberus import Validator, __version__
-from ciso8601 import parse_datetime
+
 
 class TestCerberus:
     package = 'cerberus'
@@ -19,7 +20,7 @@ class TestCerberus:
             'contractor': {'type': 'integer', 'min': 0, 'nullable': True, 'coerce': int},
             'upstream_http_referrer': {'type': 'string', 'maxlength': 1023, 'nullable': True},
             'grecaptcha_response': {'type': 'string', 'minlength': 20, 'maxlength': 1000, 'required': True},
-            'last_updated': {'type': 'datetime', 'nullable': True, 'coerce': parse_datetime},
+            'last_updated': {'type': 'datetime', 'nullable': True, 'coerce': datetime.fromisoformat},
             'skills': {
                 'type': 'list',
                 'default': [],

--- a/benchmarks/test_trafaret.py
+++ b/benchmarks/test_trafaret.py
@@ -1,4 +1,4 @@
-from ciso8601 import parse_datetime as parse
+from datetime import datetime
 import trafaret as t
 
 
@@ -23,7 +23,7 @@ class TestTrafaret:
             t.Key('upstream_http_referrer', optional=True): t.Or(t.Null | t.String(max_length=1023)),
             t.Key('grecaptcha_response'): t.String(min_length=20, max_length=1000),
 
-            t.Key('last_updated', optional=True): t.Or(t.Null | t.String >> parse),
+            t.Key('last_updated', optional=True): t.Or(t.Null | t.String >> datetime.fromisoformat),
 
             t.Key('skills', default=[]): t.List(t.Dict({
                 'subject': t.String,

--- a/benchmarks/test_trafaret.py
+++ b/benchmarks/test_trafaret.py
@@ -1,4 +1,4 @@
-from dateutil.parser import parse
+from ciso8601 import parse_datetime as parse
 import trafaret as t
 
 

--- a/benchmarks/test_valideer.py
+++ b/benchmarks/test_valideer.py
@@ -1,7 +1,6 @@
 import re
 import subprocess
-
-from ciso8601 import parse_datetime
+from datetime import datetime
 
 import valideer as V
 
@@ -24,7 +23,7 @@ class TestValideer:
             'contractor': V.Range(V.AdaptTo(int), min_value=1),
             'upstream_http_referrer': V.Nullable(V.String(max_length=1023)),
             '+grecaptcha_response': V.String(min_length=20, max_length=1000),
-            'last_updated': V.AdaptBy(parse_datetime),
+            'last_updated': V.AdaptBy(datetime.fromisoformat),
             'skills': V.Nullable(
                 [
                     {

--- a/benchmarks/test_valideer.py
+++ b/benchmarks/test_valideer.py
@@ -1,7 +1,8 @@
 import re
 import subprocess
 
-import dateutil.parser
+from ciso8601 import parse_datetime
+
 import valideer as V
 
 # valideer appears to provide no way of getting the installed version
@@ -23,7 +24,7 @@ class TestValideer:
             'contractor': V.Range(V.AdaptTo(int), min_value=1),
             'upstream_http_referrer': V.Nullable(V.String(max_length=1023)),
             '+grecaptcha_response': V.String(min_length=20, max_length=1000),
-            'last_updated': V.AdaptBy(dateutil.parser.parse),
+            'last_updated': V.AdaptBy(parse_datetime),
             'skills': V.Nullable(
                 [
                     {

--- a/benchmarks/test_voluptuous.py
+++ b/benchmarks/test_voluptuous.py
@@ -1,4 +1,4 @@
-from ciso8601 import parse_datetime
+from datetime import datetime
 import voluptuous as v
 from voluptuous.humanize import humanize_error
 
@@ -27,7 +27,7 @@ class TestVoluptuous:
                 v.Optional('contractor'): v.Maybe(v.All(v.Coerce(int), v.Range(min=1))),
                 v.Optional('upstream_http_referrer'): v.Maybe(v.All(str, v.Length(max=1023))),
                 v.Required('grecaptcha_response'): v.All(str, v.Length(min=20, max=1000)),
-                v.Optional('last_updated'): v.Maybe(parse_datetime),
+                v.Optional('last_updated'): v.Maybe(datetime.fromisoformat),
                 v.Required('skills', default=[]): [
                     v.Schema(
                         {

--- a/benchmarks/test_voluptuous.py
+++ b/benchmarks/test_voluptuous.py
@@ -1,4 +1,4 @@
-from dateutil.parser import parse as parse_datetime
+from ciso8601 import parse_datetime
 import voluptuous as v
 from voluptuous.humanize import humanize_error
 

--- a/docs/.benchmarks_table.md
+++ b/docs/.benchmarks_table.md
@@ -2,11 +2,11 @@
 
 Package | Version | Relative Performance | Mean validation time
 --- | --- | --- | ---
-attrs + cattrs | `19.3.0` |  | 9.4μs
-valideer | `0.4.2` | 1.4x slower | 12.9μs
-trafaret | `2.0.2` | 7.1x slower | 66.5μs
-pydantic | `1.5.1` | 8.7x slower | 81.3μs
-voluptuous | `0.11.7` | 9.4x slower | 88.1μs
-marshmallow | `3.6.0` | 15.3x slower | 143.0μs
-django-rest-framework | `3.11.0` | 75.1x slower | 703.4μs
-cerberus | `1.3.2` | 146.2x slower | 1368.9μs
+attrs + cattrs | `19.3.0` |  | 16.1μs
+valideer | `0.4.2` | 1.3x slower | 21.1μs
+pydantic | `1.5.1` | 4.3x slower | 69.8μs
+voluptuous | `0.11.7` | 4.5x slower | 73.0μs
+trafaret | `2.0.2` | 6.9x slower | 111.6μs
+marshmallow | `3.6.0` | 7.2x slower | 115.9μs
+django-rest-framework | `3.11.0` | 39.6x slower | 638.3μs
+cerberus | `1.3.2` | 77.5x slower | 1248.8μs

--- a/docs/.benchmarks_table.md
+++ b/docs/.benchmarks_table.md
@@ -2,10 +2,11 @@
 
 Package | Version | Relative Performance | Mean validation time
 --- | --- | --- | ---
-pydantic | `1.1` |  | 43.6μs
-attrs + cattrs | `19.3.0` | 1.4x slower | 59.9μs
-valideer | `0.4.2` | 1.4x slower | 61.8μs
-marshmallow | `3.2.2` | 2.5x slower | 107.6μs
-trafaret | `2.0.0` | 3.4x slower | 148.7μs
-django-rest-framework | `3.10.3` | 12.6x slower | 551.2μs
-cerberus | `1.3.2` | 26.3x slower | 1146.3μs
+attrs + cattrs | `19.3.0` |  | 11.0μs
+valideer | `0.4.2` | 1.5x slower | 16.9μs
+trafaret | `2.0.2` | 5.7x slower | 63.3μs
+pydantic | `1.5.1` | 6.7x slower | 73.3μs
+voluptuous | `0.11.7` | 7.7x slower | 85.0μs
+marshmallow | `3.6.0` | 11.2x slower | 123.2μs
+django-rest-framework | `3.11.0` | 59.7x slower | 657.4μs
+cerberus | `1.3.2` | 129.8x slower | 1429.2μs

--- a/docs/.benchmarks_table.md
+++ b/docs/.benchmarks_table.md
@@ -2,11 +2,11 @@
 
 Package | Version | Relative Performance | Mean validation time
 --- | --- | --- | ---
-attrs + cattrs | `19.3.0` |  | 11.0μs
-valideer | `0.4.2` | 1.5x slower | 16.9μs
-trafaret | `2.0.2` | 5.7x slower | 63.3μs
-pydantic | `1.5.1` | 6.7x slower | 73.3μs
-voluptuous | `0.11.7` | 7.7x slower | 85.0μs
-marshmallow | `3.6.0` | 11.2x slower | 123.2μs
-django-rest-framework | `3.11.0` | 59.7x slower | 657.4μs
-cerberus | `1.3.2` | 129.8x slower | 1429.2μs
+attrs + cattrs | `19.3.0` |  | 9.4μs
+valideer | `0.4.2` | 1.4x slower | 12.9μs
+trafaret | `2.0.2` | 7.1x slower | 66.5μs
+pydantic | `1.5.1` | 8.7x slower | 81.3μs
+voluptuous | `0.11.7` | 9.4x slower | 88.1μs
+marshmallow | `3.6.0` | 15.3x slower | 143.0μs
+django-rest-framework | `3.11.0` | 75.1x slower | 703.4μs
+cerberus | `1.3.2` | 146.2x slower | 1368.9μs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Seeing that `docs/.benchmarks_table.md` hadn't been updated for quite a while, I ran it along with a profiler to compare against attrs.

I noticed that the results were quite skewed due to attrs using dateutil vs the custom date parser in pydantic. It seemed only fair to give attrs a better one, since it's not dateutil we're interested in here. So I replaced dateutil with ciso8601 in the benchmark.

This changed things drastically! Now attrs and valideer beats pydantic by a huge margin. Do others get similar results?

Cheers!

## Related issue number

None

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
