### PR TITLE
Support OrderedDict

### DIFF
--- a/changes/1570-saulshanabrook.md
+++ b/changes/1570-saulshanabrook.md
@@ -1,0 +1,1 @@
+Serialize OrderedDict as lists of lists to preserve order and support OrderedDict from typing.

--- a/docs/examples/types_iterables.py
+++ b/docs/examples/types_iterables.py
@@ -1,4 +1,14 @@
-from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union, OrderedDict
+from typing import (
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    OrderedDict,
+)
 
 from pydantic import BaseModel
 

--- a/docs/examples/types_iterables.py
+++ b/docs/examples/types_iterables.py
@@ -1,4 +1,4 @@
-from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union, OrderedDict
 
 from pydantic import BaseModel
 
@@ -23,6 +23,8 @@ class Model(BaseModel):
 
     compound: Dict[Union[str, bytes], List[Set[int]]] = None
 
+    ordered_dict: OrderedDict[int, int] = None
+
 print(Model(simple_list=['1', '2', '3']).simple_list)
 print(Model(list_of_ints=['1', '2', '3']).list_of_ints)
 
@@ -34,3 +36,5 @@ print(Model(tuple_of_different_types=[4, 3, 2, 1]).tuple_of_different_types)
 
 print(Model(sequence_of_ints=[1, 2, 3, 4]).sequence_of_ints)
 print(Model(sequence_of_ints=(1, 2, 3, 4)).sequence_of_ints)
+
+print(Model(ordered_dict=((1, 2), (3, 4))).ordered_dict)

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -85,7 +85,7 @@ with custom properties and validation.
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
 `typing.OrderedDict`
-: Serialized as lists of lists, to preserve order. see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
+: Serialized as lists of lists, to preserve order. Requires Python >= 3.7. see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
 `typing.Set`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -84,6 +84,9 @@ with custom properties and validation.
 `typing.Dict`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
+`typing.OrderedDict`
+: Serialized as lists of lists, to preserve order. see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
+
 `typing.Set`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import OrderedDict
-from collections.abc import Iterable as CollectionsIterable, MutableMapping
+from collections.abc import Iterable as CollectionsIterable
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -12,6 +12,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    MutableMapping,
     Optional,
     Pattern,
     Sequence,
@@ -668,7 +669,12 @@ class ModelField(Representation):
             return tuple(result), None
 
     def _validate_mapping(
-        self, v: Any, values: Dict[str, Any], loc: 'LocStr', cls: Optional['ModelOrDc'], result: MutableMapping
+        self,
+        v: Any,
+        values: Dict[str, Any],
+        loc: 'LocStr',
+        cls: Optional['ModelOrDc'],
+        result: MutableMapping[Any, Any],
     ) -> 'ValidateReturn':
         try:
             v_iter = dict_validator(v)

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -404,7 +404,7 @@ def field_type_schema(
 
         f_schema = {
             'type': 'array',
-            'items': {"items": [key_schema, value_schema], "maxItems": 2, "minItems": 2, "type": "array"},
+            'items': {'items': [key_schema, value_schema], 'maxItems': 2, 'minItems': 2, 'type': 'array'},
         }
 
     elif field.shape == SHAPE_MAPPING:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2,7 +2,7 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, OrderedDict, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 import pytest
 
@@ -19,6 +19,11 @@ from pydantic import (
     validator,
 )
 from pydantic.fields import Field, Schema
+
+try:
+    from typing import OrderedDict
+except ImportError:
+    OrderedDict = None
 
 
 def test_str_bytes():
@@ -1109,12 +1114,14 @@ class DisplayGen(Generic[T1, T2]):
         (List[Tuple[int, int]], 'List[Tuple[int, int]]'),
         (Dict[int, str], 'Mapping[int, str]'),
         (FrozenSet[int], 'FrozenSet[int]'),
-        (OrderedDict[int, int], 'OrderedDict[int, int]'),
         (Tuple[int, ...], 'Tuple[int, ...]'),
         (Optional[List[int]], 'Optional[List[int]]'),
         (dict, 'dict'),
         (DisplayGen[bool, str], 'DisplayGen[bool, str]'),
-    ],
+    ]
+    + [(OrderedDict[int, int], 'OrderedDict[int, int]')]
+    if OrderedDict
+    else [],
 )
 def test_field_type_display(type_, expected):
     class Model(BaseModel):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2,7 +2,7 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, OrderedDict, Set, Tuple, Type, TypeVar, Union
 
 import pytest
 
@@ -1109,6 +1109,7 @@ class DisplayGen(Generic[T1, T2]):
         (List[Tuple[int, int]], 'List[Tuple[int, int]]'),
         (Dict[int, str], 'Mapping[int, str]'),
         (FrozenSet[int], 'FrozenSet[int]'),
+        (OrderedDict[int, int], 'OrderedDict[int, int]'),
         (Tuple[int, ...], 'Tuple[int, ...]'),
         (Optional[List[int]], 'Optional[List[int]]'),
         (dict, 'dict'),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from typing import List
+from typing import List, OrderedDict
 from uuid import UUID
 
 import pytest
@@ -84,11 +84,12 @@ def test_model_encoding():
         b: bytes
         c: Decimal
         d: ModelA
+        e: OrderedDict[int, int]
 
-    m = Model(a=10.2, b='foobar', c=10.2, d={'x': 123, 'y': '123'})
-    assert m.dict() == {'a': 10.2, 'b': b'foobar', 'c': Decimal('10.2'), 'd': {'x': 123, 'y': '123'}}
-    assert m.json() == '{"a": 10.2, "b": "foobar", "c": 10.2, "d": {"x": 123, "y": "123"}}'
-    assert m.json(exclude={'b'}) == '{"a": 10.2, "c": 10.2, "d": {"x": 123, "y": "123"}}'
+    m = Model(a=10.2, b='foobar', c=10.2, d={'x': 123, 'y': '123'}, e=[[1, 2]])
+    assert m.dict() == {'a': 10.2, 'b': b'foobar', 'c': Decimal('10.2'), 'd': {'x': 123, 'y': '123'}, 'e': [(1, 2)]}
+    assert m.json() == '{"a": 10.2, "b": "foobar", "c": 10.2, "d": {"x": 123, "y": "123"}, "e": [[1, 2]]}'
+    assert m.json(exclude={'b'}) == '{"a": 10.2, "c": 10.2, "d": {"x": 123, "y": "123"}, "e": [[1, 2]]}'
 
 
 def test_subclass_encoding():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,12 +1,13 @@
 import datetime
 import json
 import sys
+from collections import OrderedDict as OrderedDictCollections
 from dataclasses import dataclass as vanilla_dataclass
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from typing import List, OrderedDict
+from typing import List
 from uuid import UUID
 
 import pytest
@@ -16,6 +17,11 @@ from pydantic.color import Color
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.json import pydantic_encoder, timedelta_isoformat
 from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr
+
+try:
+    from typing import OrderedDict
+except ImportError:
+    OrderedDict = None
 
 
 class MyEnum(Enum):
@@ -84,7 +90,7 @@ def test_model_encoding():
         b: bytes
         c: Decimal
         d: ModelA
-        e: OrderedDict[int, int]
+        e: (OrderedDict[int, int] if OrderedDict else OrderedDictCollections)
 
     m = Model(a=10.2, b='foobar', c=10.2, d={'x': 123, 'y': '123'}, e=[[1, 2]])
     assert m.dict() == {'a': 10.2, 'b': b'foobar', 'c': Decimal('10.2'), 'd': {'x': 123, 'y': '123'}, 'e': [(1, 2)]}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,26 +2,12 @@ import math
 import os
 import sys
 import tempfile
-from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    FrozenSet,
-    Iterable,
-    List,
-    NewType,
-    Optional,
-    OrderedDict as OrderedDictTyped,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, NewType, Optional, OrderedDict, Set, Tuple, Union
 from uuid import UUID
 
 import pytest
@@ -1869,7 +1855,7 @@ def test_frozen_set():
 
 def test_ordered_dict():
     class Model(BaseModel):
-        a: OrderedDictTyped[int, str] = OrderedDict([[1, 'hi']])
+        a: OrderedDict[int, str] = OrderedDict([[1, 'hi']])
 
     assert Model.schema() == {
         'title': 'Model',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,12 +2,26 @@ import math
 import os
 import sys
 import tempfile
+from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, NewType, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    NewType,
+    Optional,
+    OrderedDict as OrderedDictTyped,
+    Set,
+    Tuple,
+    Union,
+)
 from uuid import UUID
 
 import pytest
@@ -1848,6 +1862,29 @@ def test_frozen_set():
                 'type': 'array',
                 'items': {'type': 'integer'},
                 'uniqueItems': True,
+            }
+        },
+    }
+
+
+def test_ordered_dict():
+    class Model(BaseModel):
+        a: OrderedDictTyped[int, str] = OrderedDict([[1, "hi"]])
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {
+            'a': {
+                'title': 'A',
+                'default': OrderedDict([[1, "hi"]]),
+                'type': 'array',
+                'items': {
+                    'type': 'array',
+                    'items': [{'type': 'integer'}, {'type': 'string'}],
+                    'minItems': 2,
+                    'maxItems': 2,
+                },
             }
         },
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1869,7 +1869,7 @@ def test_frozen_set():
 
 def test_ordered_dict():
     class Model(BaseModel):
-        a: OrderedDictTyped[int, str] = OrderedDict([[1, "hi"]])
+        a: OrderedDictTyped[int, str] = OrderedDict([[1, 'hi']])
 
     assert Model.schema() == {
         'title': 'Model',
@@ -1877,7 +1877,7 @@ def test_ordered_dict():
         'properties': {
             'a': {
                 'title': 'A',
-                'default': OrderedDict([[1, "hi"]]),
+                'default': OrderedDict([[1, 'hi']]),
                 'type': 'array',
                 'items': {
                     'type': 'array',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,12 +2,13 @@ import math
 import os
 import sys
 import tempfile
+from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, NewType, Optional, OrderedDict, Set, Tuple, Union
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, NewType, Optional, Set, Tuple, Union
 from uuid import UUID
 
 import pytest
@@ -1855,7 +1856,7 @@ def test_frozen_set():
 
 def test_ordered_dict():
     class Model(BaseModel):
-        a: OrderedDict[int, str] = OrderedDict([[1, 'hi']])
+        a: OrderedDict = OrderedDict([[1, 'hi']])
 
     assert Model.schema() == {
         'title': 'Model',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,7 +2,7 @@ import math
 import os
 import sys
 import tempfile
-from collections import OrderedDict
+from collections import OrderedDict as OrderedDictCollections
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
@@ -58,6 +58,12 @@ from pydantic.types import (
     constr,
 )
 from pydantic.typing import Literal
+
+try:
+    from typing import OrderedDict
+except ImportError:
+    OrderedDict = None
+
 
 try:
     import email_validator
@@ -1854,27 +1860,29 @@ def test_frozen_set():
     }
 
 
-def test_ordered_dict():
-    class Model(BaseModel):
-        a: OrderedDict = OrderedDict([[1, 'hi']])
+if OrderedDict:
 
-    assert Model.schema() == {
-        'title': 'Model',
-        'type': 'object',
-        'properties': {
-            'a': {
-                'title': 'A',
-                'default': OrderedDict([[1, 'hi']]),
-                'type': 'array',
-                'items': {
+    def test_typed_ordered_dict():
+        class Model(BaseModel):
+            a: OrderedDict[int, str] = OrderedDictCollections([[1, 'hi']])
+
+        assert Model.schema() == {
+            'title': 'Model',
+            'type': 'object',
+            'properties': {
+                'a': {
+                    'title': 'A',
+                    'default': OrderedDictCollections([[1, 'hi']]),
                     'type': 'array',
-                    'items': [{'type': 'integer'}, {'type': 'string'}],
-                    'minItems': 2,
-                    'maxItems': 2,
-                },
-            }
-        },
-    }
+                    'items': {
+                        'type': 'array',
+                        'items': [{'type': 'integer'}, {'type': 'string'}],
+                        'minItems': 2,
+                        'maxItems': 2,
+                    },
+                }
+            },
+        }
 
 
 def test_iterable():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import uuid
-from collections import OrderedDict
+from collections import OrderedDict as OrderedDictCollection
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
@@ -17,7 +17,7 @@ from typing import (
     MutableSet,
     NewType,
     Optional,
-    OrderedDict as OrderedDictTyping,
+    OrderedDict,
     Pattern,
     Sequence,
     Set,
@@ -637,7 +637,7 @@ def test_list_fails(value):
 
 def test_ordered_dict():
     class Model(BaseModel):
-        v: OrderedDict
+        v: OrderedDictCollection
 
     assert Model(v=OrderedDict([(1, 10), (2, 20)])).v == OrderedDict([(1, 10), (2, 20)])
     assert Model(v={1: 10, 2: 20}).v in (OrderedDict([(1, 10), (2, 20)]), OrderedDict([(2, 20), (1, 10)]))
@@ -650,7 +650,7 @@ def test_ordered_dict():
 
 def test_typed_ordered_dict():
     class Model(BaseModel):
-        v: OrderedDictTyping[int, List[int]]
+        v: OrderedDict[int, List[int]]
 
     # Test takes in three forms
     assert Model(v=OrderedDict([(1, [10]), (2, [20])])).v == OrderedDict([(1, [10]), (2, [20])])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,7 +17,6 @@ from typing import (
     MutableSet,
     NewType,
     Optional,
-    OrderedDict,
     Pattern,
     Sequence,
     Set,
@@ -62,6 +61,11 @@ from pydantic import (
     errors,
     validator,
 )
+
+try:
+    from typing import OrderedDict
+except ImportError:
+    OrderedDict = None
 
 try:
     import email_validator

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import uuid
-from collections import OrderedDict as OrderedDictCollection
+from collections import OrderedDict as OrderedDictCollections
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
@@ -637,35 +637,48 @@ def test_list_fails(value):
 
 def test_ordered_dict():
     class Model(BaseModel):
-        v: OrderedDictCollection
+        v: OrderedDictCollections
 
-    assert Model(v=OrderedDict([(1, 10), (2, 20)])).v == OrderedDict([(1, 10), (2, 20)])
-    assert Model(v={1: 10, 2: 20}).v in (OrderedDict([(1, 10), (2, 20)]), OrderedDict([(2, 20), (1, 10)]))
-    assert Model(v=[(1, 2), (3, 4)]).v == OrderedDict([(1, 2), (3, 4)])
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model(v=[1, 2, 3])
-    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
-
-
-def test_typed_ordered_dict():
-    class Model(BaseModel):
-        v: OrderedDict[int, List[int]]
-
-    # Test takes in three forms
-    assert Model(v=OrderedDict([(1, [10]), (2, [20])])).v == OrderedDict([(1, [10]), (2, [20])])
-    assert Model(v={1: [10], 2: [20]}).v in (OrderedDict([(1, [10]), (2, [20])]), OrderedDict([(2, [20]), (1, [10])]))
-    assert Model(v=[(1, [2]), (3, [4])]).v == OrderedDict([(1, [2]), (3, [4])])
-
-    # test handles sub types
-    assert Model(v=[(1, (2,))]).v == OrderedDict([(1, [2])])
+    assert Model(v=OrderedDictCollections([(1, 10), (2, 20)])).v == OrderedDictCollections([(1, 10), (2, 20)])
+    assert Model(v={1: 10, 2: 20}).v in (
+        OrderedDictCollections([(1, 10), (2, 20)]),
+        OrderedDictCollections([(2, 20), (1, 10)]),
+    )
+    assert Model(v=[(1, 2), (3, 4)]).v == OrderedDictCollections([(1, 2), (3, 4)])
 
     # Test it returns orderedDict
-    assert isinstance(Model(v=[]).v, OrderedDict)
+    assert isinstance(Model(v=[]).v, OrderedDictCollections)
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, 3])
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
+
+
+if OrderedDict:
+
+    def test_typed_ordered_dict():
+        class Model(BaseModel):
+            v: OrderedDict[int, List[int]]
+
+        # Test takes in three forms
+        assert Model(v=OrderedDict([(1, [10]), (2, [20])])).v == OrderedDict([(1, [10]), (2, [20])])
+        assert Model(v={1: [10], 2: [20]}).v in (
+            OrderedDict([(1, [10]), (2, [20])]),
+            OrderedDict([(2, [20]), (1, [10])]),
+        )
+        assert Model(v=[(1, [2]), (3, [4])]).v == OrderedDict([(1, [2]), (3, [4])])
+
+        # test handles sub types
+        assert Model(v=[(1, (2,))]).v == OrderedDict([(1, [2])])
+
+        # Test it returns orderedDict
+        assert isinstance(Model(v=[]).v, OrderedDict)
+
+        with pytest.raises(ValidationError) as exc_info:
+            Model(v=[1, 2, 3])
+        assert exc_info.value.errors() == [
+            {'loc': ('v',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}
+        ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

This adds support for `OrderedDict`s, preserving order on serialization, by turning them into a list of lists.

## Related issue number

Fixes https://github.com/samuelcolvin/pydantic/issues/1569 and fixes https://github.com/samuelcolvin/pydantic/issues/1572

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
