### PR TITLE
Apply __modify_schema__ on enum schema rather than fields that use it

### DIFF
--- a/changes/1581-therefromhere.md
+++ b/changes/1581-therefromhere.md
@@ -1,0 +1,1 @@
+Make `__modify_schema__` on Enums apply to the enum schema rather than fields that use the enum.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -545,6 +545,10 @@ def enum_process_schema(enum: Type[Enum]) -> Dict[str, Any]:
 
     add_field_type_to_schema(enum, schema)
 
+    modify_schema = getattr(enum, '__modify_schema__', None)
+    if modify_schema:
+        modify_schema(schema)
+
     return schema
 
 
@@ -698,9 +702,9 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     else:
         add_field_type_to_schema(field_type, f_schema)
 
-    modify_schema = getattr(field_type, '__modify_schema__', None)
-    if modify_schema:
-        modify_schema(f_schema)
+        modify_schema = getattr(field_type, '__modify_schema__', None)
+        if modify_schema:
+            modify_schema(f_schema)
 
     if f_schema:
         return f_schema, definitions, nested_models

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -229,7 +229,7 @@ def test_enum_modify_schema():
 
         @classmethod
         def __modify_schema__(cls, field_schema):
-            field_schema['tsEnumNames'] = list(e.name for e in cls)
+            field_schema['tsEnumNames'] =  [e.name for e in cls]
 
     class Model(BaseModel):
         spam: SpamEnum = Field(None)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -222,6 +222,34 @@ def test_choices():
     }
 
 
+def test_enum_modify_schema():
+    class SpamEnum(str, Enum):
+        foo = 'f'
+        bar = 'b'
+
+        @classmethod
+        def __modify_schema__(cls, field_schema):
+            field_schema['tsEnumNames'] = list(e.name for e in cls)
+
+    class Model(BaseModel):
+        spam: SpamEnum = Field(None)
+
+    assert Model.schema() == {
+        'definitions': {
+            'SpamEnum': {
+                'description': 'An enumeration.',
+                'enum': ['f', 'b'],
+                'title': 'SpamEnum',
+                'tsEnumNames': ['foo', 'bar'],
+                'type': 'string',
+            }
+        },
+        'properties': {'spam': {'$ref': '#/definitions/SpamEnum'}},
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
 def test_json_schema():
     class Model(BaseModel):
         a = b'foobar'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -229,7 +229,7 @@ def test_enum_modify_schema():
 
         @classmethod
         def __modify_schema__(cls, field_schema):
-            field_schema['tsEnumNames'] =  [e.name for e in cls]
+            field_schema['tsEnumNames'] = [e.name for e in cls]
 
     class Model(BaseModel):
         spam: SpamEnum = Field(None)


### PR DESCRIPTION
## Change Summary

Make `__modify_schema__` on enums apply to the enum schema rather than fields that use the enum.

Resolves #1576 

Does this seem like a reasonable thing to do?


## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
