### PR TITLE
Fix #1561 - apply Config env names for fields defined in the parent c…

### DIFF
--- a/changes/1561-ojomio.md
+++ b/changes/1561-ojomio.md
@@ -1,0 +1,2 @@
+Allow descendant Settings models to override env variable names for the fields defined in parent Settings models with `env` in their `Config`.
+Previously only `env_prefix` configuration option was applicable

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Union
 
 from .fields import ModelField
-from .main import BaseModel, Extra
+from .main import BaseConfig, BaseModel, Extra
 from .typing import display_as_type
 from .utils import deep_update, sequence_like
 
@@ -65,7 +65,7 @@ class BaseSettings(BaseModel):
             d[field.alias] = env_val
         return d
 
-    class Config(BaseModel.Config):
+    class Config(BaseConfig):
         env_prefix = ''
         env_file = None
         validate_all = True

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -3,7 +3,7 @@ import warnings
 from pathlib import Path
 from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Union
 
-from .fields import FieldInfo, ModelField
+from .fields import ModelField
 from .main import BaseModel, Extra
 from .typing import display_as_type
 from .utils import deep_update, sequence_like

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -3,7 +3,7 @@ import warnings
 from pathlib import Path
 from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Union
 
-from .fields import ModelField
+from .fields import FieldInfo, ModelField
 from .main import BaseModel, Extra
 from .typing import display_as_type
 from .utils import deep_update, sequence_like
@@ -65,7 +65,7 @@ class BaseSettings(BaseModel):
             d[field.alias] = env_val
         return d
 
-    class Config:
+    class Config(BaseModel.Config):
         env_prefix = ''
         env_file = None
         validate_all = True
@@ -76,7 +76,9 @@ class BaseSettings(BaseModel):
         @classmethod
         def prepare_field(cls, field: ModelField) -> None:
             env_names: Union[List[str], AbstractSet[str]]
-            env = field.field_info.extra.get('env')
+            field_info_from_config = cls.get_field_info(field.name)
+
+            env = field_info_from_config.get('env') or field.field_info.extra.get('env')
             if env is None:
                 if field.has_alias:
                     warnings.warn(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 import pytest
 
@@ -219,6 +219,22 @@ def test_env_inheritance_field(env):
     assert SettingsParent(foobar='abc').foobar == 'abc'
     assert SettingsChild().foobar == 'child default'
     assert SettingsChild(foobar='abc').foobar == 'abc'
+
+
+def test_env_inheritance_config(env):
+    class Parent(BaseSettings):
+        foobar: Optional[str]
+
+    class Child(Parent):
+        class Config:
+            env_prefix = 'prefix_'
+            fields = {
+                'foobar': {'env': ['foobar_env'],},
+            }
+
+    env.set('foobar_env', 'env value')
+
+    assert Child().foobar == 'env value'
 
 
 def test_env_invalid(env):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -221,7 +221,94 @@ def test_env_inheritance_field(env):
     assert SettingsChild(foobar='abc').foobar == 'abc'
 
 
+def test_env_prefix_inheritance_config(env):
+    env.set('foobar', 'foobar')
+    env.set('prefix_foobar', 'prefix_foobar')
+
+    env.set('foobar_parent_from_field', 'foobar_parent_from_field')
+    env.set('foobar_child_from_field', 'foobar_child_from_field')
+
+    env.set('foobar_parent_from_config', 'foobar_parent_from_config')
+    env.set('foobar_child_from_config', 'foobar_child_from_config')
+
+    # . Child prefix does not override explicit parent field config
+    class Parent(BaseSettings):
+        foobar: str = Field(None, env='foobar_parent_from_field')
+
+    class Child(Parent):
+        class Config:
+            env_prefix = 'prefix_'
+
+    assert Child().foobar == 'foobar_parent_from_field'
+
+    # c. Child prefix does not override explicit parent class config
+    class Parent(BaseSettings):
+        foobar: str = None
+
+        class Config:
+            fields = {
+                'foobar': {'env': ['foobar_parent_from_config']},
+            }
+
+    class Child(Parent):
+        class Config:
+            env_prefix = 'prefix_'
+
+    assert Child().foobar == 'foobar_parent_from_config'
+
+    # d. Child prefix overrides parent with implicit config
+    class Parent(BaseSettings):
+        foobar: str = None
+
+    class Child(Parent):
+        class Config:
+            env_prefix = 'prefix_'
+
+    assert Child().foobar == 'prefix_foobar'
+
+
 def test_env_inheritance_config(env):
+    env.set('foobar', 'foobar')
+    env.set('prefix_foobar', 'prefix_foobar')
+
+    env.set('foobar_parent_from_field', 'foobar_parent_from_field')
+    env.set('foobar_child_from_field', 'foobar_child_from_field')
+
+    env.set('foobar_parent_from_config', 'foobar_parent_from_config')
+    env.set('foobar_child_from_config', 'foobar_child_from_config')
+
+    # a. Child class config overrides prefix and parent field config
+    class Parent(BaseSettings):
+        foobar: str = Field(None, env='foobar_parent_from_field')
+
+    class Child(Parent):
+        class Config:
+            env_prefix = 'prefix_'
+            fields = {
+                'foobar': {'env': ['foobar_child_from_config']},
+            }
+
+    assert Child().foobar == 'foobar_child_from_config'
+
+    # b. Child class config overrides prefix and parent class config
+    class Parent(BaseSettings):
+        foobar: str = None
+
+        class Config:
+            fields = {
+                'foobar': {'env': ['foobar_parent_from_config']},
+            }
+
+    class Child(Parent):
+        class Config:
+            env_prefix = 'prefix_'
+            fields = {
+                'foobar': {'env': ['foobar_child_from_config']},
+            }
+
+    assert Child().foobar == 'foobar_child_from_config'
+
+    # . Child class config overrides prefix and parent with implicit config
     class Parent(BaseSettings):
         foobar: Optional[str]
 
@@ -229,12 +316,10 @@ def test_env_inheritance_config(env):
         class Config:
             env_prefix = 'prefix_'
             fields = {
-                'foobar': {'env': ['foobar_env']},
+                'foobar': {'env': ['foobar_child_from_field']},
             }
 
-    env.set('foobar_env', 'env value')
-
-    assert Child().foobar == 'env value'
+    assert Child().foobar == 'foobar_child_from_field'
 
 
 def test_env_invalid(env):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -229,7 +229,7 @@ def test_env_inheritance_config(env):
         class Config:
             env_prefix = 'prefix_'
             fields = {
-                'foobar': {'env': ['foobar_env'],},
+                'foobar': {'env': ['foobar_env']},
             }
 
     env.set('foobar_env', 'env value')


### PR DESCRIPTION
…lass

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Allow descendant Settings to override env variable names for fields defined in parent Settings

#1561 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
