### PR TITLE
aggregate root validation errors

### DIFF
--- a/changes/1586-beezee.md
+++ b/changes/1586-beezee.md
@@ -1,0 +1,1 @@
+Adjust handling of root validators so that errors are aggregated from _all_ failing root validators, instead of reporting on only the first root validator to fail.

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -99,7 +99,7 @@ validation occurs (and are provided with the raw input data), or `pre=False` (th
 they're called after field validation.
 
 Field validation will not occur if `pre=True` root validators raise an error. As with field validators,
-"post" (i.e. `pre=False`) root validators by default will be called even if field validation fails; this
+"post" (i.e. `pre=False`) root validators by default will be called even if prior validators fail; this
 behaviour can be changed by setting the `skip_on_failure=True` keyword argument to the validator.
 The `values` argument will be a dict containing the values which passed field validation and
 field defaults where applicable.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -42,6 +42,7 @@ from .utils import (
     generate_model_signature,
     lenient_issubclass,
     sequence_like,
+    unique_list,
     validate_field_name,
 )
 
@@ -288,27 +289,13 @@ class ModelMetaclass(ABCMeta):
             json_encoder = pydantic_encoder
         pre_rv_new, post_rv_new = extract_root_validators(namespace)
 
-        dedupe_pre_rv = set([])
-        pre_rv_unique = []
-        for rv in pre_root_validators + pre_rv_new:
-            if rv not in dedupe_pre_rv:
-                dedupe_pre_rv.add(rv)
-                pre_rv_unique.append(rv)
-
-        dedupe_post_rv = set([])
-        post_rv_unique = []
-        for rv in post_root_validators + post_rv_new:
-            if rv not in dedupe_post_rv:
-                dedupe_post_rv.add(rv)
-                post_rv_unique.append(rv)
-
         new_namespace = {
             '__config__': config,
             '__fields__': fields,
             '__field_defaults__': fields_defaults,
             '__validators__': vg.validators,
-            '__pre_root_validators__': pre_rv_unique,
-            '__post_root_validators__': post_rv_unique,
+            '__pre_root_validators__': unique_list(pre_root_validators + pre_rv_new),
+            '__post_root_validators__': unique_list(post_root_validators + post_rv_new),
             '__schema_cache__': {},
             '__json_encoder__': staticmethod(json_encoder),
             '__custom_root_type__': _custom_root_type,

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -221,6 +221,23 @@ def to_camel(string: str) -> str:
     return ''.join(word.capitalize() for word in string.split('_'))
 
 
+T = TypeVar('T')
+
+
+def unique_list(input_list: Union[List[T], Tuple[T, ...]]) -> List[T]:
+    """
+    Make a list unique while maintaining order.
+    """
+    result = []
+    unique_set = set()
+    for v in input_list:
+        if v not in unique_set:
+            unique_set.add(v)
+            result.append(v)
+
+    return result
+
+
 class PyObjectStr(str):
     """
     String class where repr doesn't include quotes. Useful with Representation when you want to return a string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from pydantic.utils import (
     import_string,
     lenient_issubclass,
     truncate,
+    unique_list,
 )
 from pydantic.version import version_info
 
@@ -99,6 +100,19 @@ def test_lenient_issubclass_is_lenient():
 def test_truncate(input_value, output):
     with pytest.warns(DeprecationWarning, match='`truncate` is no-longer used by pydantic and is deprecated'):
         assert truncate(input_value, max_len=20) == output
+
+
+@pytest.mark.parametrize(
+    'input_value,output',
+    [
+        ([], []),
+        ([1, 1, 1, 2, 1, 2, 3, 2, 3, 1, 4, 2, 3, 1], [1, 2, 3, 4]),
+        (['a', 'a', 'b', 'a', 'b', 'c', 'b', 'c', 'a'], ['a', 'b', 'c']),
+    ],
+)
+def test_unique_list(input_value, output):
+    assert unique_list(input_value) == output
+    assert unique_list(unique_list(input_value)) == unique_list(input_value)
 
 
 def test_value_items():


### PR DESCRIPTION
## Change Summary

This change enables aggregation of multiple root validation errors. 

It turns out deduplication of root validators is necessary in the metaclass, since it appears `__new__` is called twice for generics, once at class definition, and another when type arguments are applied (seems like semantically python is creating an on-the-fly subclass with the type variables unified,) the second of which results in all root validators defined on the class itself appearing in a base for the type-arg-unified subclass as well as on the type-arg-unified subclass itself, hence duplicating all of them. The issue is caught by current generic tests, but was masked by the short-circuiting (duplication of root validators was not apparent because root validation was halted after the first failure.)

Added test coverage to make sure multiple root validators can fail simultaneously.

## Related issue number

#1571 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
