### PR TITLE
Update datetime parser to support negative timestamps

### DIFF
--- a/changes/1600-mlbiche.md
+++ b/changes/1600-mlbiche.md
@@ -1,0 +1,1 @@
+Update datetime parser to support negative timestamps

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -248,7 +248,7 @@ types:
 * `datetime` fields can be:
 
     * `datetime`, existing `datetime` object
-    * `int` or `float`, assumed as Unix time, i.e. seconds (if <= `2e10`) or milliseconds (if > `2e10`) since 1 January 1970
+    * `int` or `float`, assumed as Unix time, i.e. seconds (if >= `-2e10` or <= `2e10`) or milliseconds (if < `-2e10`or > `2e10`) since 1 January 1970
     * `str`, following formats work:
 
         * `YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z[±]HH[:]MM]]]`

--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -75,7 +75,7 @@ def get_numeric(value: StrBytesIntFloat, native_expected_type: str) -> Union[Non
 
 
 def from_unix_seconds(seconds: Union[int, float]) -> datetime:
-    while seconds > MS_WATERSHED:
+    while abs(seconds) > MS_WATERSHED:
         seconds /= 1000
     dt = EPOCH + timedelta(seconds=seconds)
     return dt.replace(tzinfo=timezone.utc)

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -93,6 +93,7 @@ def test_time_parsing(value, result):
         (1_494_012_444, datetime(2017, 5, 5, 19, 27, 24, tzinfo=timezone.utc)),
         # values in ms
         ('1494012444000.883309', datetime(2017, 5, 5, 19, 27, 24, 883, tzinfo=timezone.utc)),
+        ('-1494012444000.883309', datetime(1922, 8, 29, 4, 32, 35, 999117, tzinfo=timezone.utc)),
         (1_494_012_444_000, datetime(2017, 5, 5, 19, 27, 24, tzinfo=timezone.utc)),
         ('2012-04-23T09:15:00', datetime(2012, 4, 23, 9, 15)),
         ('2012-4-9 4:8:16', datetime(2012, 4, 9, 4, 8, 16)),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Update datetime parser to support negative timestamps. Negative timestamps corresponds to dates before 1970/1/1.

<!-- Please give a short summary of the changes. -->

## Related issue number

Close #1600 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
