### PR TITLE
squash internal __root__ models in .dict()

### DIFF
--- a/changes/1414-patrickkwang.md
+++ b/changes/1414-patrickkwang.md
@@ -1,0 +1,1 @@
+Squash internal `__root__` dicts in `.dict()` (and, by extension, in `.json()`).

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -606,7 +606,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
         if isinstance(v, BaseModel):
             if to_dict:
-                return v.dict(
+                v_dict = v.dict(
                     by_alias=by_alias,
                     exclude_unset=exclude_unset,
                     exclude_defaults=exclude_defaults,
@@ -614,6 +614,9 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                     exclude=exclude,
                     exclude_none=exclude_none,
                 )
+                if '__root__' in v_dict:
+                    return v_dict['__root__']
+                return v_dict
             else:
                 return v.copy(include=include, exclude=exclude)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -863,6 +863,26 @@ def test_root_list():
     assert m.__root__ == ['a']
 
 
+def test_encode_nested_root():
+    house_dict = {'pets': ['dog', 'cats']}
+
+    class Pets(BaseModel):
+        __root__: List[str]
+
+    class House(BaseModel):
+        pets: Pets
+
+    assert House(**house_dict).dict() == house_dict
+
+    class PetsDeep(BaseModel):
+        __root__: Pets
+
+    class HouseDeep(BaseModel):
+        pets: PetsDeep
+
+    assert HouseDeep(**house_dict).dict() == house_dict
+
+
 def test_root_failed():
     with pytest.raises(ValueError, match='__root__ cannot be mixed with other fields'):
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
This change squashes `{'__root__': X}` → `X` when converting a nested model to dict. This does _not_ make that change at the outermost level, so `.dict()` still always returns a dict (as discussed in #1193).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1414 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
