### PR TITLE
fix: type hints on BaseConfig

### DIFF
--- a/changes/1614-PrettyWood.md
+++ b/changes/1614-PrettyWood.md
@@ -1,0 +1,1 @@
+Ensure `SchemaExtraCallable` is always defined to get type hints on BaseConfig.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -66,6 +66,10 @@ if TYPE_CHECKING:
             pass
 
 
+else:
+    SchemaExtraCallable = Callable[..., None]
+
+
 try:
     import cython  # type: ignore
 except ImportError:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 import sys
 from enum import Enum
-from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Type
+from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Type, get_type_hints
 from uuid import UUID, uuid4
 
 import pytest
@@ -1119,3 +1119,10 @@ def test_reuse_same_field():
         Model1.parse_obj({})
     with pytest.raises(ValidationError):
         Model2.parse_obj({})
+
+
+def test_base_config_type_hinting():
+    class M(BaseModel):
+        a: int
+
+    get_type_hints(M.__config__)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Just added `SchemaExtraCallable` when `TYPE_CHECKING` is `False` to make sure `typing.get_type_hints` does not crash.

## Related issue number

closes #1614 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
