### PR TITLE
Use chain.from_iterable in class_validators.py

### DIFF
--- a/changes/1642-cool-RR.txt
+++ b/changes/1642-cool-RR.txt
@@ -1,3 +1,3 @@
-Use chain.from_iterable in class_validators.py.
-
-This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.
+Use `chain.from_iterable` in class_validators.py. This is a faster and more idiomatic way of using `itertools.chain`.
+Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never
+stored as a huge list. This can save on both runtime and memory space.

--- a/changes/1642-cool-RR.txt
+++ b/changes/1642-cool-RR.txt
@@ -1,0 +1,3 @@
+Use chain.from_iterable in class_validators.py.
+
+This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -164,11 +164,9 @@ class ValidatorGroup:
 
     def check_for_unused(self) -> None:
         unused_validators = set(
-            chain(
-                *[
-                    (v.func.__name__ for v in self.validators[f] if v.check_fields)
-                    for f in (self.validators.keys() - self.used_validators)
-                ]
+            chain.from_iterable(
+                (v.func.__name__ for v in self.validators[f] if v.check_fields)
+                for f in (self.validators.keys() - self.used_validators)
             )
         )
         if unused_validators:


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.