### PR TITLE
Document schema_extra calling convention

### DIFF
--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -156,7 +156,10 @@ Outputs:
 ```
 
 For more fine-grained control, you can alternatively set `schema_extra` to a callable and post-process the generated schema.
-The callable is passed the schema dictionary as the first and only argument, and is expected to mutate it *in-place*; the return value is not used.
+The callable can have one or two positional arguments.
+The first will be the schema dictionary.
+The second, if accepted, will be the model class.
+The callable is expected to mutate the schema dictionary *in-place*; the return value is not used.
 
 For example, the `title` key can be removed from the model's `properties`:
 


### PR DESCRIPTION
## Change Summary

Mention that `schema_extra` can take one or two arguments.

## Checklist

* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)

(do small documentation changes need this?)