### PR TITLE
added nested values construct assign to field when it is a model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ env/
 env36/
 env37/
 env38/
+venv/
+.venv/
 *.py[cod]
 *.egg-info/
 .python-version

--- a/changes/1643-fsramalho.md
+++ b/changes/1643-fsramalho.md
@@ -1,0 +1,1 @@
+Always assign values to the fields even when nested errors occurs for those values. 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -906,9 +906,17 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.extend(errors_)
 
                 if isinstance(value, dict):
-                    field_model = list(filter(lambda x: x, map(
-                        lambda y: getattr(y[0].exc, 'model', None)
-                        if isinstance(y, list) else getattr(y.exc, 'model', None), errors_)))
+                    field_model = list(
+                        filter(
+                            lambda x: x,
+                            map(
+                                lambda y: getattr(y[0].exc, 'model', None)
+                                if isinstance(y, list)
+                                else getattr(y.exc, 'model', None),
+                                errors_,
+                            )
+                        )
+                    )
 
                     if field_model:
                         v_ = field_model[-1].construct(**value)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -969,7 +969,7 @@ def parse_field_value_based_on_errors(value: Any, errors: Union[ErrorWrapper, Li
         field_model = field_models[0] if field_models else None
 
     else:
-        raise NotImplementedError(f"Errors from field.validate with type {type(errors)} not handled")
+        raise NotImplementedError(f'Errors from field.validate with type {type(errors)} not handled')
 
     if not field_model:
         return

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -914,7 +914,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
                                 if isinstance(y, list)
                                 else getattr(y.exc, 'model', None),
                                 errors_,
-                            )
+                            ),
                         )
                     )
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -894,6 +894,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
         if value is _missing:
             if field.required:
                 errors.append(ErrorWrapper(MissingError(), loc=field.alias))
+                values[name] = None
                 continue
 
             value = field.get_default()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -906,7 +906,9 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.extend(errors_)
 
                 if isinstance(value, dict):
-                    field_model = list(filter(lambda x: x, map(lambda y: getattr(y[0].exc, 'model', None) if isinstance(y, list) else getattr(y.exc, 'model', None), errors_)))
+                    field_model = list(filter(lambda x: x, map(
+                        lambda y: getattr(y[0].exc, 'model', None)
+                        if isinstance(y, list) else getattr(y.exc, 'model', None), errors_)))
 
                     if field_model:
                         v_ = field_model[-1].construct(**value)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -906,11 +906,10 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.extend(errors_)
 
                 if isinstance(value, dict):
-                    field_model = list(filter(lambda x: getattr(x[0].exc, 'model', None)
-                        if isinstance(x, list) else getattr(x.exc, 'model', None), errors_))
+                    field_model = list(filter(lambda x: x, map(lambda y: getattr(y[0].exc, 'model', None) if isinstance(y, list) else getattr(y.exc, 'model', None), errors_)))
 
                     if field_model:
-                        v_ = field_model[0].construct(**value)
+                        v_ = field_model[-1].construct(**value)
 
         values[name] = v_
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -897,7 +897,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.append(errors_)
 
                 if isinstance(value, dict):
-                    field_model = getattr(errors_.exc, "model", None)
+                    field_model = getattr(errors_.exc, 'model', None)
 
                     if field_model:
                         v_ = field_model.construct(**value)
@@ -906,7 +906,9 @@ def validate_model(  # noqa: C901 (ignore complexity)
                 errors.extend(errors_)
 
                 if isinstance(value, dict):
-                    field_model = list(filter(lambda x: getattr(x[0].exc, "model", None) if isinstance(x, list) else getattr(x.exc, "model", None), errors_))
+                    field_model = list(filter(lambda x: getattr(x[0].exc, 'model', None)
+                        if isinstance(x, list) else getattr(x.exc, 'model', None), errors_))
+
                     if field_model:
                         v_ = field_model[0].construct(**value)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -733,7 +733,7 @@ def test_return_errors_error():
     assert e.errors() == [{'loc': ('bar', 2), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}]
 
     d, f, e = validate_model(Model, {'bar': (1, 2, 3)}, False)
-    assert d == {'bar': [1, 2, 3]}
+    assert d == {'bar': [1, 2, 3], 'foo':None}
     assert f == {'bar'}
     assert e.errors() == [{'loc': ('foo',), 'msg': 'field required', 'type': 'value_error.missing'}]
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -728,7 +728,7 @@ def test_return_errors_error():
         bar: List[int]
 
     d, f, e = validate_model(Model, {'foo': '123', 'bar': (1, 2, 'x')}, False)
-    assert d == {'bar': (1, 2, 'x'), 'foo': 123}
+    assert d == {'bar': None, 'foo': 123}
     assert f == {'foo', 'bar'}
     assert e.errors() == [{'loc': ('bar', 2), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}]
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1565,13 +1565,7 @@ def test_pass_nested_model_values():
             return values
 
     with pytest.raises(ValidationError) as exc_info:
-        Foo(
-            **dict(
-                number=1,
-                bar=dict(field_1='a'),
-                bar_list=[(23, 3), dict(field_1=[20, 34]), dict(field_1='a')],
-            )
-        )
+        Foo(**dict(number=1, bar=dict(field_1='a'), bar_list=[(23, 3), dict(field_1=[20, 34]), dict(field_1='a')]))
 
     assert exc_info.value.errors() == [
         {'loc': ('bar', '__root__'), 'msg': 'field_1 cannot be a', 'type': 'value_error'},

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1574,29 +1574,9 @@ def test_pass_nested_model_values():
         )
 
     assert exc_info.value.errors() == [
-        {
-            'loc': ('bar', '__root__'),
-            'msg': 'field_1 cannot be a',
-            'type': 'value_error',
-        },
-        {
-            'loc': ('bar_list', 0),
-            'msg': 'value is not a valid dict',
-            'type': 'type_error.dict',
-        },
-        {
-            'loc': ('bar_list', 1, 'field_1'),
-            'msg': 'str type expected',
-            'type': 'type_error.str',
-        },
-        {
-            'loc': ('bar_list', 2, '__root__'),
-            'msg': 'field_1 cannot be a',
-            'type': 'value_error',
-        },
-        {
-            'loc': ('__root__',),
-            'msg': 'It is invalid number = 1 and bar.field_1 = a',
-            'type': 'value_error',
-        },
+        {'loc': ('bar', '__root__'), 'msg': 'field_1 cannot be a', 'type': 'value_error'},
+        {'loc': ('bar_list', 0), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'},
+        {'loc': ('bar_list', 1, 'field_1'), 'msg': 'str type expected', 'type': 'type_error.str'},
+        {'loc': ('bar_list', 2, '__root__'), 'msg': 'field_1 cannot be a', 'type': 'value_error'},
+        {'loc': ('__root__',), 'msg': 'It is invalid number = 1 and bar.field_1 = a', 'type': 'value_error'},
     ]

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -48,7 +48,8 @@ def test_value_validation():
 
         @root_validator()
         def validate_sum(cls, values):
-            if sum(values.get('data', {}).values()) > 5:
+            data = values.get("data")
+            if data and sum(data.values())>5:
                 raise ValueError('sum too large')
             return values
 
@@ -57,7 +58,6 @@ def test_value_validation():
         Response[Dict[int, int]](data={1: 'a'})
     assert exc_info.value.errors() == [
         {'loc': ('data', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-        {'loc': ('__root__',), 'msg': "unsupported operand type(s) for +: 'int' and 'str'", 'type': 'type_error'},
     ]
 
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -56,7 +56,8 @@ def test_value_validation():
     with pytest.raises(ValidationError) as exc_info:
         Response[Dict[int, int]](data={1: 'a'})
     assert exc_info.value.errors() == [
-        {'loc': ('data', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+        {'loc': ('data', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('__root__',), 'msg': "unsupported operand type(s) for +: 'int' and 'str'", 'type': 'type_error'},
     ]
 
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -48,8 +48,8 @@ def test_value_validation():
 
         @root_validator()
         def validate_sum(cls, values):
-            data = values.get("data")
-            if data and sum(data.values())>5:
+            data = values.get('data')
+            if data and sum(data.values()) > 5:
                 raise ValueError('sum too large')
             return values
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -181,7 +181,8 @@ def test_validating_assignment_dict():
     with pytest.raises(ValidationError) as exc_info:
         ValidateAssignmentModel(a='x', b='xx')
     assert exc_info.value.errors() == [
-        {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+        {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('b',), 'msg': "'<' not supported between instances of 'int' and 'str'", 'type': 'type_error'},
     ]
 
 
@@ -761,7 +762,11 @@ def test_root_validator():
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
-    assert root_val_values == [{'a': 123, 'b': 'barbar'}, {'a': 1, 'b': 'snap dragonsnap dragon'}, {'b': 'barbar'}]
+    assert root_val_values == [
+        {'a': 123, 'b': 'barbar'},
+        {'a': 1, 'b': 'snap dragonsnap dragon'},
+        {'a': 'broken', 'b': 'barbar'},
+    ]
 
 
 def test_root_validator_pre():
@@ -988,7 +993,11 @@ def test_root_validator_classmethod(validator_classmethod, root_validator_classm
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
-    assert root_val_values == [{'a': 123, 'b': 'barbar'}, {'a': 1, 'b': 'snap dragonsnap dragon'}, {'b': 'barbar'}]
+    assert root_val_values == [
+        {'a': 123, 'b': 'barbar'},
+        {'a': 1, 'b': 'snap dragonsnap dragon'},
+        {'a': 'broken', 'b': 'barbar'},
+    ]
 
 
 def test_root_validator_skip_on_failure():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -182,7 +182,7 @@ def test_validating_assignment_dict():
         ValidateAssignmentModel(a='x', b='xx')
     assert exc_info.value.errors() == [
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
-        {'loc': ('b',), 'msg': "'<' not supported between instances of 'int' and 'str'", 'type': 'type_error'},
+        {'loc': ('b',), 'msg': "'<' not supported between instances of 'int' and 'NoneType'", 'type': 'type_error'},
     ]
 
 
@@ -765,7 +765,7 @@ def test_root_validator():
     assert root_val_values == [
         {'a': 123, 'b': 'barbar'},
         {'a': 1, 'b': 'snap dragonsnap dragon'},
-        {'a': 'broken', 'b': 'barbar'},
+        {'a': None, 'b': 'barbar'},
     ]
 
 
@@ -996,7 +996,7 @@ def test_root_validator_classmethod(validator_classmethod, root_validator_classm
     assert root_val_values == [
         {'a': 123, 'b': 'barbar'},
         {'a': 1, 'b': 'snap dragonsnap dragon'},
-        {'a': 'broken', 'b': 'barbar'},
+        {'a': None, 'b': 'barbar'},
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
This fix allows to pass the construct result of a value of a field when this field is a model, allowing root validations in a top model to be evaluated properly.  In the issue it is present the motivation for this fix.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
[#1643](https://github.com/samuelcolvin/pydantic/issues/1643)

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
