### PR TITLE
Document default `regex` anchoring semantics (#1631)

### DIFF
--- a/changes/1648-yurikhan.md
+++ b/changes/1648-yurikhan.md
@@ -1,0 +1,1 @@
+Document default `regex` anchoring semantics

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -69,6 +69,23 @@ It has the following arguments:
   JSON Schema
 * `regex`: for string values, this adds a Regular Expression validation generated from the passed string and an
   annotation of `pattern` to the JSON Schema
+
+    !!! note
+        *pydantic* validates strings using `re.match`,
+        which treats regular expressions as implicitly anchored at the beginning.
+        On the contrary,
+        JSON Schema validators treat the `pattern` keyword as implicitly unanchored,
+        more like what `re.search` does.
+
+        For interoperability, depending on your desired behavior,
+        either explicitly anchor your regular expressions with `^`
+        (e.g. `^foo` to match any string starting with `foo`),
+        or explicitly allow an arbitrary prefix with `.*?`
+        (e.g. `.*?foo` to match any string containig the substring `foo`).
+
+        See [#1631](https://github.com/samuelcolvin/pydantic/issues/1631)
+        for a discussion of possible changes to *pydantic* behavior in **v2**.
+
 * `**` any other keyword arguments (e.g. `examples`) will be added verbatim to the field's schema
 
 Instead of using `Field`, the `fields` property of [the Config class](model_config.md) can be used


### PR DESCRIPTION
## Change Summary

Document that `regex` is checked using `re.match`. Suggest a way to write regular expressions that have the same meaning in Pydantic and JSON Schema.

## Related issue number

#1631 

## Checklist

* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
