### PR TITLE
[Trivial] Update datamode_code_generator:typo in pip install

### DIFF
--- a/docs/datamodel_code_generator.md
+++ b/docs/datamodel_code_generator.md
@@ -8,7 +8,7 @@
 
 ## Install
 ```bash
-pip install datamodel-code-generato
+pip install datamodel-code-generator
 ```
 
 ## Example


### PR DESCRIPTION
As seen in https://koxudaxi.github.io/datamodel-code-generator, the correct command is 
`pip install datamodel-code-generator`
not
`pip install datamodel-code-generato`

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
