### PR TITLE
fix: forward ref with nested models and optional fields

### DIFF
--- a/changes/1736-PrettyWood.md
+++ b/changes/1736-PrettyWood.md
@@ -1,0 +1,1 @@
+Fix behaviour with forward refs and optional fields in nested models

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -342,6 +342,11 @@ class ModelField(Representation):
         """
 
         self._set_default_and_type()
+        if self.type_.__class__ == ForwardRef:
+            # self.type_ is currently a ForwardRef and there's nothing we can do now,
+            # user will need to call model.update_forward_refs()
+            return
+
         self._type_analysis()
         if self.required is Undefined:
             self.required = True
@@ -373,11 +378,6 @@ class ModelField(Representation):
 
         if self.type_ is None:
             raise errors_.ConfigError(f'unable to infer type for attribute "{self.name}"')
-
-        if self.type_.__class__ == ForwardRef:
-            # self.type_ is currently a ForwardRef and there's nothing we can do now,
-            # user will need to call model.update_forward_refs()
-            return
 
         if self.required is False and default_value is None:
             self.allow_none = True

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -439,3 +439,35 @@ else:
     raise AssertionError('error not raised')
     """
     )
+
+
+def test_forward_ref_optional(create_module):
+    module = create_module(
+        """
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class Spec(BaseModel):
+    spec_fields: List[str] = Field(..., alias="fields")
+    filter: Optional[str]
+    sort: Optional[str]
+
+
+class PSpec(Spec):
+    g: Optional[GSpec]
+
+
+class GSpec(Spec):
+    p: Optional[PSpec]
+
+PSpec.update_forward_refs()
+
+class Filter(BaseModel):
+    g: Optional[GSpec]
+    p: Optional[PSpec]
+    """
+    )
+    Filter = module.Filter
+    assert isinstance(Filter(p={'sort': 'some_field:asc', 'fields': []}), Filter)

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -441,6 +441,7 @@ else:
     )
 
 
+@skip_pre_37
 def test_forward_ref_optional(create_module):
     module = create_module(
         """


### PR DESCRIPTION
## Change Summary
PR #1712 introduced a regression for forward refs in `ModelField.prepare`
as it would not return early for forward refs anymore.
Optional fields would hence have `required` set to `True`.

## Related issue number
closes #1736

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
