### PR TITLE
Improved conlist/set

### DIFF
--- a/changes/1753-hmvp.md
+++ b/changes/1753-hmvp.md
@@ -1,0 +1,1 @@
+Improve constrained list and set to allow generic typing

--- a/docs/examples/types_constrained.py
+++ b/docs/examples/types_constrained.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
+from typing import TypeVar
 
 from pydantic import (
     BaseModel,
+    ConstrainedList,
     NegativeFloat,
     NegativeInt,
     PositiveFloat,
@@ -15,6 +17,13 @@ from pydantic import (
     constr,
     Field,
 )
+
+
+T = TypeVar('T')
+
+
+class LongList(ConstrainedList[T]):
+    min_items = 100
 
 
 class Model(BaseModel):
@@ -38,6 +47,7 @@ class Model(BaseModel):
 
     short_list: conlist(int, min_items=1, max_items=4)
     short_set: conset(int, min_items=1, max_items=4)
+    long_list: LongList[int]
 
     decimal_positive: condecimal(gt=0)
     decimal_negative: condecimal(lt=0)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -33,7 +33,7 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
 from .types import PyObject, StrBytes
-from .typing import AnyCallable, ForwardRef, is_classvar, resolve_annotations, update_field_forward_refs, get_origin
+from .typing import AnyCallable, ForwardRef, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
 from .utils import (
     ClassAttribute,
     GetterDict,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -33,7 +33,7 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
 from .types import PyObject, StrBytes
-from .typing import AnyCallable, ForwardRef, is_classvar, resolve_annotations, update_field_forward_refs
+from .typing import AnyCallable, ForwardRef, is_classvar, resolve_annotations, update_field_forward_refs, get_origin
 from .utils import (
     ClassAttribute,
     GetterDict,
@@ -256,7 +256,7 @@ class ModelMetaclass(ABCMeta):
                     if (
                         isinstance(value, untouched_types)
                         and ann_type != PyObject
-                        and not lenient_issubclass(getattr(ann_type, '__origin__', None), Type)
+                        and not lenient_issubclass(get_origin(ann_type), Type)
                     ):
                         continue
                     fields[ann_name] = inferred = ModelField.infer(

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -55,7 +55,7 @@ from .types import (
     conset,
     constr,
 )
-from .typing import ForwardRef, Literal, is_callable_type, is_literal_type, literal_values, get_origin, get_args
+from .typing import ForwardRef, Literal, get_args, get_origin, is_callable_type, is_literal_type, literal_values
 from .utils import get_model, lenient_issubclass, sequence_like
 
 if TYPE_CHECKING:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -55,7 +55,7 @@ from .types import (
     conset,
     constr,
 )
-from .typing import ForwardRef, Literal, is_callable_type, is_literal_type, literal_values
+from .typing import ForwardRef, Literal, is_callable_type, is_literal_type, literal_values, get_origin, get_args
 from .utils import get_model, lenient_issubclass, sequence_like
 
 if TYPE_CHECKING:
@@ -803,9 +803,9 @@ def get_annotation_from_field_info(annotation: Any, field_info: FieldInfo, field
             or lenient_issubclass(type_, (ConstrainedList, ConstrainedSet))
         ):
             return type_
-        origin = getattr(type_, '__origin__', None)
+        origin = get_origin(type_)
         if origin is not None:
-            args: Tuple[Any, ...] = type_.__args__
+            args: Tuple[Any, ...] = get_args(type_)
             if any(isinstance(a, ForwardRef) for a in args):
                 # forward refs cause infinite recursion below
                 return type_

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -129,15 +129,9 @@ def conbytes(*, strip_whitespace: bool = False, min_length: int = None, max_leng
 T = TypeVar('T')
 
 
-# This types superclass should be List[T], but cython chokes on that...
-class ConstrainedList(list):  # type: ignore
-    # Needed for pydantic to detect that this is a list
-    __origin__ = list
-    __args__: List[Type[T]]  # type: ignore
-
+class ConstrainedList(List[T]):
     min_items: Optional[int] = None
     max_items: Optional[int] = None
-    item_type: Type[T]  # type: ignore
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
@@ -164,22 +158,17 @@ class ConstrainedList(list):  # type: ignore
         return v
 
 
-def conlist(item_type: Type[T], *, min_items: int = None, max_items: int = None) -> Type[List[T]]:
-    # __args__ is needed to conform to typing generics api
-    namespace = {'min_items': min_items, 'max_items': max_items, 'item_type': item_type, '__args__': [item_type]}
+def conlist(item_type: Type[T], *, min_items: Optional[int] = None, max_items: Optional[int] = None,) -> Type[List[T]]:
+    namespace = {'min_items': min_items, 'max_items': max_items}
     # We use new_class to be able to deal with Generic types
-    return new_class('ConstrainedListValue', (ConstrainedList,), {}, lambda ns: ns.update(namespace))
+    return new_class(
+        'ConstrainedListValue', (ConstrainedList[item_type],), {}, lambda ns: ns.update(namespace)  # type:ignore
+    )
 
 
-# This types superclass should be Set[T], but cython chokes on that...
-class ConstrainedSet(set):  # type: ignore
-    # Needed for pydantic to detect that this is a set
-    __origin__ = set
-    __args__: Set[Type[T]]  # type: ignore
-
+class ConstrainedSet(Set[T]):
     min_items: Optional[int] = None
     max_items: Optional[int] = None
-    item_type: Type[T]  # type: ignore
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
@@ -204,10 +193,11 @@ class ConstrainedSet(set):  # type: ignore
 
 
 def conset(item_type: Type[T], *, min_items: int = None, max_items: int = None) -> Type[Set[T]]:
-    # __args__ is needed to conform to typing generics api
-    namespace = {'min_items': min_items, 'max_items': max_items, 'item_type': item_type, '__args__': [item_type]}
+    namespace = {'min_items': min_items, 'max_items': max_items}
     # We use new_class to be able to deal with Generic types
-    return new_class('ConstrainedSetValue', (ConstrainedSet,), {}, lambda ns: ns.update(namespace))
+    return new_class(
+        'ConstrainedSetValue', (ConstrainedSet[item_type],), {}, lambda ns: ns.update(namespace)  # type:ignore
+    )
 
 
 class ConstrainedStr(str):

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -19,7 +19,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_args,
 )
 from uuid import UUID
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -19,6 +19,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
 )
 from uuid import UUID
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -80,8 +80,7 @@ if sys.version_info < (3, 8):
 
 
 else:
-    from typing import Literal, get_origin
-    from typing import get_args as typing_get_args
+    from typing import Literal, get_args as typing_get_args, get_origin
 
     def get_args(tp: Type[Any]) -> Tuple[Any, ...]:
         """Get type arguments with all substitutions performed.

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -82,20 +82,16 @@ if sys.version_info < (3, 8):
 else:
     from typing import Literal, get_args as typing_get_args, get_origin
 
-    def get_args(tp: Type[Any]) -> Tuple[Any, ...]:
-        """Get type arguments with all substitutions performed.
+    if sys.version_info < (3, 8, 3):
 
-        For unions, basic simplifications used by Union constructor are performed.
-        Examples::
-            get_args(Dict[str, int]) == (str, int)
-            get_args(int) == ()
-            get_args(Union[int, Union[T, int], str][int]) == (int, str)
-            get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
-            get_args(Callable[[], T][int]) == ([], int)
-        """
-        if get_origin(tp) is collections.abc.Callable and not getattr(tp, '__args__'):
-            return ()
-        return typing_get_args(tp)
+        def get_args(tp: Type[Any]) -> Tuple[Any, ...]:
+            """This is a workaround for https://bugs.python.org/issue40398."""
+            if get_origin(tp) is collections.abc.Callable and not getattr(tp, '__args__'):
+                return ()
+            return typing_get_args(tp)
+
+    else:
+        get_args = typing_get_args
 
 
 if TYPE_CHECKING:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -211,7 +211,7 @@ def test_constrained_list_type_conversions():
     class ConListModel(BaseModel):
         v: conlist(UUID) = []
 
-    assert ConListModel(v=["8a15ecb2-8cf5-41fc-b10d-10a515d01ea2"]).v == [UUID("8a15ecb2-8cf5-41fc-b10d-10a515d01ea2")]
+    assert ConListModel(v=['8a15ecb2-8cf5-41fc-b10d-10a515d01ea2']).v == [UUID('8a15ecb2-8cf5-41fc-b10d-10a515d01ea2')]
 
 
 def test_constrained_list_type_erased_class():
@@ -228,10 +228,10 @@ def test_constrained_list_type_erased_class():
         ConListModel(v=[])
     assert exc_info.value.errors() == [
         {
-            "loc": ("v",),
-            "msg": "ensure this value has at least 1 items",
-            "type": "value_error.list.min_items",
-            "ctx": {"limit_value": 1},
+            'loc': ('v',),
+            'msg': 'ensure this value has at least 1 items',
+            'type': 'value_error.list.min_items',
+            'ctx': {'limit_value': 1},
         }
     ]
 
@@ -246,12 +246,11 @@ def test_constrained_list_type_erased_class():
         }
     ]
 
-    assert ConListModel(v=["8a15ecb2-8cf5-41fc-b10d-10a515d01ea2"]).v == [UUID("8a15ecb2-8cf5-41fc-b10d-10a515d01ea2")]
+    assert ConListModel(v=['8a15ecb2-8cf5-41fc-b10d-10a515d01ea2']).v == [UUID('8a15ecb2-8cf5-41fc-b10d-10a515d01ea2')]
 
 
-# @pytest.mark.skip("Not working for some reason")
 def test_constrained_list_class():
-    T = TypeVar("T")
+    T = TypeVar('T')
 
     class ConList(ConstrainedList[T]):
         min_items = 1
@@ -263,14 +262,14 @@ def test_constrained_list_class():
         ConListModel(v=[])
     assert exc_info.value.errors() == [
         {
-            "loc": ("v",),
-            "msg": "ensure this value has at least 1 items",
-            "type": "value_error.list.min_items",
-            "ctx": {"limit_value": 1},
+            'loc': ('v',),
+            'msg': 'ensure this value has at least 1 items',
+            'type': 'value_error.list.min_items',
+            'ctx': {'limit_value': 1},
         }
     ]
 
-    assert ConListModel(v=["8a15ecb2-8cf5-41fc-b10d-10a515d01ea2"]).v == [UUID("8a15ecb2-8cf5-41fc-b10d-10a515d01ea2")]
+    assert ConListModel(v=['8a15ecb2-8cf5-41fc-b10d-10a515d01ea2']).v == [UUID('8a15ecb2-8cf5-41fc-b10d-10a515d01ea2')]
 
 
 def test_conlist():
@@ -428,7 +427,7 @@ def test_constrained_set_type_conversions():
     class ConSetModel(BaseModel):
         v: conset(UUID) = []
 
-    assert ConSetModel(v=["8a15ecb2-8cf5-41fc-b10d-10a515d01ea2"]).v == {UUID("8a15ecb2-8cf5-41fc-b10d-10a515d01ea2")}
+    assert ConSetModel(v=['8a15ecb2-8cf5-41fc-b10d-10a515d01ea2']).v == {UUID('8a15ecb2-8cf5-41fc-b10d-10a515d01ea2')}
 
 
 def test_constrained_set_type_erased_class():
@@ -442,18 +441,18 @@ def test_constrained_set_type_erased_class():
         ConSetModel(v=[])
     assert exc_info.value.errors() == [
         {
-            "loc": ("v",),
-            "msg": "ensure this value has at least 1 items",
-            "type": "value_error.set.min_items",
-            "ctx": {"limit_value": 1},
+            'loc': ('v',),
+            'msg': 'ensure this value has at least 1 items',
+            'type': 'value_error.set.min_items',
+            'ctx': {'limit_value': 1},
         }
     ]
 
-    assert ConSetModel(v=["8a15ecb2-8cf5-41fc-b10d-10a515d01ea2"]).v == {UUID("8a15ecb2-8cf5-41fc-b10d-10a515d01ea2")}
+    assert ConSetModel(v=['8a15ecb2-8cf5-41fc-b10d-10a515d01ea2']).v == {UUID('8a15ecb2-8cf5-41fc-b10d-10a515d01ea2')}
 
 
 def test_constrained_set_class():
-    T = TypeVar("T")
+    T = TypeVar('T')
 
     class ConSet(ConstrainedSet[T]):
         min_items = 1
@@ -465,14 +464,14 @@ def test_constrained_set_class():
         ConSetModel(v=[])
     assert exc_info.value.errors() == [
         {
-            "loc": ("v",),
-            "msg": "ensure this value has at least 1 items",
-            "type": "value_error.set.min_items",
-            "ctx": {"limit_value": 1},
+            'loc': ('v',),
+            'msg': 'ensure this value has at least 1 items',
+            'type': 'value_error.set.min_items',
+            'ctx': {'limit_value': 1},
         }
     ]
 
-    assert ConSetModel(v=["8a15ecb2-8cf5-41fc-b10d-10a515d01ea2"]).v == {UUID("8a15ecb2-8cf5-41fc-b10d-10a515d01ea2")}
+    assert ConSetModel(v=['8a15ecb2-8cf5-41fc-b10d-10a515d01ea2']).v == {UUID('8a15ecb2-8cf5-41fc-b10d-10a515d01ea2')}
 
 
 def test_conset():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Improved a bit upon conlist and constr. Added more ways to use the base classes while keeping mypy happy.
See the added tests for functionality that did not work before.

I also removed most calls to `__origin__` and `__args__` in favor of an official API.

So the tricky part will be in seeing if this works in every environment. The last time I tried to do something like this cython was nog happy...

## Related issue number

Fixes #1309 
Fixes or improves #975

The following should now be possible (using `conlist` does not work, I am not sure if that can be done without going to deep into typing magic)
```
from typing import Generic, TypeVar

from pydantic import ConstrainedList
from pydantic.generics import GenericModel

DataT = TypeVar('DataT')


class CList(ConstrainedList[DataT]):
    min_items = 1
    max_items = 10


class A(GenericModel, Generic[DataT]):
    f: CList[DataT]


a = A[int].parse_obj({'f': ['a']})
print(a)  # a=['a']

```

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
