### PR TITLE
feat: support `update_forward_refs` in scripts

### DIFF
--- a/changes/1734-PrettyWood.md
+++ b/changes/1734-PrettyWood.md
@@ -1,0 +1,1 @@
+Support `update_forward_refs` in scripts

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -681,7 +681,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         """
         Try to update ForwardRefs on fields based on this Model, globalns and localns.
         """
-        globalns = sys.modules[cls.__module__].__dict__.copy()
+        globalns = sys.modules[cls.__module__ or '__main__'].__dict__.copy()
         globalns.setdefault(cls.__name__, cls)
         for f in cls.__fields__.values():
             update_field_forward_refs(f, globalns=globalns, localns=localns)

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from pydantic import ConfigError, ValidationError
+from pydantic import ConfigError, ValidationError, create_model
 
 skip_pre_37 = pytest.mark.skipif(sys.version_info < (3, 7), reason='testing >= 3.7 behaviour only')
 
@@ -439,3 +439,11 @@ else:
     raise AssertionError('error not raised')
     """
     )
+
+
+def test_forward_ref_script():
+    """It should update forward refs in a script (not a module)"""
+    sub_model = create_model('Sub', name=(str, ...))
+    main_model = create_model('Main', sub=('Sub', ...))
+    main_model.update_forward_refs(Sub=sub_model)
+    assert main_model(sub={'name': 'pika'}).dict() == {'sub': {'name': 'pika'}}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Currently `update_forward_refs` works only for modules. This adds a default behaviour for scripts

⚠️ **It's probably better to first check #1686 as it probably covers also this case** ⚠️ 

## Related issue number
closes #1734

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
