### PR TITLE
fix(schema): add basic support of Pattern type in schema generation

### DIFF
--- a/changes/1767-PrettyWood.md
+++ b/changes/1767-PrettyWood.md
@@ -1,0 +1,1 @@
+add basic support of Pattern type in schema generation

--- a/docs/build/schema_mapping.py
+++ b/docs/build/schema_mapping.py
@@ -146,6 +146,13 @@ table = [
         ''
     ],
     [
+        'Pattern',
+        'string',
+        {'format': 'regex'},
+        'JSON Schema Validation',
+        ''
+    ],
+    [
         'bytes',
         'string',
         {'format': 'binary'},

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Pattern,
     Sequence,
     Set,
     Tuple,
@@ -618,6 +619,7 @@ field_class_to_schema: Tuple[Tuple[Any, Dict[str, Any]], ...] = (
     (IPv6Interface, {'type': 'string', 'format': 'ipv6interface'}),
     (IPv4Address, {'type': 'string', 'format': 'ipv4'}),
     (IPv6Address, {'type': 'string', 'format': 'ipv6'}),
+    (Pattern, {'type': 'string', 'format': 'regex'}),
     (str, {'type': 'string'}),
     (bytes, {'type': 'string', 'format': 'binary'}),
     (bool, {'type': 'boolean'}),
@@ -643,7 +645,8 @@ def add_field_type_to_schema(field_type: Any, schema: Dict[str, Any]) -> None:
     and then modifies the given `schema` with the information from that type.
     """
     for type_, t_schema in field_class_to_schema:
-        if issubclass(field_type, type_):
+        # Fallback for `typing.Pattern` as it is not a valid class
+        if lenient_issubclass(field_type, type_) or field_type is type_ is Pattern:
             schema.update(t_schema)
             break
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2055,6 +2055,13 @@ def test_pattern():
     f2 = Foobar(pattern=p)
     assert f2.pattern is p
 
+    assert Foobar.schema() == {
+        'type': 'object',
+        'title': 'Foobar',
+        'properties': {'pattern': {'type': 'string', 'format': 'regex', 'title': 'Pattern'}},
+        'required': ['pattern'],
+    }
+
 
 def test_pattern_error():
     class Foobar(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Since `typing.Pattern` is not a valid type, an error is raised when generating the schema.
This PR adds a basic support for it.

<!-- Please give a short summary of the changes. -->

## Related issue number
closes #1767
closes #1269

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
