### PR TITLE
Fix #1770

### DIFF
--- a/changes/1770-selimb.md
+++ b/changes/1770-selimb.md
@@ -1,0 +1,1 @@
+Fix false positive from mypy plugin when a class nested within a `BaseModel` is named `Model`.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -328,7 +328,7 @@ class PydanticModelTransformer:
         construct_arguments = [fields_set_argument] + construct_arguments
 
         obj_type = ctx.api.named_type('__builtins__.object')
-        self_tvar_name = 'Model'
+        self_tvar_name = '_PydanticBaseModel'  # Make sure it does not conflict with other names in the class
         tvar_fullname = ctx.cls.fullname + '.' + self_tvar_name
         tvd = TypeVarDef(self_tvar_name, tvar_fullname, -1, [], obj_type)
         self_tvar_expr = TypeVarExpr(self_tvar_name, tvar_fullname, [], obj_type)

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -123,3 +123,13 @@ p = AddProject(name='x', slug='y', description='z')
 
 class TypeAliasAsAttribute(BaseModel):
     __type_alias_attribute__ = Union[str, bytes]
+
+
+class NestedModel(BaseModel):
+    class Model(BaseModel):
+        id: str
+
+    model: Model
+
+
+_ = NestedModel.Model


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Fixes #1770 by ensuring the (arbitrary) type variable name does not conflict with names defined in a `BaseModel`.

## Related issue number

#1770 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/1770-selimb.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
