### PR TITLE
[fixes #1794][docs] clarify argument type to parse_file

### DIFF
--- a/changes/1794-mdavis-xyz.md
+++ b/changes/1794-mdavis-xyz.md
@@ -1,0 +1,2 @@
+Clarify documentation for `parse_file` to show that the argument
+should be a file *path* not a file-like object.

--- a/docs/examples/models_parse.py
+++ b/docs/examples/models_parse.py
@@ -30,3 +30,9 @@ m = User.parse_raw(
     pickle_data, content_type='application/pickle', allow_pickle=True
 )
 print(m)
+
+path = 'data.json'
+with open(path, 'w') as f:
+    f.write('{"id": 123, "name": "James"}')
+m = User.parse_file(path)
+print(m)

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -81,7 +81,7 @@ Models possess the following methods and attributes:
 : a utility for loading strings of numerous formats; cf. [helper functions](#helper-functions)
 
 `parse_file()`
-: like `parse_raw()` but for files; cf. [helper function](#helper-functions)
+: like `parse_raw()` but for file paths; cf. [helper function](#helper-functions)
 
 `from_orm()`
 : loads data into a model from an arbitrary class; cf. [ORM mode](#orm-mode-aka-arbitrary-class-instances)
@@ -238,7 +238,7 @@ _(This script is complete, it should run "as is")_
   rather than keyword arguments. If the object passed is not a dict a `ValidationError` will be raised.
 * **`parse_raw`**: this takes a *str* or *bytes* and parses it as *json*, then passes the result to `parse_obj`.
   Parsing *pickle* data is also supported by setting the `content_type` argument appropriately.
-* **`parse_file`**: this reads a file and passes the contents to `parse_raw`. If `content_type` is omitted,
+* **`parse_file`**: this takes in a file path, reads the file and passes the contents to `parse_raw`. If `content_type` is omitted,
   it is inferred from the file's extension.
 
 ```py


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Clarify that `parse_file` takes a file *path* not a file-like object.

## Related issue number

closes #1794 

## Checklist

* [ ] Unit tests for the changes exist - `make docs` fails, but it fails on `master` with the same error
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
