### PR TITLE
feat(tools): add `parse_raw_as` utility function

### DIFF
--- a/changes/1812-PrettyWood.md
+++ b/changes/1812-PrettyWood.md
@@ -1,0 +1,1 @@
+add `parse_raw_as` utility function

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -533,8 +533,8 @@ _(This script is complete, it should run "as is")_
 
 This function is capable of parsing data into any of the types pydantic can handle as fields of a `BaseModel`.
 
-Pydantic also includes a similar standalone function called `parse_file_as`,
-which is analogous to `BaseModel.parse_file`.
+Pydantic also includes two similar standalone functions called `parse_file_as` and `parse_raw_as`,
+which are analogous to `BaseModel.parse_file` and `BaseModel.parse_raw`.
 
 ## Data Conversion
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     # tools
     'parse_file_as',
     'parse_obj_as',
+    'parse_raw_as',
     # types
     'NoneStr',
     'NoneBytes',

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -3,11 +3,11 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
-from pydantic.parse import Protocol, load_file
-
+from .parse import Protocol, load_file, load_str_bytes
+from .types import StrBytes
 from .typing import display_as_type
 
-__all__ = ('parse_file_as', 'parse_obj_as')
+__all__ = ('parse_file_as', 'parse_obj_as', 'parse_raw_as')
 
 NameFactory = Union[str, Callable[[Type[Any]], str]]
 
@@ -53,5 +53,22 @@ def parse_file_as(
         encoding=encoding,
         allow_pickle=allow_pickle,
         json_loads=json_loads,
+    )
+    return parse_obj_as(type_, obj, type_name=type_name)
+
+
+def parse_raw_as(
+    type_: Type[T],
+    b: StrBytes,
+    *,
+    content_type: str = None,
+    encoding: str = 'utf8',
+    proto: Protocol = None,
+    allow_pickle: bool = False,
+    json_loads: Callable[[str], Any] = json.loads,
+    type_name: Optional[NameFactory] = None,
+) -> T:
+    obj = load_str_bytes(
+        b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle, json_loads=json_loads,
     )
     return parse_obj_as(type_, obj, type_name=type_name)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,7 @@ import pytest
 
 from pydantic import BaseModel, ValidationError
 from pydantic.dataclasses import dataclass
-from pydantic.tools import parse_file_as, parse_obj_as
+from pydantic.tools import parse_file_as, parse_obj_as, parse_raw_as
 
 
 @pytest.mark.parametrize('obj,type_,parsed', [('1', int, 1), (['1'], List[int], [1])])
@@ -88,3 +88,13 @@ def test_parse_file_as_json_loads(tmp_path):
     p = tmp_path / 'test_json_loads.json'
     p.write_text('{"1": "2"}')
     assert parse_file_as(Dict[int, int], p, json_loads=custom_json_loads) == {1: 99}
+
+
+def test_raw_as():
+    class Item(BaseModel):
+        id: int
+        name: str
+
+    item_data = '[{"id": 1, "name": "My Item"}]'
+    items = parse_raw_as(List[Item], item_data)
+    assert items == [Item(id=1, name='My Item')]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
We already have two utility functions `parse_obj_as` and `parse_file_as`. Two recent issues asked for `parse_raw_as`, which makes sense.

## Related issue number
closes #1812

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
