### PR TITLE
docs: Fix incorrect description of copy method

### DIFF
--- a/changes/1821-KimMachineGun.md
+++ b/changes/1821-KimMachineGun.md
@@ -1,0 +1,1 @@
+Fix typo in the anchor of exporting_models.md#modelcopy and incorrect description.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -71,7 +71,7 @@ Models possess the following methods and attributes:
   cf. [exporting models](exporting_models.md#modeljson)
 
 `copy()`
-: returns a copy(by default, shallow copy) of the model; cf. [exporting models](exporting_models.md#modelcopy)
+: returns a copy (by default, shallow copy) of the model; cf. [exporting models](exporting_models.md#modelcopy)
 
 `parse_obj()`
 : a utility for loading any object into a model with error handling if the object is not a dictionary;

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -71,7 +71,7 @@ Models possess the following methods and attributes:
   cf. [exporting models](exporting_models.md#modeljson)
 
 `copy()`
-: returns a deep copy of the model; cf. [exporting models](exporting_models.md#modeldcopy)
+: returns a deep copy of the model; cf. [exporting models](exporting_models.md#modelcopy)
 
 `parse_obj()`
 : a utility for loading any object into a model with error handling if the object is not a dictionary;

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -71,7 +71,7 @@ Models possess the following methods and attributes:
   cf. [exporting models](exporting_models.md#modeljson)
 
 `copy()`
-: returns a deep copy of the model; cf. [exporting models](exporting_models.md#modelcopy)
+: returns a copy(by default, shallow copy) of the model; cf. [exporting models](exporting_models.md#modelcopy)
 
 `parse_obj()`
 : a utility for loading any object into a model with error handling if the object is not a dictionary;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
This change fixes typo in the anchor of `exporting_models.md#modelcopy` and incorrect description.
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
