### PR TITLE
documentation: remove strict_optional from sample mypy.ini

### DIFF
--- a/docs/mypy_plugin.md
+++ b/docs/mypy_plugin.md
@@ -123,7 +123,6 @@ A `mypy.ini` file with all plugin strictness flags enabled (and some other mypy 
 plugins = pydantic.mypy
 
 follow_imports = silent
-strict_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 disallow_any_generics = True


### PR DESCRIPTION
Really trivial suggested change, but strict_optional=True is the default for mypy since 0.600, so its presence in the sample mypy.ini in the docs seems redundant.

https://mypy.readthedocs.io/en/stable/config_file.html#none-and-optional-handling
