### PR TITLE
✨ Add types SpaceSeparated, CommaSeparated, CommaSeparatedStripped

### DIFF
--- a/changes/1848-tiangolo.md
+++ b/changes/1848-tiangolo.md
@@ -1,0 +1,1 @@
+Add types for string values separated by commas or spaces: `SpaceSeparated`, `CommaSeparated`, `CommaSeparatedStripped`

--- a/docs/build/exec_examples.py
+++ b/docs/build/exec_examples.py
@@ -140,6 +140,8 @@ def exec_examples():
     })
 
     sys.path.append(str(EXAMPLES_DIR))
+    # Move to the examples dir so that settings_env.py can read settings.env
+    os.chdir(EXAMPLES_DIR)
     for file in sorted(EXAMPLES_DIR.iterdir()):
 
         def error(desc: str):
@@ -229,6 +231,7 @@ def exec_examples():
     for file_name, content in new_files.items():
         (TMP_EXAMPLES_DIR / file_name).write_text(content, 'utf-8')
     gen_ansi_output()
+    os.chdir(THIS_DIR)
     return 0
 
 

--- a/docs/build/exec_examples.py
+++ b/docs/build/exec_examples.py
@@ -133,7 +133,11 @@ def exec_examples():
     errors = []
     all_md = all_md_contents()
     new_files = {}
-    os.environ.update({'my_auth_key': 'xxx', 'my_api_key': 'xxx'})
+    os.environ.update({
+        'my_auth_key': 'xxx',
+        'my_api_key': 'xxx',
+        'cors_origins': 'https://helpmanual.io, http://127.0.0.1:8000/',
+    })
 
     sys.path.append(str(EXAMPLES_DIR))
     for file in sorted(EXAMPLES_DIR.iterdir()):

--- a/docs/examples/settings.env
+++ b/docs/examples/settings.env
@@ -1,0 +1,6 @@
+# ignore comment
+ENVIRONMENT="production"
+API_KEY="super-secret-key"
+REDIS_ADDRESS=localhost:6379
+TIMEOUT_SECONDS=300
+CORS_ORIGINS="https://helpmanual.io, http://127.0.0.1:8000/"

--- a/docs/examples/settings_env.py
+++ b/docs/examples/settings_env.py
@@ -1,0 +1,20 @@
+from pydantic import (
+    CommaSeparatedStripped,
+    BaseSettings,
+    RedisDsn,
+)
+
+
+class Settings(BaseSettings):
+    environment: str = 'development'
+    api_key: str
+    redis_dsn: RedisDsn = 'redis://user:pass@localhost:6379/1'
+    timeout_seconds: int = 60
+    cors_origins: CommaSeparatedStripped[str] = []
+
+    class Config:
+        env_file = 'settings.env'
+        env_file_encoding = 'utf-8'
+
+
+print(Settings().dict())

--- a/docs/examples/settings_main.py
+++ b/docs/examples/settings_main.py
@@ -7,6 +7,7 @@ from pydantic import (
     RedisDsn,
     PostgresDsn,
     Field,
+    CommaSeparatedStripped,
 )
 
 
@@ -27,6 +28,10 @@ class Settings(BaseSettings):
     # to override domains:
     # export my_prefix_domains='["foo.com", "bar.com"]'
     domains: Set[str] = set()
+
+    # to override cors_origins:
+    # export cors_origins="https://helpmanual.io, http://127.0.0.1:8000/"
+    cors_origins: CommaSeparatedStripped[str] = []
 
     # to override more_settings:
     # export my_prefix_more_settings='{"foo": "x", "apple": 1}'

--- a/docs/examples/types_split_str.py
+++ b/docs/examples/types_split_str.py
@@ -1,0 +1,21 @@
+from pydantic import (
+    BaseModel,
+    CommaSeparated,
+    CommaSeparatedStripped,
+    SpaceSeparated
+)
+
+
+class Model(BaseModel):
+    comma_separated: CommaSeparated[int]
+    space_separated: SpaceSeparated[float]
+    comma_separated_stripped: CommaSeparatedStripped[str]
+
+
+model = Model(
+    comma_separated='1,2,345,678',
+    space_separated='2 3.45 4.678 0',
+    comma_separated_stripped='Samuel, David, Sebastián'
+)
+
+print(model)

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -128,6 +128,25 @@ Because python-dotenv is used to parse the file, bash-like semantics such as `ex
 (depending on your OS and environment) may allow your dotenv file to also be used with `source`,
 see [python-dotenv's documentation](https://saurabh-kumar.com/python-dotenv/#usages) for more details.
 
+## A simple example
+
+For example, if you had a file `settings.env` with:
+
+```bash
+{!.tmp_examples/settings.env!}
+```
+
+You could load and parse it with:
+
+```py
+{!.tmp_examples/settings_env.py!}
+```
+
+!!! tip
+    Notice that you can use `CommaSeparatedStripped[str]` to parse a string separated by commas.
+
+    This is specially useful in environments where it is difficult to write valid JSON inside of quotes.
+
 ## Field value priority
 
 In the case where a value is specified for the same `Settings` field in multiple ways,

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -189,7 +189,7 @@ _(This script is complete, it should run "as is")_
     pydantic can't validate the values automatically for you because it would require
     consuming the infinite generator.
 
-## Validating the first value
+#### Validating the first value
 
 You can create a [validator](validators.md) to validate the first value in an infinite generator and still not consume it entirely.
 

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -765,7 +765,7 @@ surrounding space from the values.
 
 You can use them with an internal type.
 
-The same way you could type annotations like `List[float]`, you can use `CommaSeparated[float]`, etc.
+The same way you could use type annotations like `List[float]`, you can use `CommaSeparated[float]`, etc.
 
 *pydantic* will parse the string, extract the list of values, and then validate/parse
 the values with the declared internal type (type parameter).

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -505,6 +505,19 @@ _(This script is complete, it should run "as is")_
 : type method for constraining strs;
   see [Constrained Types](#constrained-types)
 
+`CommaSeparated`
+: separate the input string by commas (`,`);
+see [Values separated by commas and spaces](#values-separated-by-commas-and-spaces).
+
+`SpaceSeparated`
+: separate the input string by spaces (` `);
+see [Values separated by commas and spaces](#values-separated-by-commas-and-spaces).
+
+`CommaSeparatedStripped`
+: separate the input string by commas (`,`) and strip any
+surrounding space from the values;
+see [Values separated by commas and spaces](#values-separated-by-commas-and-spaces).
+
 ### URLs
 
 For URI/URL validation the following types are available:
@@ -737,6 +750,42 @@ raw bytes and print out human readable versions of the bytes as well.
 {!.tmp_examples/types_bytesize.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+## Values separated by commas and spaces
+
+In special cases, you might need to declare that a type should receive a string with
+values of some type, separated by commas (`,`) or spaces (` `).
+
+You can use:
+
+* `CommaSeparated`: separate the input string by commas (`,`).
+* `SpaceSeparated`: separate the input string by spaces (` `).
+* `CommaSeparatedStripped`: separate the input string by commas (`,`) and strip any
+surrounding space from the values.
+
+You can use them with an internal type.
+
+The same way you could type annotations like `List[float]`, you can use `CommaSeparated[float]`, etc.
+
+*pydantic* will parse the string, extract the list of values, and then validate/parse
+the values with the declared internal type (type parameter).
+
+If you pass a list of values instead of a string, *pydantic* will receive it and
+validate it as a normal list.
+
+!!! tip
+    This is mostly useful for reading environment variables. You will see an example
+    in [Settings management](settings.md).
+
+```py
+{!.tmp_examples/types_split_str.py!}
+```
+
+_(This script is complete, it should run "as is")_
+
+!!! warning
+    As `CommaSeparated`, `SpaceSeparated`, and `CommaSeparatedStripped` are custom
+    generics, they are only supported with [Python `>=3.7`](https://www.python.org/dev/peps/pep-0560/).
 
 ## Custom Data Types
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -96,6 +96,10 @@ __all__ = [
     'StrictFloat',
     'PaymentCardNumber',
     'ByteSize',
+    'SplitStr',
+    'SpaceSeparated',
+    'CommaSeparated',
+    'CommaSeparatedStripped',
     # version
     'VERSION',
 ]

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -5,8 +5,9 @@ from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Union
 
 from .fields import ModelField
 from .main import BaseModel, Extra
+from .types import SplitStr
 from .typing import display_as_type
-from .utils import deep_update, sequence_like
+from .utils import deep_update, lenient_issubclass, sequence_like
 
 env_file_sentinel = str(object())
 
@@ -77,7 +78,7 @@ class BaseSettings(BaseModel):
             if env_val is None:
                 continue
 
-            if field.is_complex():
+            if field.is_complex() and not lenient_issubclass(field.outer_type_, SplitStr):
                 try:
                     env_val = self.__config__.json_loads(env_val)  # type: ignore
                 except ValueError as e:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -912,8 +912,8 @@ if not TYPE_CHECKING:  # noqa: C901
 
 if TYPE_CHECKING:
 
+    # Actual valid type annotations, for mypy and static type checkers
     class SplitStr(List[T]):
-        # Needed for pydantic to detect that this is a list
         item_type: Type[T]
 
         @classmethod

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -83,6 +83,10 @@ __all__ = [
     'StrictFloat',
     'PaymentCardNumber',
     'ByteSize',
+    'SplitStr',
+    'SpaceSeparated',
+    'CommaSeparated',
+    'CommaSeparatedStripped',
 ]
 
 NoneStr = Optional[str]

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -852,6 +852,9 @@ if not TYPE_CHECKING:  # noqa: C901
         __args__: List[Type[T]]
         item_type: Type[T]
 
+        # classmethod not required, but make Cython happy until 0.30.0 is available
+        # ref: https://github.com/cython/cython/issues/3764
+        @classmethod
         def __class_getitem__(cls, item_type: Type[T]) -> Type[List[T]]:
             # __args__ is needed to conform to typing generics api
             namespace = {'item_type': item_type, '__args__': [item_type]}

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -840,7 +840,7 @@ class ByteSize(int):
         return self / unit_div
 
 
-if not TYPE_CHECKING:
+if not TYPE_CHECKING:  # noqa: C901
     # Actual implementation, Cythonable
     class SplitStr(list):
         # Needed for pydantic to detect that this is a list
@@ -904,6 +904,7 @@ if not TYPE_CHECKING:
 
 
 if TYPE_CHECKING:
+
     class SplitStr(List[T]):
         # Needed for pydantic to detect that this is a list
         item_type: Type[T]
@@ -920,11 +921,11 @@ if TYPE_CHECKING:
         def split_str_validator(cls, v: 'Optional[Union[List[T], str]]', field: 'ModelField') -> 'Optional[List[T]]':
             ...
 
-    class SpaceSeparated(SplitStr[T]):
+    class SpaceSeparated(SplitStr[T]):  # noqa: F811
         ...
 
-    class CommaSeparated(SplitStr[T]):
+    class CommaSeparated(SplitStr[T]):  # noqa: F811
         ...
 
-    class CommaSeparatedStripped(SplitStr[T]):
+    class CommaSeparatedStripped(SplitStr[T]):  # noqa: F811
         ...

--- a/tests/test_types_split_str.py
+++ b/tests/test_types_split_str.py
@@ -1,10 +1,16 @@
+import sys
 from typing import Optional, Union
 
 import pytest
 
 from pydantic import BaseModel, CommaSeparated, CommaSeparatedStripped, SpaceSeparated, ValidationError
 
+skip_36 = pytest.mark.skipif(
+    sys.version_info < (3, 7), reason='generic split str lists only supported for python 3.7 and above'
+)
 
+
+@skip_36
 def test_comma_separated_int_from_str():
     class Model(BaseModel):
         v: CommaSeparated[int] = []
@@ -13,6 +19,7 @@ def test_comma_separated_int_from_str():
     assert m.v == [1, 2, 3]
 
 
+@skip_36
 def test_comma_separated_int_from_list():
     class Model(BaseModel):
         v: CommaSeparated[int] = []
@@ -21,6 +28,7 @@ def test_comma_separated_int_from_list():
     assert m.v == [1, 2, 3]
 
 
+@skip_36
 def test_comma_separated_int_default():
     class Model(BaseModel):
         v: CommaSeparated[int] = []
@@ -29,6 +37,7 @@ def test_comma_separated_int_default():
     assert m.v == []
 
 
+@skip_36
 def test_comma_separated_int_none():
     class Model(BaseModel):
         v: CommaSeparated[int] = None
@@ -37,6 +46,7 @@ def test_comma_separated_int_none():
     assert m.v is None
 
 
+@skip_36
 def test_comma_separated_int_optional():
     class Model(BaseModel):
         v: Optional[CommaSeparated[int]] = None
@@ -45,6 +55,7 @@ def test_comma_separated_int_optional():
     assert m.v is None
 
 
+@skip_36
 def test_comma_separated_int_optional_str():
     class Model(BaseModel):
         v: Optional[CommaSeparated[int]] = None
@@ -53,6 +64,7 @@ def test_comma_separated_int_optional_str():
     assert m.v == [2, 3, 4]
 
 
+@skip_36
 def test_comma_separated_int_optional_required():
     class Model(BaseModel):
         v: Optional[CommaSeparated[int]]
@@ -61,6 +73,7 @@ def test_comma_separated_int_optional_required():
     assert m.v is None
 
 
+@skip_36
 def test_comma_separated_int_invalid_str():
     class Model(BaseModel):
         v: CommaSeparated[int] = []
@@ -74,6 +87,7 @@ def test_comma_separated_int_invalid_str():
     ]
 
 
+@skip_36
 def test_comma_separated_int_invalid_list():
     class Model(BaseModel):
         v: CommaSeparated[int] = []
@@ -87,6 +101,7 @@ def test_comma_separated_int_invalid_list():
     ]
 
 
+@skip_36
 def test_comma_separated_int_invalid_value():
     class Model(BaseModel):
         v: CommaSeparated[int] = []
@@ -97,6 +112,7 @@ def test_comma_separated_int_invalid_value():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
 
 
+@skip_36
 def test_comma_separated_int_required():
     class Model(BaseModel):
         v: CommaSeparated[int]
@@ -107,6 +123,7 @@ def test_comma_separated_int_required():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+@skip_36
 def test_space_separated_int_from_str():
     class Model(BaseModel):
         v: SpaceSeparated[int] = []
@@ -115,6 +132,7 @@ def test_space_separated_int_from_str():
     assert m.v == [1, 234, 5678]
 
 
+@skip_36
 def test_space_separated_int_from_list():
     class Model(BaseModel):
         v: SpaceSeparated[int] = []
@@ -123,6 +141,7 @@ def test_space_separated_int_from_list():
     assert m.v == [1, 2, 3]
 
 
+@skip_36
 def test_space_separated_int_default():
     class Model(BaseModel):
         v: SpaceSeparated[int] = []
@@ -131,6 +150,7 @@ def test_space_separated_int_default():
     assert m.v == []
 
 
+@skip_36
 def test_space_separated_int_none():
     class Model(BaseModel):
         v: SpaceSeparated[int] = None
@@ -139,6 +159,7 @@ def test_space_separated_int_none():
     assert m.v is None
 
 
+@skip_36
 def test_space_separated_int_optional():
     class Model(BaseModel):
         v: Optional[SpaceSeparated[int]] = None
@@ -147,6 +168,7 @@ def test_space_separated_int_optional():
     assert m.v is None
 
 
+@skip_36
 def test_space_separated_int_optional_str():
     class Model(BaseModel):
         v: Optional[SpaceSeparated[int]] = None
@@ -155,6 +177,7 @@ def test_space_separated_int_optional_str():
     assert m.v == [2, 3, 4]
 
 
+@skip_36
 def test_space_separated_int_optional_none():
     class Model(BaseModel):
         v: Optional[SpaceSeparated[int]] = None
@@ -163,6 +186,7 @@ def test_space_separated_int_optional_none():
     assert m.v is None
 
 
+@skip_36
 def test_space_separated_int_invalid_str():
     class Model(BaseModel):
         v: SpaceSeparated[int] = []
@@ -176,6 +200,7 @@ def test_space_separated_int_invalid_str():
     ]
 
 
+@skip_36
 def test_space_separated_int_invalid_list():
     class Model(BaseModel):
         v: SpaceSeparated[int] = []
@@ -189,6 +214,7 @@ def test_space_separated_int_invalid_list():
     ]
 
 
+@skip_36
 def test_space_separated_int_required():
     class Model(BaseModel):
         v: SpaceSeparated[int]
@@ -199,6 +225,7 @@ def test_space_separated_int_required():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+@skip_36
 def test_space_separated_int_invalid_value():
     class Model(BaseModel):
         v: SpaceSeparated[int] = []
@@ -209,6 +236,7 @@ def test_space_separated_int_invalid_value():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
 
 
+@skip_36
 def test_comma_separated_str_spaces():
     class Model(BaseModel):
         v: CommaSeparated[str] = []
@@ -217,6 +245,7 @@ def test_comma_separated_str_spaces():
     assert m.v == ['foo ', '  bar ', 'baz \n']
 
 
+@skip_36
 def test_comma_separated_stripped_str():
     class Model(BaseModel):
         v: CommaSeparatedStripped[str] = []
@@ -225,6 +254,7 @@ def test_comma_separated_stripped_str():
     assert m.v == ['foo', 'bar', 'baz']
 
 
+@skip_36
 def test_comma_separated_stripped_list():
     class Model(BaseModel):
         v: CommaSeparatedStripped[str] = []
@@ -233,6 +263,7 @@ def test_comma_separated_stripped_list():
     assert m.v == ['foo ', '  bar ', 'baz \n']
 
 
+@skip_36
 def test_comma_separated_stripped_optional_none():
     class Model(BaseModel):
         v: Optional[CommaSeparatedStripped[int]] = None
@@ -241,6 +272,7 @@ def test_comma_separated_stripped_optional_none():
     assert m.v is None
 
 
+@skip_36
 def test_comma_separated_stripped_invalid():
     class Model(BaseModel):
         v: CommaSeparatedStripped[str] = []
@@ -251,6 +283,7 @@ def test_comma_separated_stripped_invalid():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
 
 
+@skip_36
 def test_comma_separated_union_str():
     class Model(BaseModel):
         v: CommaSeparatedStripped[Union[bool, float]] = []
@@ -259,6 +292,7 @@ def test_comma_separated_union_str():
     assert m.v == [True, 3, False, False, 3.14159]
 
 
+@skip_36
 def test_comma_separated_union_list():
     class Model(BaseModel):
         v: CommaSeparatedStripped[Union[bool, float]] = []
@@ -267,6 +301,7 @@ def test_comma_separated_union_list():
     assert m.v == [True, 3, False, False, 3.14159]
 
 
+@skip_36
 def test_comma_separated_union_str_invalid():
     class Model(BaseModel):
         v: CommaSeparatedStripped[Union[bool, int]] = []
@@ -280,6 +315,7 @@ def test_comma_separated_union_str_invalid():
     ]
 
 
+@skip_36
 def test_comma_separated_sub_model():
     class Model(BaseModel):
         v: CommaSeparatedStripped[Union[bool, float]] = []
@@ -291,6 +327,7 @@ def test_comma_separated_sub_model():
     assert m.data.v == [True, 3, False, False, 3.14159]
 
 
+@skip_36
 def test_comma_separated_sub_model_invalid():
     class Model(BaseModel):
         v: CommaSeparatedStripped[Union[bool, int]] = []
@@ -307,6 +344,7 @@ def test_comma_separated_sub_model_invalid():
     ]
 
 
+@skip_36
 def test_split_str_schema():
     class Model(BaseModel):
         comma_separated_stripped: CommaSeparatedStripped[int] = []

--- a/tests/test_types_split_str.py
+++ b/tests/test_types_split_str.py
@@ -160,7 +160,7 @@ def test_space_separated_int_optional_none():
         v: Optional[SpaceSeparated[int]] = None
 
     m = Model(v=None)
-    assert m.v == None
+    assert m.v is None
 
 
 def test_space_separated_int_invalid_str():
@@ -238,7 +238,7 @@ def test_comma_separated_stripped_optional_none():
         v: Optional[CommaSeparatedStripped[int]] = None
 
     m = Model(v=None)
-    assert m.v == None
+    assert m.v is None
 
 
 def test_comma_separated_stripped_invalid():

--- a/tests/test_types_split_str.py
+++ b/tests/test_types_split_str.py
@@ -1,0 +1,339 @@
+from typing import Optional, Union
+
+import pytest
+
+from pydantic import BaseModel, CommaSeparated, CommaSeparatedStripped, SpaceSeparated, ValidationError
+
+
+def test_comma_separated_int_from_str():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = []
+
+    m = Model(v='1,2,3')
+    assert m.v == [1, 2, 3]
+
+
+def test_comma_separated_int_from_list():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = []
+
+    m = Model(v=[1, 2, 3])
+    assert m.v == [1, 2, 3]
+
+
+def test_comma_separated_int_default():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = []
+
+    m = Model()
+    assert m.v == []
+
+
+def test_comma_separated_int_none():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = None
+
+    m = Model()
+    assert m.v is None
+
+
+def test_comma_separated_int_optional():
+    class Model(BaseModel):
+        v: Optional[CommaSeparated[int]] = None
+
+    m = Model()
+    assert m.v is None
+
+
+def test_comma_separated_int_optional_str():
+    class Model(BaseModel):
+        v: Optional[CommaSeparated[int]] = None
+
+    m = Model(v='2,3,4')
+    assert m.v == [2, 3, 4]
+
+
+def test_comma_separated_int_optional_required():
+    class Model(BaseModel):
+        v: Optional[CommaSeparated[int]]
+
+    m = Model(v=None)
+    assert m.v is None
+
+
+def test_comma_separated_int_invalid_str():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v='foo,bar')
+
+    assert exc_info.value.errors() == [
+        {'loc': ('v', 0), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('v', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
+
+
+def test_comma_separated_int_invalid_list():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v=['foo', 'bar'])
+
+    assert exc_info.value.errors() == [
+        {'loc': ('v', 0), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('v', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
+
+
+def test_comma_separated_int_invalid_value():
+    class Model(BaseModel):
+        v: CommaSeparated[int] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v={'foo': 'bar'})
+
+    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
+
+
+def test_comma_separated_int_required():
+    class Model(BaseModel):
+        v: CommaSeparated[int]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model()
+
+    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'field required', 'type': 'value_error.missing'}]
+
+
+def test_space_separated_int_from_str():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = []
+
+    m = Model(v='1 234 5678')
+    assert m.v == [1, 234, 5678]
+
+
+def test_space_separated_int_from_list():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = []
+
+    m = Model(v=[1, 2, 3])
+    assert m.v == [1, 2, 3]
+
+
+def test_space_separated_int_default():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = []
+
+    m = Model()
+    assert m.v == []
+
+
+def test_space_separated_int_none():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = None
+
+    m = Model()
+    assert m.v is None
+
+
+def test_space_separated_int_optional():
+    class Model(BaseModel):
+        v: Optional[SpaceSeparated[int]] = None
+
+    m = Model()
+    assert m.v is None
+
+
+def test_space_separated_int_optional_str():
+    class Model(BaseModel):
+        v: Optional[SpaceSeparated[int]] = None
+
+    m = Model(v='2 3 4')
+    assert m.v == [2, 3, 4]
+
+
+def test_space_separated_int_optional_none():
+    class Model(BaseModel):
+        v: Optional[SpaceSeparated[int]] = None
+
+    m = Model(v=None)
+    assert m.v == None
+
+
+def test_space_separated_int_invalid_str():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v='foo bar')
+
+    assert exc_info.value.errors() == [
+        {'loc': ('v', 0), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('v', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
+
+
+def test_space_separated_int_invalid_list():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v=['foo', 'bar'])
+
+    assert exc_info.value.errors() == [
+        {'loc': ('v', 0), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {'loc': ('v', 1), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
+
+
+def test_space_separated_int_required():
+    class Model(BaseModel):
+        v: SpaceSeparated[int]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model()
+
+    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'field required', 'type': 'value_error.missing'}]
+
+
+def test_space_separated_int_invalid_value():
+    class Model(BaseModel):
+        v: SpaceSeparated[int] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v={'foo': 'bar'})
+
+    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
+
+
+def test_comma_separated_str_spaces():
+    class Model(BaseModel):
+        v: CommaSeparated[str] = []
+
+    m = Model(v='foo ,  bar ,baz \n')
+    assert m.v == ['foo ', '  bar ', 'baz \n']
+
+
+def test_comma_separated_stripped_str():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[str] = []
+
+    m = Model(v='foo ,  bar ,baz \n')
+    assert m.v == ['foo', 'bar', 'baz']
+
+
+def test_comma_separated_stripped_list():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[str] = []
+
+    m = Model(v=['foo ', '  bar ', 'baz \n'])
+    assert m.v == ['foo ', '  bar ', 'baz \n']
+
+
+def test_comma_separated_stripped_optional_none():
+    class Model(BaseModel):
+        v: Optional[CommaSeparatedStripped[int]] = None
+
+    m = Model(v=None)
+    assert m.v == None
+
+
+def test_comma_separated_stripped_invalid():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[str] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v={'foo': 'bar'})
+
+    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
+
+
+def test_comma_separated_union_str():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[Union[bool, float]] = []
+
+    m = Model(v='true, 3, 0, FALSE, 3.14159')
+    assert m.v == [True, 3, False, False, 3.14159]
+
+
+def test_comma_separated_union_list():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[Union[bool, float]] = []
+
+    m = Model(v=[True, 3, 0, False, 3.14159])
+    assert m.v == [True, 3, False, False, 3.14159]
+
+
+def test_comma_separated_union_str_invalid():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[Union[bool, int]] = []
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v='true, 3, 0, FALSE, 3.14159')
+
+    assert exc_info.value.errors() == [
+        {'loc': ('v', 4), 'msg': 'value could not be parsed to a boolean', 'type': 'type_error.bool'},
+        {'loc': ('v', 4), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
+
+
+def test_comma_separated_sub_model():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[Union[bool, float]] = []
+
+    class SuperModel(BaseModel):
+        data: Model
+
+    m = SuperModel(data={'v': 'true, 3, 0, FALSE, 3.14159'})
+    assert m.data.v == [True, 3, False, False, 3.14159]
+
+
+def test_comma_separated_sub_model_invalid():
+    class Model(BaseModel):
+        v: CommaSeparatedStripped[Union[bool, int]] = []
+
+    class SuperModel(BaseModel):
+        data: Model
+
+    with pytest.raises(ValidationError) as exc_info:
+        SuperModel(data={'v': 'true, 3, 0, FALSE, 3.14159'})
+
+    assert exc_info.value.errors() == [
+        {'loc': ('data', 'v', 4), 'msg': 'value could not be parsed to a boolean', 'type': 'type_error.bool'},
+        {'loc': ('data', 'v', 4), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+    ]
+
+
+def test_split_str_schema():
+    class Model(BaseModel):
+        comma_separated_stripped: CommaSeparatedStripped[int] = []
+        comma_separated_union: CommaSeparated[Union[bool, float]] = []
+        space_separated_required: SpaceSeparated[str]
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {
+            'comma_separated_stripped': {
+                'title': 'Comma Separated Stripped',
+                'default': [],
+                'anyOf': [{'type': 'array', 'items': {'type': 'integer'}}, {'type': 'string'}],
+            },
+            'comma_separated_union': {
+                'title': 'Comma Separated Union',
+                'default': [],
+                'anyOf': [
+                    {'type': 'array', 'items': {'anyOf': [{'type': 'boolean'}, {'type': 'number'}]}},
+                    {'type': 'string'},
+                ],
+            },
+            'space_separated_required': {
+                'title': 'Space Separated Required',
+                'anyOf': [{'type': 'array', 'items': {'type': 'string'}}, {'type': 'string'}],
+            },
+        },
+        'required': ['space_separated_required'],
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

✨ Add types `SpaceSeparated`, `CommaSeparated`, `CommaSeparatedStripped`.

Those would be especially useful for reading env vars that sometimes have problems embedding JSON strings with internal quotes.

The types are generic, so they can be used as standard types, like `List[str]`. The code is separated in implementation and type annotations so that it works correctly, Cython can compile it but types work correctly as if it was a generic `List`, with type checkers, `mypy`, editor completion, etc.

I had to write the actual implementation inside of an `if not TYPE_CHECKING` block and declare the "types" in a subsequent `if TYPE_CHECKING` to make `mypy` happy.

---

~I want to confirm Cython can indeed handle it in CI before adding tests and docs.~ Cython works :heavy_check_mark: 

## Usage example

A code-colored example is worth a thousand words or something, so...

Take this file `settings.env`:

```bash
# ignore comment
ENVIRONMENT="production"
API_KEY="super-secret-key"
REDIS_ADDRESS=localhost:6379
TIMEOUT_SECONDS=300
CORS_ORIGINS="https://helpmanual.io, http://127.0.0.1:8000/"
```

:point_up: Notice the `CORS_ORIGINS`, it's a **string** of values separated by commas and even an extra space (it's not a valid JSON-encoded payload inside a string, no quote escaping, etc).

It can now be read with this `Settings` class:

```Python
from pydantic import (
    CommaSeparatedStripped,
    BaseSettings,
    RedisDsn,
)


class Settings(BaseSettings):
    environment: str = 'development'
    api_key: str
    redis_dsn: RedisDsn = 'redis://user:pass@localhost:6379/1'
    timeout_seconds: int = 60
    cors_origins: CommaSeparatedStripped[str] = []

    class Config:
        env_file = 'settings.env'
        env_file_encoding = 'utf-8'


print(Settings().dict())
```

:point_up: Notice the `cors_origins: CommaSeparatedStripped[str] = []`. That will read the string of values separated by commas (even with space), parse it, convert it to a list, and validate its values with the internal type (type parameter).

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/1458

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
