### PR TITLE
add a __call__ stub to PyObject for mypy

### DIFF
--- a/changes/1352-brianmaissy.md
+++ b/changes/1352-brianmaissy.md
@@ -1,0 +1,1 @@
+Add a `__call__` stub to `PyObject` so that mypy will know that it is callable

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -317,6 +317,11 @@ class PyObject:
         except ImportError as e:
             raise errors.PyObjectError(error_message=str(e))
 
+    if TYPE_CHECKING:
+
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:
+            ...
+
 
 class ConstrainedNumberMeta(type):
     def __new__(cls, name: str, bases: Any, dct: Dict[str, Any]) -> 'ConstrainedInt':  # type: ignore

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -5,10 +5,10 @@ Do a little skipping about with types to demonstrate its usage.
 """
 import json
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
-from pydantic import BaseModel, NoneStr, StrictBool, root_validator, validate_arguments, validator
+from pydantic import BaseModel, NoneStr, PyObject, StrictBool, root_validator, validate_arguments, validator
 from pydantic.fields import Field
 from pydantic.generics import GenericModel
 
@@ -127,3 +127,13 @@ def foo(a: int, *, c: str = 'x') -> str:
 
 foo(1, c='thing')
 foo(1)
+
+
+class MyConf(BaseModel):
+    str_pyobject: PyObject = Field('datetime.date')
+    callable_pyobject: PyObject = Field(date)
+
+
+conf = MyConf()
+var1: date = conf.str_pyobject(2020, 12, 20)
+var2: date = conf.callable_pyobject(2111, 1, 1)


### PR DESCRIPTION
## Change Summary

* add a `__call__` stub to `PyObject` so that mypy will know that it is callable
* add a test that it works

## Related issue number

Resolves #1352 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
