### PR TITLE
Fix mypy

### DIFF
--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -125,7 +125,7 @@ class BaseSettings(BaseModel):
 
 def read_env_file(file_path: Path, *, encoding: str = None, case_sensitive: bool = False) -> Dict[str, Optional[str]]:
     try:
-        from dotenv import dotenv_values
+        from dotenv import dotenv_values  # type: ignore
     except ImportError as e:
         raise ImportError('python-dotenv is not installed, run `pip install pydantic[dotenv]`') from e
 


### PR DESCRIPTION
Using pydantic with mypy raises 

```python
venv/lib/python3.7/site-packages/pydantic/env_settings.py:128: error: Cannot find implementation or library stub for module named
'dotenv'  [import]
```

A simple `# type : ignore` in this line will do.
