### PR TITLE
Allow Infinity, -Infinity and NaN as Decimal values

### DIFF
--- a/changes/1885-umatbro.md
+++ b/changes/1885-umatbro.md
@@ -1,0 +1,1 @@
+Allow `Infinity`, `-Infinity` and `NaN` as `Decimal` type values.

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -57,7 +57,6 @@ __all__ = (
     'NumberNotLeError',
     'NumberNotMultipleError',
     'DecimalError',
-    'DecimalIsNotFiniteError',
     'DecimalMaxDigitsError',
     'DecimalMaxPlacesError',
     'DecimalWholeDigitsError',
@@ -384,11 +383,6 @@ class NumberNotMultipleError(PydanticValueError):
 
 
 class DecimalError(PydanticTypeError):
-    msg_template = 'value is not a valid decimal'
-
-
-class DecimalIsNotFiniteError(PydanticValueError):
-    code = 'decimal.not_finite'
     msg_template = 'value is not a valid decimal'
 
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -467,9 +467,9 @@ class ConstrainedDecimal(Decimal, metaclass=ConstrainedNumberMeta):
 
     @classmethod
     def validate(cls, value: Decimal) -> Decimal:
+        if not value.is_finite():
+            return value
         digit_tuple, exponent = value.as_tuple()[1:]
-        if exponent in {'F', 'n', 'N'}:
-            raise errors.DecimalIsNotFiniteError()
 
         if exponent >= 0:
             # A positive exponent adds that many trailing zeros.

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -291,9 +291,6 @@ def decimal_validator(v: Any) -> Decimal:
     except DecimalException:
         raise errors.DecimalError()
 
-    if not v.is_finite():
-        raise errors.DecimalIsNotFiniteError()
-
     return v
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from pydantic import UUID1, BaseConfig, BaseModel, PydanticTypeError, ValidationError, conint, errors, validator
+from pydantic import UUID1, BaseConfig, BaseModel, PydanticTypeError, ValidationError, conint, validator
 from pydantic.error_wrappers import flatten_errors, get_exc_type
 from pydantic.errors import StrRegexError
 from pydantic.typing import Literal
@@ -277,13 +277,7 @@ def test_errors_unknown_error_object():
 
 
 @pytest.mark.parametrize(
-    'exc,type_',
-    (
-        (TypeError(), 'type_error'),
-        (ValueError(), 'value_error'),
-        (AssertionError(), 'assertion_error'),
-        (errors.DecimalIsNotFiniteError(), 'value_error.decimal.not_finite'),
-    ),
+    'exc,type_', ((TypeError(), 'type_error'), (ValueError(), 'value_error'), (AssertionError(), 'assertion_error'),),
 )
 def test_get_exc_type(exc, type_):
     if isinstance(type_, str):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -612,7 +612,6 @@ class BoolCastable:
         ('decimal_check', '  42.24  ', Decimal('42.24')),
         ('decimal_check', Decimal('42.24'), Decimal('42.24')),
         ('decimal_check', 'not a valid decimal', ValidationError),
-        ('decimal_check', 'NaN', ValidationError),
     ],
 )
 def test_default_validators(field, value, result):
@@ -1550,11 +1549,7 @@ def test_anystr_strip_whitespace_disabled():
             ],
         ),
         *[
-            (
-                condecimal(decimal_places=2, max_digits=10),
-                value,
-                [{'loc': ('foo',), 'msg': 'value is not a valid decimal', 'type': 'value_error.decimal.not_finite'}],
-            )
+            (condecimal(decimal_places=2, max_digits=10), value, Decimal(value),)
             for value in (
                 'NaN',
                 '-NaN',
@@ -1571,11 +1566,7 @@ def test_anystr_strip_whitespace_disabled():
             )
         ],
         *[
-            (
-                condecimal(decimal_places=2, max_digits=10),
-                Decimal(value),
-                [{'loc': ('foo',), 'msg': 'value is not a valid decimal', 'type': 'value_error.decimal.not_finite'}],
-            )
+            (condecimal(decimal_places=2, max_digits=10), Decimal(value), Decimal(value),)
             for value in (
                 'NaN',
                 '-NaN',
@@ -1613,6 +1604,8 @@ def test_decimal_validation(type_, value, result):
             model(foo=value)
         assert exc_info.value.errors() == result
         assert exc_info.value.json().startswith('[')
+    elif result.is_nan():
+        assert model(foo=value).foo.is_nan()
     else:
         assert model(foo=value).foo == result
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
This PR allows to use `Infinity` and `NaN` values for `Decimal` type.

## Related issue number
#1885 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
