### PR TITLE
add smart_deepcopy (originaly from #1679)

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,6 +1,5 @@
 import warnings
 from collections.abc import Iterable as CollectionsIterable
-from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -36,7 +35,7 @@ from .typing import (
     is_new_type,
     new_type_supertype,
 )
-from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_like
+from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_like, smart_deepcopy
 from .validators import constant_validator, dict_validator, find_validators, validate_json
 
 Required: Any = Ellipsis
@@ -271,14 +270,7 @@ class ModelField(Representation):
         self.prepare()
 
     def get_default(self) -> Any:
-        if self.default_factory is not None:
-            value = self.default_factory()
-        elif self.default is None:
-            # deepcopy is quite slow on None
-            value = None
-        else:
-            value = deepcopy(self.default)
-        return value
+        return smart_deepcopy(self.default) if self.default_factory is None else self.default_factory()
 
     @classmethod
     def infer(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -42,6 +42,7 @@ from .utils import (
     generate_model_signature,
     lenient_issubclass,
     sequence_like,
+    smart_deepcopy,
     unique_list,
     validate_field_name,
 )
@@ -219,7 +220,7 @@ class ModelMetaclass(ABCMeta):
         pre_root_validators, post_root_validators = [], []
         for base in reversed(bases):
             if _is_base_model_class_defined and issubclass(base, BaseModel) and base != BaseModel:
-                fields.update(deepcopy(base.__fields__))
+                fields.update(smart_deepcopy(base.__fields__))
                 config = inherit_config(base.__config__, config)
                 validators = inherit_validators(base.__validators__, validators)
                 pre_root_validators += base.__pre_root_validators__
@@ -527,7 +528,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         Default values are respected, but no other validation is performed.
         """
         m = cls.__new__(cls)
-        object.__setattr__(m, '__dict__', {**deepcopy(cls.__field_defaults__), **values})
+        object.__setattr__(m, '__dict__', {**smart_deepcopy(cls.__field_defaults__), **values})
         if _fields_set is None:
             _fields_set = set(values.keys())
         object.__setattr__(m, '__fields_set__', _fields_set)
@@ -558,6 +559,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         )
 
         if deep:
+            # chances of having empty dict here are quite low for using smart_deepcopy
             v = deepcopy(v)
 
         cls = self.__class__

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -53,7 +53,7 @@ __all__ = (
     'ClassAttribute',
 )
 
-# these are types that returned by deepcopy unchanged
+# these are types that are returned unchanged by deepcopy
 IMMUTABLE_NON_COLLECTIONS_TYPES: Set[Type[Any]] = {
     int,
     float,

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -80,7 +80,7 @@ IMMUTABLE_NON_COLLECTIONS_TYPES: Set[Type[Any]] = {
 BUILTIN_COLLECTIONS: Set[Type[Any]] = {
     list,
     set,
-    # tuple,
+    tuple,
     frozenset,
     dict,
     OrderedDict,
@@ -581,7 +581,7 @@ def smart_deepcopy(obj: Obj) -> Obj:
     """
     Return type as is for immutable built-in types
     Use obj.copy() for built-in empty collections
-    Use copy.deepcopy() only on non-empty collections and unknown objects
+    Use copy.deepcopy() for non-empty collections and unknown objects
     """
 
     obj_type = obj.__class__

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import string
+from copy import deepcopy
 from distutils.version import StrictVersion
 from enum import Enum
 from typing import NewType, Union
@@ -13,12 +14,14 @@ from pydantic.dataclasses import dataclass
 from pydantic.fields import Undefined
 from pydantic.typing import Literal, all_literal_values, display_as_type, is_new_type, new_type_supertype
 from pydantic.utils import (
+    BUILTIN_COLLECTIONS,
     ClassAttribute,
     ValueItems,
     deep_update,
     get_model,
     import_string,
     lenient_issubclass,
+    smart_deepcopy,
     truncate,
     unique_list,
 )
@@ -347,3 +350,30 @@ def test_all_literal_values():
 
     L312 = Literal['3', Literal[L1, L2]]
     assert sorted(all_literal_values(L312)) == sorted(('1', '2', '3'))
+
+
+@pytest.mark.parametrize(
+    'obj',
+    (1, 1.0, '1', b'1', int, None, test_all_literal_values, len, test_all_literal_values.__code__, lambda: ..., ...),
+)
+def test_smart_deepcopy_immutable_non_sequence(obj, mocker):
+    # make sure deepcopy is not used
+    # (other option will be to use obj.copy(), but this will produce error as none of given objects doesn't have it)
+    mocker.patch('pydantic.utils.deepcopy', side_effect=RuntimeError)
+    assert smart_deepcopy(obj) is deepcopy(obj) is obj
+
+
+@pytest.mark.parametrize('empty_collection', map(lambda collection: collection(), BUILTIN_COLLECTIONS))
+def test_smart_deepcopy_empty_collection(empty_collection, mocker):
+    mocker.patch('pydantic.utils.deepcopy', side_effect=RuntimeError)  # make sure deepcopy is not used
+    if not isinstance(empty_collection, (tuple, frozenset)):  # empty tuple or frozenset are always the same object
+        assert smart_deepcopy(empty_collection) is not empty_collection
+
+
+@pytest.mark.parametrize('collection', BUILTIN_COLLECTIONS)
+def test_smart_deepcopy_collection(collection, mocker):
+    expected_value = object()
+    if issubclass(collection, dict):
+        collection = collection.fromkeys
+    mocker.patch('pydantic.utils.deepcopy', return_value=expected_value)
+    assert smart_deepcopy(collection((1,))) is expected_value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -358,22 +358,22 @@ def test_all_literal_values():
 )
 def test_smart_deepcopy_immutable_non_sequence(obj, mocker):
     # make sure deepcopy is not used
-    # (other option will be to use obj.copy(), but this will produce error as none of given objects doesn't have it)
+    # (other option will be to use obj.copy(), but this will produce error as none of given objects have this method)
     mocker.patch('pydantic.utils.deepcopy', side_effect=RuntimeError)
     assert smart_deepcopy(obj) is deepcopy(obj) is obj
 
 
-@pytest.mark.parametrize('empty_collection', map(lambda collection: collection(), BUILTIN_COLLECTIONS))
+@pytest.mark.parametrize('empty_collection', (collection() for collection in BUILTIN_COLLECTIONS))
 def test_smart_deepcopy_empty_collection(empty_collection, mocker):
     mocker.patch('pydantic.utils.deepcopy', side_effect=RuntimeError)  # make sure deepcopy is not used
     if not isinstance(empty_collection, (tuple, frozenset)):  # empty tuple or frozenset are always the same object
         assert smart_deepcopy(empty_collection) is not empty_collection
 
 
-@pytest.mark.parametrize('collection', BUILTIN_COLLECTIONS)
+@pytest.mark.parametrize(
+    'collection', (c.fromkeys((1,)) if issubclass(c, dict) else c((1,)) for c in BUILTIN_COLLECTIONS)
+)
 def test_smart_deepcopy_collection(collection, mocker):
     expected_value = object()
-    if issubclass(collection, dict):
-        collection = collection.fromkeys
     mocker.patch('pydantic.utils.deepcopy', return_value=expected_value)
-    assert smart_deepcopy(collection((1,))) is expected_value
+    assert smart_deepcopy(collection) is expected_value


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
add `smart_deepcopy()`:
```py
smart_deepcopy(obj: ~Obj) -> ~Obj
    Return type as is for immutable built-in types
    Use obj.copy() for built-in empty collections
    Use copy.deepcopy() only on non-empty collections and unknown objects
```

It's primarily needed for faster copying of default values, since they're often are immutable types or empty collections

Here's benchmark showing the difference in speed between different types of values:
```py
from copy import deepcopy
from timeit import timeit

from pydantic.utils import smart_deepcopy, BUILTIN_COLLECTIONS

cases = {
    "IMMUTABLE":
        (1, 1.0, '1', b'1', int, None, smart_deepcopy, len, smart_deepcopy.__code__, lambda: _, ...),
    "EMPTY_COLLECTIONS":
        map(lambda collection: collection(), BUILTIN_COLLECTIONS),
    "NON_EMPTY_COLLECTIONS":
        map(lambda c: c.fromkeys([1]) if issubclass(c, dict) else c([1]), BUILTIN_COLLECTIONS),
}

for name, values in cases.items():
    deepcopy_results = []
    smart_deepcopy_results = []
    for value in values:
        deepcopy_results.append(timeit(lambda: deepcopy(value), number=100000))
        smart_deepcopy_results.append(timeit(lambda: smart_deepcopy(value), number=100000))

    deepcopy_result = sum(deepcopy_results)
    smart_deepcopy_result = sum(smart_deepcopy_results)
    faster_by = deepcopy_result / smart_deepcopy_result
    print(f"{name}: {deepcopy_result=:.3}s, {smart_deepcopy_result=:.3}s, {faster_by=:.3} times")

```
```py
IMMUTABLE: deepcopy_result=0.658s, smart_deepcopy_result=0.235s, faster_by=2.8 times
EMPTY_COLLECTIONS: deepcopy_result=1.73s, smart_deepcopy_result=0.261s, faster_by=6.62 times
NON_EMPTY_COLLECTIONS: deepcopy_result=2.33s, smart_deepcopy_result=2.5s, faster_by=0.933 times
```


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
