### PR TITLE
Fix typo in document

### DIFF
--- a/docs/mypy_plugin.md
+++ b/docs/mypy_plugin.md
@@ -58,7 +58,7 @@ There are other benefits too! See below for more details.
 * classes decorated with [`@pydantic.dataclasess.dataclass`](usage/dataclasses.md) are type checked the same as standard python dataclasses
 * The `@pydantic.dataclasess.dataclass` decorator accepts a `config` keyword argument which has the same meaning as [the `Config` sub-class](usage/model_config.md).
 
-### Optional Capabilites:
+### Optional Capabilities:
 #### Prevent the use of required dynamic aliases
 * If the [`warn_required_dynamic_aliases` **plugin setting**](#plugin-settings) is set to `True`, you'll get a mypy
   error any time you use a dynamically-determined alias or alias generator on a model with

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -53,7 +53,7 @@ A few more things to note:
 ## Subclass Validators and `each_item`
 
 If using a validator with a subclass that references a `List` type field on a parent class, using `each_item=True` will
-cause the validator not to run; instead, the list must be iterated over programatically.
+cause the validator not to run; instead, the list must be iterated over programmatically.
 
 ```py
 {!.tmp_examples/validators_subclass_each_item.py!}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Fix typo:
1. `Capabilites` -> `Capabilities` in `mypy_plugin.md`
2. `programatically` -> `programmatically` in `usage/validators.md`
