### PR TITLE
fix(validation): also check `root_validators` when `validate_assignment` is on

### DIFF
--- a/changes/1971-PrettyWood.md
+++ b/changes/1971-PrettyWood.md
@@ -1,0 +1,1 @@
+Also check `root_validators` when `validate_assignment` is on

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ from pydantic import (
     Required,
     ValidationError,
     constr,
+    root_validator,
     validator,
 )
 
@@ -591,6 +592,76 @@ def test_validating_assignment_fail():
             'type': 'value_error.any_str.min_length',
             'ctx': {'limit_value': 1},
         }
+    ]
+
+
+def test_validating_assignment_pre_root_validator_fail():
+    class Model(BaseModel):
+        current_value: float = Field(..., alias='current')
+        max_value: float
+
+        class Config:
+            validate_assignment = True
+
+        @root_validator(pre=True)
+        def values_are_not_string(cls, values):
+            if any(isinstance(x, str) for x in values.values()):
+                raise ValueError('values cannot be a string')
+            return values
+
+    m = Model(current=100, max_value=200)
+    with pytest.raises(ValidationError) as exc_info:
+        m.current_value = '100'
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('__root__',),
+            'msg': 'values cannot be a string',
+            'type': 'value_error',
+        }
+    ]
+
+
+def test_validating_assignment_post_root_validator_fail():
+    class Model(BaseModel):
+        current_value: float = Field(..., alias='current')
+        max_value: float
+
+        class Config:
+            validate_assignment = True
+
+        @root_validator
+        def current_lessequal_max(cls, values):
+            current_value = values.get('current_value')
+            max_value = values.get('max_value')
+            if current_value > max_value:
+                raise ValueError('current_value cannot be greater than max_value')
+            return values
+
+        @root_validator(skip_on_failure=True)
+        def current_lessequal_300(cls, values):
+            current_value = values.get('current_value')
+            if current_value > 300:
+                raise ValueError('current_value cannot be greater than 300')
+            return values
+
+        @root_validator
+        def current_lessequal_500(cls, values):
+            current_value = values.get('current_value')
+            if current_value > 500:
+                raise ValueError('current_value cannot be greater than 500')
+            return values
+
+    m = Model(current=100, max_value=200)
+    m.current_value = '100'
+    with pytest.raises(ValidationError) as exc_info:
+        m.current_value = 1000
+    assert exc_info.value.errors() == [
+        {'loc': ('__root__',), 'msg': 'current_value cannot be greater than max_value', 'type': 'value_error'},
+        {
+            'loc': ('__root__',),
+            'msg': 'current_value cannot be greater than 500',
+            'type': 'value_error',
+        },
     ]
 
 


### PR DESCRIPTION
## Change Summary
This is a proposal but I agree with @caldwellshane that `root_validator` should be considered as a regular validator. It should hence be triggered when `validate_assignment` is on.
This is not the case at the moment

## Related issue number

closes #1971

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
