### PR TITLE
Force fields.Undefined to be a singleton object

### DIFF
--- a/changes/1981-daviskirk.md
+++ b/changes/1981-daviskirk.md
@@ -1,0 +1,1 @@
+Force `fields.Undefined` to be a singleton object, fixing inherited generic model schemas

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -40,10 +40,18 @@ from .validators import constant_validator, dict_validator, find_validators, val
 
 Required: Any = Ellipsis
 
+T = TypeVar('T')
+
 
 class UndefinedType:
     def __repr__(self) -> str:
         return 'PydanticUndefined'
+
+    def __copy__(self: T) -> T:
+        return self
+
+    def __deepcopy__(self: T, _: Any) -> T:
+        return self
 
 
 Undefined = UndefinedType()

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -69,6 +69,11 @@ def parse_raw_as(
     type_name: Optional[NameFactory] = None,
 ) -> T:
     obj = load_str_bytes(
-        b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle, json_loads=json_loads,
+        b,
+        proto=proto,
+        content_type=content_type,
+        encoding=encoding,
+        allow_pickle=allow_pickle,
+        json_loads=json_loads,
     )
     return parse_obj_as(type_, obj, type_name=type_name)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -411,6 +411,26 @@ def test_custom_schema():
 
 
 @skip_36
+def test_child_schema():
+
+    T = TypeVar('T')
+
+    class Model(GenericModel, Generic[T]):
+        a: T
+
+    class Child(Model[T], Generic[T]):
+        pass
+
+    schema = Child[int].schema()
+    assert schema == {
+        'title': 'Child[int]',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'integer'}},
+        'required': ['a'],
+    }
+
+
+@skip_36
 def test_custom_generic_naming():
     T = TypeVar('T')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 import string
-from copy import deepcopy
+from copy import copy, deepcopy
 from distutils.version import StrictVersion
 from enum import Enum
 from typing import NewType, Union
@@ -294,6 +294,11 @@ def test_deep_update_is_not_mutating():
 
 def test_undefined_repr():
     assert repr(Undefined) == 'PydanticUndefined'
+
+
+def test_undefined_copy():
+    copy(Undefined) is Undefined
+    deepcopy(Undefined) is Undefined
 
 
 def test_get_model():


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

In various places of the code, we compare directly to `fields.Undefined`
since we assume it to be constant.
When new models get created however, the object is deepcopied and
is no longer identical with the original object.
We therefore add `__copy__` and `__deepcopy__` methods to ensure
that the copied objects are actually the same original object.

## Related issue number

While I did does not address the exact error message #1578 had, schema generation on inherited generics that had required generic fields did not work at all,  so it might also fix this.

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
