### PR TITLE
chore: change example path in documentation to not be tracked by git

### DIFF
--- a/docs/examples/models_parse.py
+++ b/docs/examples/models_parse.py
@@ -1,5 +1,7 @@
 import pickle
 from datetime import datetime
+from pathlib import Path
+
 from pydantic import BaseModel, ValidationError
 
 
@@ -31,7 +33,9 @@ m = User.parse_raw(
 )
 print(m)
 
-path = 'data.json'
+path = 'docs/.tmp_examples/data.json'
+Path(path).parent.mkdir(parents=True, exist_ok=True)
+
 with open(path, 'w') as f:
     f.write('{"id": 123, "name": "James"}')
 m = User.parse_file(path)


### PR DESCRIPTION
To make `parse_file` more explicit in #1795, a file `data.json` is created
once we serve the documentation. But it's not ignored by git.
Instead of adding `data.json` in `.gitignore`, let's just change the path
to be with all the rest of the documentation

![Screen Shot 2020-10-10 at 9 31 31 PM](https://user-images.githubusercontent.com/18406791/95663607-e6a02700-0b40-11eb-8b58-5178406b95e6.png)

Closes #1992 