### PR TITLE
Fix #1999: call validator with correct "values" type in `setattr`

### DIFF
--- a/changes/1999-me-ransh.md
+++ b/changes/1999-me-ransh.md
@@ -1,0 +1,1 @@
+call validator with the correct `values` parameter type in `BaseModel.__setattr__`

--- a/changes/1999-me-ransh.md
+++ b/changes/1999-me-ransh.md
@@ -1,1 +1,2 @@
-call validator with the correct `values` parameter type in `BaseModel.__setattr__`
+Call validator with the correct `values` parameter type in `BaseModel.__setattr__`,
+when `validate_assignment = True` in model config.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -367,7 +367,8 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         elif self.__config__.validate_assignment:
             known_field = self.__fields__.get(name, None)
             if known_field:
-                value, error_ = known_field.validate(value, self.dict(exclude={name}), loc=name, cls=self.__class__)
+                values = dict(self._iter(exclude={name}))
+                value, error_ = known_field.validate(value, values, loc=name, cls=self.__class__)
                 if error_:
                     raise ValidationError([error_], self.__class__)
         self.__dict__[name] = value

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -367,9 +367,10 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         elif self.__config__.validate_assignment:
             known_field = self.__fields__.get(name, None)
             if known_field:
-                values = dict(self._iter(exclude={name}))
-                value, error_ = known_field.validate(value, values, loc=name, cls=self.__class__)
+                original_value = self.__dict__.pop(name)
+                value, error_ = known_field.validate(value, self.__dict__, loc=name, cls=self.__class__)
                 if error_:
+                    self.__dict__[name] = original_value
                     raise ValidationError([error_], self.__class__)
         self.__dict__[name] = value
         self.__fields_set__.add(name)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -185,6 +185,30 @@ def test_validating_assignment_dict():
     ]
 
 
+def test_validating_assignment_values_dict():
+    class ModelOne(BaseModel):
+        a: int
+
+    class ModelTwo(BaseModel):
+        m: ModelOne
+        b: int
+
+        @validator('b')
+        def validate_b(cls, b, values):
+            if 'm' in values:
+                return b + values['m'].a  # this fails if values['m'] is a dict
+            else:
+                return b
+
+        class Config:
+            validate_assignment = True
+
+    model = ModelTwo(m=ModelOne(a=1), b=2)
+    assert model.b == 3
+    model.b = 3
+    assert model.b == 4
+
+
 def test_validate_multiple():
     # also test TypeError
     class Model(BaseModel):


### PR DESCRIPTION
## Change Summary

Call validator with the correct `values` parameter type in `BaseModel.__setattr__`

## Related issue number

Fixes #1999 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/1999-me-ransh.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
