### PR TITLE
Allow generics to extend concrete classes. fixes #2005

### DIFF
--- a/changes/2005-choogeboom.md
+++ b/changes/2005-choogeboom.md
@@ -1,0 +1,2 @@
+Allows subclasses of generic models to make some, or all, of the superclass's type parameters concrete, while 
+also defining new type parameters in the subclass.

--- a/docs/examples/models_generics_inheritance_extend.py
+++ b/docs/examples/models_generics_inheritance_extend.py
@@ -3,15 +3,17 @@ from pydantic.generics import GenericModel
 
 TypeX = TypeVar('TypeX')
 TypeY = TypeVar('TypeY')
+TypeZ = TypeVar('TypeZ')
 
 
-class BaseClass(GenericModel, Generic[TypeX]):
+class BaseClass(GenericModel, Generic[TypeX, TypeY]):
     x: TypeX
-
-
-class ChildClass(BaseClass[int], Generic[TypeY]):
     y: TypeY
 
 
+class ChildClass(BaseClass[int, TypeY], Generic[TypeY, TypeZ]):
+    z: TypeZ
+
+
 # Replace TypeY by str
-print(ChildClass[str](x=1, y='y'))
+print(ChildClass[str, int](x=1, y='y', z=3))

--- a/docs/examples/models_generics_inheritance_extend.py
+++ b/docs/examples/models_generics_inheritance_extend.py
@@ -1,0 +1,17 @@
+from typing import TypeVar, Generic
+from pydantic.generics import GenericModel
+
+TypeX = TypeVar('TypeX')
+TypeY = TypeVar('TypeY')
+
+
+class BaseClass(GenericModel, Generic[TypeX]):
+    x: TypeX
+
+
+class ChildClass(BaseClass[int], Generic[TypeY]):
+    y: TypeY
+
+
+# Replace TypeY by str
+print(ChildClass[str](x=1, y='y'))

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -319,6 +319,14 @@ To inherit from a GenericModel without replacing the `TypeVar` instance, a class
 ```
 _(This script is complete, it should run "as is")_
 
+You can also create a generic subclass of a `GenericModel` that partially or fully replaces the type 
+parameters in the superclass.
+
+```py
+{!.tmp_examples/models_generics_inheritance_extend.py!}
+```
+_(This script is complete, it should run "as is")_
+
 If the name of the concrete subclasses is important, you can also override the default behavior:
 
 ```py

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,4 +1,16 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Tuple, Type, TypeVar, Union, cast, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Generic,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    get_type_hints,
+)
 
 from .class_validators import gather_all_validators
 from .fields import FieldInfo, ModelField
@@ -25,7 +37,7 @@ class GenericModel(BaseModel):
         cached = _generic_types_cache.get((cls, params))
         if cached is not None:
             return cached
-        if cls.__concrete__:
+        if cls.__concrete__ and Generic not in cls.__bases__:
             raise TypeError('Cannot parameterize a concrete instantiation of a generic model')
         if not isinstance(params, tuple):
             params = (params,)

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,16 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Generic,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    get_type_hints,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generic, Tuple, Type, TypeVar, Union, cast, get_type_hints
 
 from .class_validators import gather_all_validators
 from .fields import FieldInfo, ModelField

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -603,8 +603,8 @@ def test_multiple_specification():
 
 @skip_36
 def test_generic_subclass_of_concrete_generic():
-    T = TypeVar("T")
-    U = TypeVar("U")
+    T = TypeVar('T')
+    U = TypeVar('U')
 
     class GenericBaseModel(GenericModel, Generic[T]):
         data: T

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -599,3 +599,22 @@ def test_multiple_specification():
         {'loc': ('a',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
         {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
+
+
+@skip_36
+def test_generic_subclass_of_concrete_generic():
+    T = TypeVar("T")
+    U = TypeVar("U")
+
+    class GenericBaseModel(GenericModel, Generic[T]):
+        data: T
+
+    class GenericSub(GenericBaseModel[int], Generic[U]):
+        extra: U
+
+    ConcreteSub = GenericSub[int]
+
+    with pytest.raises(ValidationError):
+        ConcreteSub(data=2, extra='wrong')
+
+    ConcreteSub(data=2, extra=3)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -622,6 +622,7 @@ def test_generic_subclass_of_concrete_generic():
     ConcreteSub(data=2, extra=3)
 
 
+@skip_36
 def test_generic_model_pickle(create_module):
     # Using create_module because pickle doesn't support
     # objects with <locals> in their __qualname__  (e. g. defined in function)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -617,4 +617,7 @@ def test_generic_subclass_of_concrete_generic():
     with pytest.raises(ValidationError):
         ConcreteSub(data=2, extra='wrong')
 
+    with pytest.raises(ValidationError):
+        ConcreteSub(data='wrong', extra=2)
+
     ConcreteSub(data=2, extra=3)


### PR DESCRIPTION
## Change Summary

Allows models to extend other generic models and add new type parameters, while completely filling out the superclass parameters.

## Related issue number

fixes #2005

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
