### PR TITLE
Allow generic abstract classes to pass validation

### DIFF
--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -80,7 +80,7 @@ class GenericModel(BaseModel):
     @classmethod
     def validate(cls: Type[GenericModelT], value: Any) -> GenericModelT:
         actual_cls = cls.__base__
-        return super(GenericModel, actual_cls).validate(value)
+        return super(GenericModel, actual_cls).validate(value)  # type: ignore
 
 
 def resolve_type_hint(type_: Any, typevars_map: Dict[Any, Any]) -> Type[Any]:

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -77,6 +77,11 @@ class GenericModel(BaseModel):
         params_component = ', '.join(param_names)
         return f'{cls.__name__}[{params_component}]'
 
+    @classmethod
+    def validate(cls: Type[GenericModelT], value: Any) -> GenericModelT:
+        actual_cls = cls.__base__
+        return super(GenericModel, actual_cls).validate(value)
+
 
 def resolve_type_hint(type_: Any, typevars_map: Dict[Any, Any]) -> Type[Any]:
     if hasattr(type_, '__origin__') and getattr(type_, '__parameters__', None):

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -623,3 +623,6 @@ def test_abstract_generic_type_recursion():
 
     OuterClass[int](inner_class=ConcreteInnerClass[int](base_data=2))
     OuterClass(inner_class=ConcreteInnerClass(base_data=2))
+
+    with pytest.raises(ValidationError):
+        OuterClass[int](inner_class=ConcreteInnerClass[str](base_data='stuff'))

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -614,7 +614,6 @@ def test_abstract_generic_type_recursion():
             pass
 
     class ConcreteInnerClass(BaseInnerClass[T], Generic[T]):
-
         def base_abstract(self) -> None:
             return None
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,3 +1,4 @@
+import abc
 import sys
 from enum import Enum
 from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
@@ -599,3 +600,25 @@ def test_multiple_specification():
         {'loc': ('a',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
         {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
+
+
+@skip_36
+def test_abstract_generic_type_recursion():
+    T = TypeVar('T')
+
+    class BaseInnerClass(GenericModel, abc.ABC, Generic[T]):
+        base_data: T
+
+        @abc.abstractmethod
+        def base_abstract(self) -> None:
+            pass
+
+    class ConcreteInnerClass(BaseInnerClass[T], Generic[T]):
+
+        def base_abstract(self) -> None:
+            return None
+
+    class OuterClass(GenericModel, Generic[T]):
+        inner_class: BaseInnerClass[T]
+
+    OuterClass[int](inner_class=ConcreteInnerClass[int](base_data=2))

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -622,3 +622,4 @@ def test_abstract_generic_type_recursion():
         inner_class: BaseInnerClass[T]
 
     OuterClass[int](inner_class=ConcreteInnerClass[int](base_data=2))
+    OuterClass(inner_class=ConcreteInnerClass(base_data=2))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1286,7 +1286,6 @@ def test_abstract_recursion():
             pass
 
     class ConcreteInnerClass(BaseInnerClass):
-
         def do_something(self) -> None:
             return None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1294,4 +1294,3 @@ def test_abstract_recursion():
         inner_class: List[BaseInnerClass]
 
     OuterClass(inner_class=[ConcreteInnerClass(base_data=2)])
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import abc
 import sys
 from enum import Enum
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Type, get_type_hints
@@ -1274,3 +1275,23 @@ def test_base_config_type_hinting():
         a: int
 
     get_type_hints(M.__config__)
+
+
+def test_abstract_recursion():
+    class BaseInnerClass(BaseModel, abc.ABC):
+        base_data: int
+
+        @abc.abstractmethod
+        def do_something(self) -> None:
+            pass
+
+    class ConcreteInnerClass(BaseInnerClass):
+
+        def do_something(self) -> None:
+            return None
+
+    class OuterClass(BaseModel):
+        inner_class: List[BaseInnerClass]
+
+    OuterClass(inner_class=[ConcreteInnerClass(base_data=2)])
+


### PR DESCRIPTION
## Change Summary

This PR overrides `BaseModel.validate` in `GenericModel` to overcome some wierdness with generics. Basically, the `isinstance` check in `BaseModel.validate` fails because `ConcreteInnerClass[int]` is not a subclass of `BaseInnerClass[int]`. They are both subclasses of `BaseInnerClass[T]`, though.

This is currently a partial solution, because, while it allows validations to pass, it does so in a way that is too permissive, because `ConcreteInnerClass[str]` would also pass.

I think the real solution is to properly establish the class relationship

## Related issue number

#2007 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
