### PR TITLE
Add model contexts and context option to BaseModel.parse_obj

### DIFF
--- a/changes/1993-uriyyo.md
+++ b/changes/1993-uriyyo.md
@@ -1,0 +1,1 @@
+Merge `_generic_validator_basic` and `_generic_validator_cls` into one function


### PR DESCRIPTION
## Change Summary

This pull request adds the possibility for passing context to `BaseModel.parse_obj`

Fixes #1549

While a basic test is implemented, I will do a lot more work in making sure this actually works for all the cases we have.  However, I would love to have some feedback if this is going in the right direction or not!

Disclaimer:

Unfortunately, I had trouble getting my head around all the various lambda combinations in `class_validators.py` and thought that passing the validation arguments by keywords would simplify things (started with code from #1993).  It did, but it also made a smart dent on the benchmarks, so I'll probably go back and rewrite this the hard way.
 
## Related issue number

#1549 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
