### PR TITLE
Make a v1.6.2 release for python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
     env:
       PYTHON: ${{ matrix.python-version }}
       OS: ubuntu

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v1.6.2 (2020-10-23)
+
+* Python 3.9 support, #1844 by @PrettyWood
+
 ## v1.6.1 (2020-07-15)
 
 * fix validation and parsing of nested models with `default_factory`, #1710 by @PrettyWood

--- a/changes/1832-PrettyWood.md
+++ b/changes/1832-PrettyWood.md
@@ -1,0 +1,1 @@
+add basic support for python 3.9

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Tuple, Type, TypeVar, Uni
 from .class_validators import gather_all_validators
 from .fields import FieldInfo, ModelField
 from .main import BaseModel, create_model
+from .typing import get_origin
 from .utils import lenient_issubclass
 
 _generic_types_cache: Dict[Tuple[Type[Any], Union[Any, Tuple[Any, ...]]], Type[BaseModel]] = {}
@@ -37,7 +38,7 @@ class GenericModel(BaseModel):
         check_parameters_count(cls, params)
         typevars_map: Dict[TypeVarType, Type[Any]] = dict(zip(cls.__parameters__, params))
         type_hints = get_type_hints(cls).items()
-        instance_type_hints = {k: v for k, v in type_hints if getattr(v, '__origin__', None) is not ClassVar}
+        instance_type_hints = {k: v for k, v in type_hints if get_origin(v) is not ClassVar}
         concrete_type_hints: Dict[str, Type[Any]] = {
             k: resolve_type_hint(v, typevars_map) for k, v in instance_type_hints.items()
         }
@@ -79,7 +80,7 @@ class GenericModel(BaseModel):
 
 
 def resolve_type_hint(type_: Any, typevars_map: Dict[Any, Any]) -> Type[Any]:
-    if hasattr(type_, '__origin__') and getattr(type_, '__parameters__', None):
+    if get_origin(type_) and getattr(type_, '__parameters__', None):
         concrete_type_args = tuple([typevars_map[x] for x in type_.__parameters__])
         return type_[concrete_type_args]
     return typevars_map.get(type_, type_)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -33,7 +33,7 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import model_schema
 from .types import PyObject, StrBytes
-from .typing import AnyCallable, ForwardRef, is_classvar, resolve_annotations, update_field_forward_refs
+from .typing import AnyCallable, ForwardRef, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
 from .utils import (
     ClassAttribute,
     GetterDict,
@@ -246,7 +246,7 @@ class ModelMetaclass(ABCMeta):
                     if (
                         isinstance(value, untouched_types)
                         and ann_type != PyObject
-                        and not lenient_issubclass(getattr(ann_type, '__origin__', None), Type)
+                        and not lenient_issubclass(get_origin(ann_type), Type)
                     ):
                         continue
                     fields[ann_name] = inferred = ModelField.infer(

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -55,7 +55,7 @@ from .types import (
     conset,
     constr,
 )
-from .typing import ForwardRef, Literal, is_callable_type, is_literal_type, literal_values
+from .typing import ForwardRef, Literal, get_args, get_origin, is_callable_type, is_literal_type, literal_values
 from .utils import get_model, lenient_issubclass, sequence_like
 
 if TYPE_CHECKING:
@@ -803,9 +803,9 @@ def get_annotation_from_field_info(annotation: Any, field_info: FieldInfo, field
             or lenient_issubclass(type_, (ConstrainedList, ConstrainedSet))
         ):
             return type_
-        origin = getattr(type_, '__origin__', None)
+        origin = get_origin(type_)
         if origin is not None:
-            args: Tuple[Any, ...] = type_.__args__
+            args: Tuple[Any, ...] = get_args(type_)
             if any(isinstance(a, ForwardRef) for a in args):
                 # forward refs cause infinite recursion below
                 return type_

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -1,6 +1,6 @@
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '1.6.1'
+VERSION = '1.6.2'
 
 
 def version_info() -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ per-file-ignores =
     docs/examples/types_constrained.py: F722
 
 [bdist_wheel]
-python-tag = py36.py37.py38
+python-tag = py36.py37.py38.py39
 
 [coverage:run]
 source = pydantic

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
This branch isn't intended to actually be merged -- just doing it for the CI. It was created like so:

```
git checkout v1.6.1
git cherry-pick 794d0bccf93b006b388a565aabc523ab34920a8c
[make edits to history/version in 63c64659f7935b2a3e5ab425ad205187e2336065]
```

I assume that a new release hasn't been made because there are changes in master that still need consideration before a new release is made. However, it would be great if just the bare minimum for python 3.9 could be pushed as v1.6.2. 

Thanks for your consideration!