### PR TITLE
Prevent fields from being deleted from BaseModel.__dict__ when a field validator raises an unexpected exception

### DIFF
--- a/changes/2044-johnsabath.md
+++ b/changes/2044-johnsabath.md
@@ -1,0 +1,1 @@
+Fixed regression introduced in v1.7 involving exception handling in field validators when `validate_assignment=True`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -384,12 +384,16 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
             known_field = self.__fields__.get(name, None)
             if known_field:
-                original_value = self.__dict__[name]
-                value, error_ = known_field.validate(value, self.__dict__, loc=name, cls=self.__class__)
-                if error_:
+                original_value = self.__dict__.pop(name)
+                try:
+                    value, error_ = known_field.validate(value, self.__dict__, loc=name, cls=self.__class__)
+                    if error_:
+                        raise ValidationError([error_], self.__class__)
+                except Exception:
                     self.__dict__[name] = original_value
-                    raise ValidationError([error_], self.__class__)
-                new_values[name] = value
+                    raise
+                else:
+                    new_values[name] = value
 
             errors = []
             for skip_on_failure, validator in self.__post_root_validators__:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -384,7 +384,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
             known_field = self.__fields__.get(name, None)
             if known_field:
-                original_value = self.__dict__.pop(name)
+                original_value = self.__dict__[name]
                 value, error_ = known_field.validate(value, self.__dict__, loc=name, cls=self.__class__)
                 if error_:
                     self.__dict__[name] = original_value

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1157,20 +1157,25 @@ def test_nested_literal_validator():
     ]
 
 
-def test_field_that_is_being_validated_is_excluded_from_validator_values():
-    validators_values = None
+def test_field_that_is_being_validated_is_excluded_from_validator_values(mocker):
+    check_values = mocker.MagicMock()
 
     class Model(BaseModel):
         foo: str
         bar: str
 
+        class Config:
+            validate_assignment = True
+
         @validator('foo')
         def validate_foo(cls, v, values):
-            nonlocal validators_values
-            validators_values = values
+            check_values({**values})
 
-    Model(foo='foo_value', bar='bar_value')
-    assert validators_values == {'bar': 'bar_value'}
+    model = Model(foo='foo_value', bar='bar_value')
+    check_values.reset_mock()
+
+    model.foo = 'new_foo_value'
+    check_values.assert_called_once_with({'bar': 'bar_value'})
 
 
 def test_exceptions_in_field_validators_restore_original_field_value():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1188,10 +1188,10 @@ def test_exceptions_in_field_validators_restore_original_field_value():
         @validator('foo')
         def validate_foo(cls, v):
             if v == 'raise_exception':
-                raise Exception()
+                raise RuntimeError('test error')
             return v
 
     model = Model(foo='foo')
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError, match='test error'):
         model.foo = 'raise_exception'
     assert model.foo == 'foo'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Addressing https://github.com/samuelcolvin/pydantic/issues/2044

<!-- Please give a short summary of the changes. -->

## Related issue number

fix https://github.com/samuelcolvin/pydantic/issues/2044

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
