### PR TITLE
make host optional in AnyUrl

### DIFF
--- a/changes/1983-vgerak.md
+++ b/changes/1983-vgerak.md
@@ -1,0 +1,2 @@
+Make host optional in `AnyUrl` to conform to [RFC 8089](https://tools.ietf.org/html/rfc8089#section-2)
+(now allows URLs like `"file:///foo/bar"`).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
- Add `host_required` parameter (`False` in `AnyUrl`, `True` on `HttpUrl`, `PostgresDsn`, `RedisDsn`, `stricturl`, as suggested
- Move (now) failing host validation tests from `AnyUrl` to `HttpUrl`, add relevant tests for Postgres, Redis, stricturl

## Related issue number
Fixes #1983 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI & Coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
