### PR TITLE
fix: pydantic dataclass can inherit from stdlib dataclass and `arbitrary_types_allowed` is supported

### DIFF
--- a/changes/2042-PrettyWood.md
+++ b/changes/2042-PrettyWood.md
@@ -1,1 +1,2 @@
 fix: _pydantic_ `dataclass` can inherit from stdlib `dataclass`
+and `Config.arbitrary_types_allowed` is supported

--- a/changes/2042-PrettyWood.md
+++ b/changes/2042-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: _pydantic_ `dataclass` can inherit from stdlib `dataclass`

--- a/docs/examples/dataclasses_arbitrary_types_allowed.py
+++ b/docs/examples/dataclasses_arbitrary_types_allowed.py
@@ -1,0 +1,42 @@
+import dataclasses
+
+import pydantic
+
+
+class ArbitraryType:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return f'ArbitraryType(value={self.value!r})'
+
+
+@dataclasses.dataclass
+class DC:
+    a: ArbitraryType
+    b: str
+
+
+# valid as it is a builtin dataclass without validation
+my_dc = DC(a=ArbitraryType(value=3), b='qwe')
+
+try:
+    class Model(pydantic.BaseModel):
+        dc: DC
+        other: str
+
+    Model(dc=my_dc, other='other')
+except RuntimeError as e:  # invalid as it is now a pydantic dataclass
+    print(e)
+
+
+class Model(pydantic.BaseModel):
+    dc: DC
+    other: str
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+m = Model(dc=my_dc, other='other')
+print(repr(m))

--- a/docs/examples/dataclasses_stdlib_inheritance.py
+++ b/docs/examples/dataclasses_stdlib_inheritance.py
@@ -1,0 +1,27 @@
+import dataclasses
+
+import pydantic
+
+
+@dataclasses.dataclass
+class Z:
+    z: int
+
+
+@dataclasses.dataclass
+class Y(Z):
+    y: int = 0
+
+
+@pydantic.dataclasses.dataclass
+class X(Y):
+    x: int = 0
+
+
+foo = X(x=b'1', y='2', z='3')
+print(foo)
+
+try:
+    X(z='pika')
+except pydantic.ValidationError as e:
+    print(e)

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -49,6 +49,8 @@ Dataclasses attributes can be populated by tuples, dictionaries or instances of 
 
 ## Stdlib dataclasses and _pydantic_ dataclasses
 
+### Convert stdlib dataclasses into _pydantic_ dataclasses
+
 Stdlib dataclasses (nested or not) can be easily converted into _pydantic_ dataclasses by just decorating
 them with `pydantic.dataclasses.dataclass`.
 
@@ -56,6 +58,8 @@ them with `pydantic.dataclasses.dataclass`.
 {!.tmp_examples/dataclasses_stdlib_to_pydantic.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+### Inherit from stdlib dataclasses
 
 Stdlib dataclasses (nested or not) can also be inherited and _pydantic_ will automatically validate
 all the inherited fields.
@@ -65,11 +69,24 @@ all the inherited fields.
 ```
 _(This script is complete, it should run "as is")_
 
+### Use of stdlib dataclasses with `BaseModel`
+
 Bear in mind that stdlib dataclasses (nested or not) are **automatically converted** into _pydantic_ dataclasses
 when mixed with `BaseModel`!
 
 ```py
 {!.tmp_examples/dataclasses_stdlib_with_basemodel.py!}
+```
+_(This script is complete, it should run "as is")_
+
+### Use custom types
+
+Since stdlib dataclasses are automatically converted to add validation using
+custom types may cause some unexpected behaviour.
+In this case you can simply add `arbitrary_types_allowed` in the config!
+
+```py
+{!.tmp_examples/dataclasses_arbitrary_types_allowed.py!}
 ```
 _(This script is complete, it should run "as is")_
 

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -57,6 +57,14 @@ them with `pydantic.dataclasses.dataclass`.
 ```
 _(This script is complete, it should run "as is")_
 
+Stdlib dataclasses (nested or not) can also be inherited and _pydantic_ will automatically validate
+all the inherited fields.
+
+```py
+{!.tmp_examples/dataclasses_stdlib_inheritance.py!}
+```
+_(This script is complete, it should run "as is")_
+
 Bear in mind that stdlib dataclasses (nested or not) are **automatically converted** into _pydantic_ dataclasses
 when mixed with `BaseModel`!
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -8,7 +8,7 @@ from .main import create_model, validate_model
 from .utils import ClassAttribute
 
 if TYPE_CHECKING:
-    from .main import BaseModel  # noqa: F401
+    from .main import BaseConfig, BaseModel  # noqa: F401
     from .typing import CallableGenerator
 
     DataclassT = TypeVar('DataclassT', bound='Dataclass')
@@ -216,10 +216,10 @@ def dataclass(
     return wrap(_cls)
 
 
-def make_dataclass_validator(_cls: Type[Any], **kwargs: Any) -> 'CallableGenerator':
+def make_dataclass_validator(_cls: Type[Any], config: Type['BaseConfig']) -> 'CallableGenerator':
     """
     Create a pydantic.dataclass from a builtin dataclass to add type validation
     and yield the validators
     """
-    cls = dataclass(_cls, **kwargs)
+    cls = dataclass(_cls, config=config)
     yield from _get_validators(cls)

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -120,7 +120,9 @@ def _process_class(
     # ```
     # with the exact same fields as the base dataclass
     if is_builtin_dataclass(_cls):
-        _cls = type(_cls.__name__, (_cls,), {'__post_init__': _pydantic_post_init})
+        _cls = type(
+            _cls.__name__, (_cls,), {'__annotations__': _cls.__annotations__, '__post_init__': _pydantic_post_init}
+        )
     else:
         _cls.__post_init__ = _pydantic_post_init
     cls: Type['Dataclass'] = dataclasses.dataclass(  # type: ignore

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -593,7 +593,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         yield make_literal_validator(type_)
         return
     if is_builtin_dataclass(type_):
-        yield from make_dataclass_validator(type_)
+        yield from make_dataclass_validator(type_, config)
         return
     if type_ is Enum:
         yield enum_validator

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2,7 +2,7 @@ import dataclasses
 from collections.abc import Hashable
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, Dict, FrozenSet, Optional
+from typing import ClassVar, Dict, FrozenSet, List, Optional
 
 import pytest
 
@@ -757,3 +757,23 @@ def test_inherit_builtin_dataclass():
     assert pika.x == 2
     assert pika.y == 4
     assert pika.z == 3
+
+
+def test_dataclass_arbitrary():
+    class ArbitraryType:
+        def __init__(self):
+            ...
+
+    @dataclasses.dataclass
+    class Test:
+        foo: ArbitraryType
+        bar: List[ArbitraryType]
+
+    class TestModel(BaseModel):
+        a: ArbitraryType
+        b: Test
+
+        class Config:
+            arbitrary_types_allowed = True
+
+    TestModel(a=ArbitraryType(), b=(ArbitraryType(), [ArbitraryType()]))

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -738,3 +738,22 @@ def test_override_builtin_dataclass_nested_schema():
         'title': 'File',
         'type': 'object',
     }
+
+
+def test_inherit_builtin_dataclass():
+    @dataclasses.dataclass
+    class Z:
+        z: int
+
+    @dataclasses.dataclass
+    class Y(Z):
+        y: int
+
+    @pydantic.dataclasses.dataclass
+    class X(Y):
+        x: int
+
+    pika = X(x='2', y='4', z='3')
+    assert pika.x == 2
+    assert pika.y == 4
+    assert pika.z == 3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
#1817 introduced a regression when _pydantic_ `dataclass` inherits from a stdlib `dataclass`.
This fixes the expected behaviour. Some extra documentation has also been added.

## Related issue number
closes #2042
closes #2054

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
