### PR TITLE
underscore_attrs_are_private causing TypeError

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,5 +134,5 @@ docs-serve:
 .PHONY: publish-docs
 publish-docs:
 	zip -r site.zip site
-	@curl -f -H "Content-Type: application/zip" -H "Authorization: Bearer ${NETLIFY}" \
+	@curl -H "Content-Type: application/zip" -H "Authorization: Bearer ${NETLIFY}" \
 	      --data-binary "@site.zip" https://api.netlify.com/api/v1/sites/pydantic-docs.netlify.com/deploys

--- a/changes/2047-samuelcolvin.md
+++ b/changes/2047-samuelcolvin.md
@@ -1,0 +1,1 @@
+fix `underscore_attrs_are_private` causing `TypeError` when overriding `__init__`

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -631,4 +631,10 @@ def is_valid_field(name: str) -> bool:
 
 
 def is_valid_private_name(name: str) -> bool:
-    return not is_valid_field(name) and name not in {'__annotations__', '__module__', '__annotations__', '__qualname__'}
+    return not is_valid_field(name) and name not in {
+        '__annotations__',
+        '__module__',
+        '__annotations__',
+        '__qualname__',
+        '__classcell__',
+    }

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -631,10 +631,4 @@ def is_valid_field(name: str) -> bool:
 
 
 def is_valid_private_name(name: str) -> bool:
-    return not is_valid_field(name) and name not in {
-        '__annotations__',
-        '__module__',
-        '__annotations__',
-        '__qualname__',
-        '__classcell__',
-    }
+    return not is_valid_field(name) and name not in {'__annotations__', '__classcell__', '__module__', '__qualname__'}

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -160,3 +160,20 @@ def test_slots_are_ignored():
 def test_default_and_default_factory_used_error():
     with pytest.raises(TypeError, match='default and default_factory args can not be used together'):
         PrivateAttr(default=123, default_factory=lambda: 321)
+
+
+def test_config_override_init():
+    class MyModel(BaseModel):
+        x: str
+        _private_attr: int
+
+        def __init__(self, **data) -> None:
+            super().__init__(**data)
+            self._private_attr = 123
+
+        class Config:
+            underscore_attrs_are_private = True
+
+    m = MyModel(x='hello')
+    assert m.dict() == {'x': 'hello'}
+    assert m._private_attr == 123


### PR DESCRIPTION
## Change Summary

fix `underscore_attrs_are_private` causing `TypeError` when overriding `__init__`

## Related issue number

fix #2047

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
