### PR TITLE
Add two overload variants to `validate_arguments`

### DIFF
--- a/changes/2055-layday.md
+++ b/changes/2055-layday.md
@@ -1,0 +1,1 @@
+add two overload variants to `validate_arguments` for the nested decorator signature

--- a/changes/2055-layday.md
+++ b/changes/2055-layday.md
@@ -1,1 +1,1 @@
-add two overload variants to `validate_arguments` for the nested decorator signature
+fix annotation of `validate_arguments` when passing configuration as argument

--- a/tests/mypy/modules/fail4.py
+++ b/tests/mypy/modules/fail4.py
@@ -24,13 +24,3 @@ def bar() -> str:
 
 # return type should be a string
 y: int = bar()
-
-
-# nested decorator should not produce an error
-@validate_arguments(config={'arbitrary_types_allowed': True})
-def baz(a: int, *, c: str = 'x') -> str:
-    return c * a
-
-
-# ok
-z: str = baz(1, c='hello')

--- a/tests/mypy/modules/fail4.py
+++ b/tests/mypy/modules/fail4.py
@@ -24,3 +24,13 @@ def bar() -> str:
 
 # return type should be a string
 y: int = bar()
+
+
+# nested decorator should not produce an error
+@validate_arguments(config={'arbitrary_types_allowed': True})
+def baz(a: int, *, c: str = 'x') -> str:
+    return c * a
+
+
+# ok
+z: str = baz(1, c='hello')

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -121,6 +121,7 @@ class WithField(BaseModel):
     first_name: str = Field('John', const=True)
 
 
+# simple decorator
 @validate_arguments
 def foo(a: int, *, c: str = 'x') -> str:
     return c * a
@@ -128,6 +129,16 @@ def foo(a: int, *, c: str = 'x') -> str:
 
 foo(1, c='thing')
 foo(1)
+
+
+# nested decorator should not produce an error
+@validate_arguments(config={'arbitrary_types_allowed': True})
+def bar(a: int, *, c: str = 'x') -> str:
+    return c * a
+
+
+bar(1, c='thing')
+bar(1)
 
 
 class Foo(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Added two overload variants to `validate_arguments` for the nested decorator signature.

## Related issue number

fix #2052

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] ~~Documentation reflects the changes where applicable~~
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
