### PR TITLE
feat: add default encoder for `Pattern` type

### DIFF
--- a/changes/2045-PrettyWood.md
+++ b/changes/2045-PrettyWood.md
@@ -1,0 +1,1 @@
+add default encoder for `Pattern` type

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -5,7 +5,7 @@ from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from types import GeneratorType
-from typing import Any, Callable, Dict, Type, Union
+from typing import Any, Callable, Dict, Pattern, Type, Union
 from uuid import UUID
 
 from .color import Color
@@ -53,6 +53,9 @@ def pydantic_encoder(obj: Any) -> Any:
         return obj.dict()
     elif is_dataclass(obj):
         return asdict(obj)
+
+    if isinstance(obj, Pattern):
+        return obj.pattern
 
     # Check the class type and its superclasses for a matching encoder
     for base in obj.__class__.__mro__[:-1]:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import re
 import sys
 from dataclasses import dataclass as vanilla_dataclass
 from decimal import Decimal
@@ -51,6 +52,7 @@ class MyEnum(Enum):
         (Decimal('12.34'), '12.34'),
         (create_model('BarModel', a='b', c='d')(), '{"a": "b", "c": "d"}'),
         (MyEnum.foo, '"bar"'),
+        (re.compile('^regex$'), '"^regex$"'),
     ],
 )
 def test_encoding(input, output):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
As we allow `Pattern` to be used as a regular type and considering we now support `Pattern` when generating
schema (#1768) it makes sense to also add a default encoder for it

## Related issue number
closes #2045

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
