### PR TITLE
fix: forward all the params of the stdlib `dataclass` when converted into _pydantic_ `dataclass`

### DIFF
--- a/changes/2065-PrettyWood.md
+++ b/changes/2065-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: forward all the params of the stdlib `dataclass` when converted into _pydantic_ `dataclass`

--- a/docs/examples/dataclasses_stdlib_with_basemodel.py
+++ b/docs/examples/dataclasses_stdlib_with_basemodel.py
@@ -5,14 +5,20 @@ from typing import Optional
 from pydantic import BaseModel, ValidationError
 
 
+@dataclasses.dataclass(frozen=True)
+class User:
+    name: str
+
+
 @dataclasses.dataclass
 class File:
     filename: str
-    last_modification_time: Optional[datetime]
+    last_modification_time: Optional[datetime] = None
 
 
 class Foo(BaseModel):
     file: File
+    user: Optional[User] = None
 
 
 file = File(
@@ -24,4 +30,10 @@ print(file)
 try:
     Foo(file=file)
 except ValidationError as e:
+    print(e)
+
+foo = Foo(file=File(filename='myfile'), user=User(name='pika'))
+try:
+    foo.user.name = 'bulbi'
+except dataclasses.FrozenInstanceError as e:
     print(e)

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -71,8 +71,9 @@ _(This script is complete, it should run "as is")_
 
 ### Use of stdlib dataclasses with `BaseModel`
 
-Bear in mind that stdlib dataclasses (nested or not) are **automatically converted** into _pydantic_ dataclasses
-when mixed with `BaseModel`!
+Bear in mind that stdlib dataclasses (nested or not) are **automatically converted** into _pydantic_
+dataclasses when mixed with `BaseModel`! Furthermore the generated _pydantic_ dataclass will have
+the **exact same configuration** (`order`, `frozen`, ...) as the original one.
 
 ```py
 {!.tmp_examples/dataclasses_stdlib_with_basemodel.py!}

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -220,6 +220,9 @@ def make_dataclass_validator(_cls: Type[Any], config: Type['BaseConfig']) -> 'Ca
     """
     Create a pydantic.dataclass from a builtin dataclass to add type validation
     and yield the validators
+    It retrieves the parameters of the dataclass and forwards them to the newly created dataclass
     """
-    cls = dataclass(_cls, config=config)
+    dataclass_params = _cls.__dataclass_params__
+    stdlib_dataclass_parameters = {param: getattr(dataclass_params, param) for param in dataclass_params.__slots__}
+    cls = dataclass(_cls, config=config, **stdlib_dataclass_parameters)
     yield from _get_validators(cls)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -777,3 +777,21 @@ def test_dataclass_arbitrary():
             arbitrary_types_allowed = True
 
     TestModel(a=ArbitraryType(), b=(ArbitraryType(), [ArbitraryType()]))
+
+
+def test_forward_stdlib_dataclass_params():
+    @dataclasses.dataclass(frozen=True)
+    class Item:
+        name: str
+
+    class Example(BaseModel):
+        item: Item
+        other: str
+
+        class Config:
+            arbitrary_types_allowed = True
+
+    e = Example(item=Item(name='pika'), other='bulbi')
+    e.other = 'bulbi2'
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.item.name = 'pika2'


### PR DESCRIPTION
## Change Summary
When converting (automatically or not) a stdlib `dataclass` into a _pydantic_ `dataclass`, we
forward only the `Config` instance but not all the params used to created the initial `dataclass.
Now we do!

## Related issue number
closes #2065

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
