### PR TITLE
Correct defaultdict field validation

### DIFF
--- a/changes/1536-Gronix.md
+++ b/changes/1536-Gronix.md
@@ -1,0 +1,3 @@
+Add a new post-validator that converts the validated 
+dictionary which is returned by method `__validate_mapping` into a defaultdict
+with correct `default_factory` attribute.

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -172,6 +172,10 @@ class DictError(PydanticTypeError):
     msg_template = 'value is not a valid dict'
 
 
+class DefaultDictFactoryError(PydanticTypeError):
+    msg_template = 'invalid default factory type, expected: {expected_factory}'
+
+
 class EmailError(PydanticValueError):
     msg_template = 'value is not a valid email address'
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable as CollectionsIterable
 from typing import (
     TYPE_CHECKING,
     Any,
+    DefaultDict,
     Deque,
     Dict,
     FrozenSet,
@@ -40,7 +41,7 @@ from .typing import (
     new_type_supertype,
 )
 from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_like, smart_deepcopy
-from .validators import constant_validator, dict_validator, find_validators, validate_json
+from .validators import constant_validator, defaultdict_validator, dict_validator, find_validators, validate_json
 
 Required: Any = Ellipsis
 
@@ -488,6 +489,10 @@ class ModelField(Representation):
             self.type_ = get_args(self.type_)[0]
             self.shape = SHAPE_SEQUENCE
         elif issubclass(origin, Mapping):
+            if issubclass(origin, DefaultDict):
+                # add a post-validator for DefaultDict: convert dict returned by "_validate_mapping" to defaultdict
+                self.class_validators['__defaultdict'] = Validator(defaultdict_validator, pre=False)
+
             self.key_field = self._create_sub_type(get_args(self.type_)[0], 'key_' + self.name, for_keys=True)
             self.type_ = get_args(self.type_)[1]
             self.shape = SHAPE_MAPPING


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

When using `DefaultDict` field, incoming value always recreated as regular `dict`. 

Now with this PR post-validator will convert validated dictionary into `defaultdict` class with correct `default_factory` attribute.

## Related issue number

closes #1536 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
