### PR TITLE
fix typo in example secret filename

### DIFF
--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -135,7 +135,7 @@ Placing secret values in files is a common pattern to provide sensitive configur
 A secret file follows the same principal as a dotenv file except it only contains a single value and the file name 
 is used as the key. A secret file will look like the following:
 
-`/var/run/db_password`:
+`/var/run/database_password`:
 ```
 super_secret_database_password
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This change fixes a minor but potentially confusing typo in the "Secret Support" section of the settings documentation: previously, the example secret filename, `db_password`, did not match/correspond with the example `Settings` model's `database_password` field.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
