### PR TITLE
Fix generics creation time and allow model name reusing

### DIFF
--- a/changes/2078-MrMrRobat.md
+++ b/changes/2078-MrMrRobat.md
@@ -1,0 +1,1 @@
+fix slow `GenericModel` concrete model creation, allow `GenericModel` concrete name reusing in module 

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,9 +1,7 @@
 import sys
-from types import FrameType, ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Dict,
     Generic,
@@ -62,12 +60,12 @@ class GenericModel(BaseModel):
         model_name = cls.__concrete_name__(params)
         validators = gather_all_validators(cls)
         fields = _build_generic_fields(cls.__fields__, concrete_type_hints, typevars_map)
-        model_module = get_caller_module_name() or cls.__module__
+        model_module, called_globally = get_caller_frame_info()
         created_model = cast(
             Type[GenericModel],  # casting ensures mypy is aware of the __concrete__ and __parameters__ attributes
             create_model(
                 model_name,
-                __module__=model_module,
+                __module__=model_module or cls.__module__,
                 __base__=cls,
                 __config__=None,
                 __validators__=validators,
@@ -75,13 +73,13 @@ class GenericModel(BaseModel):
             ),
         )
 
-        if is_call_from_module():  # create global reference and therefore allow pickling
-            object_in_module = sys.modules[model_module].__dict__.setdefault(model_name, created_model)
-            if object_in_module is not created_model:
-                # this should not ever happen because of _generic_types_cache, but just in case
-                raise TypeError(f'{model_name!r} already defined above, please consider reusing it') from NameError(
-                    f'Name conflict: {model_name!r} in {model_module!r} is already used by {object_in_module!r}'
-                )
+        if called_globally:  # create global reference and therefore allow pickling
+            object_by_reference = None
+            reference_name = model_name
+            reference_module_globals = sys.modules[created_model.__module__].__dict__
+            while object_by_reference is not created_model:
+                object_by_reference = reference_module_globals.setdefault(reference_name, created_model)
+                reference_name += '_'
 
         created_model.Config = cls.Config
         concrete = all(not _is_typevar(v) for v in concrete_type_hints.values())
@@ -143,30 +141,19 @@ def _is_typevar(v: Any) -> bool:
     return isinstance(v, TypeVar)
 
 
-def get_caller_module_name() -> Optional[str]:
-    """
-    Used inside a function to get its caller module name
-
-    Will only work against non-compiled code, therefore used only in pydantic.generics
-    """
-    import inspect
-
-    previous_caller_frame = sys._getframe(1).f_back
-    if previous_caller_frame is None:
-        raise RuntimeError('This function must be used inside another function')
-
-    getmodule = cast(Callable[[FrameType, str], Optional[ModuleType]], inspect.getmodule)
-    previous_caller_module = getmodule(previous_caller_frame, previous_caller_frame.f_code.co_filename)
-    return previous_caller_module.__name__ if previous_caller_module is not None else None
-
-
-def is_call_from_module() -> bool:
+def get_caller_frame_info() -> Tuple[Optional[str], bool]:
     """
     Used inside a function to check whether it was called globally
 
     Will only work against non-compiled code, therefore used only in pydantic.generics
+
+    :returns Tuple[module_name, called_globally]
     """
-    previous_caller_frame = sys._getframe(1).f_back
-    if previous_caller_frame is None:
-        raise RuntimeError('This function must be used inside another function')
-    return previous_caller_frame.f_locals is previous_caller_frame.f_globals
+    try:
+        previous_caller_frame = sys._getframe(2)
+    except ValueError as e:
+        raise RuntimeError('This function must be used inside another function') from e
+    except AttributeError:  # sys module does not have _getframe function, so there's nothing we can do about it
+        return None, False
+    frame_globals = previous_caller_frame.f_globals
+    return frame_globals.get('__name__'), previous_caller_frame.f_locals is frame_globals

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -151,10 +151,9 @@ def get_caller_module_name() -> Optional[str]:
     """
     import inspect
 
-    try:
-        previous_caller_frame = inspect.stack()[2].frame
-    except IndexError as e:
-        raise RuntimeError('This function must be used inside another function') from e
+    previous_caller_frame = sys._getframe(1).f_back
+    if previous_caller_frame is None:
+        raise RuntimeError('This function must be used inside another function')
 
     getmodule = cast(Callable[[FrameType, str], Optional[ModuleType]], inspect.getmodule)
     previous_caller_module = getmodule(previous_caller_frame, previous_caller_frame.f_code.co_filename)
@@ -167,10 +166,7 @@ def is_call_from_module() -> bool:
 
     Will only work against non-compiled code, therefore used only in pydantic.generics
     """
-    import inspect
-
-    try:
-        previous_caller_frame = inspect.stack()[2].frame
-    except IndexError as e:
-        raise RuntimeError('This function must be used inside another function') from e
+    previous_caller_frame = sys._getframe(1).f_back
+    if previous_caller_frame is None:
+        raise RuntimeError('This function must be used inside another function')
     return previous_caller_frame.f_locals is previous_caller_frame.f_globals

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -747,34 +747,26 @@ def test_is_call_from_module(create_module):
 def test_is_call_from_module_called_in_module(create_module):
     @create_module
     def module():
-        from unittest.mock import patch
+        from unittest.mock import patch, Mock
 
         import pytest
 
         from pydantic.generics import is_call_from_module
 
         with pytest.raises(RuntimeError, match='This function must be used inside another function') as exc_info:
-            with patch('inspect.stack', new=lambda: [..., ...]):
+            with patch('sys._getframe', new=Mock(return_value=Mock(f_back=None))):
                 is_call_from_module()
-
-        e = exc_info.value
-        assert isinstance(e.__cause__, IndexError)
-        assert isinstance(e.__context__, IndexError)
 
 
 def test_get_caller_module_called_from_module(create_module):
     @create_module
     def module():
-        from unittest.mock import patch
+        from unittest.mock import patch, Mock
 
         import pytest
 
         from pydantic.generics import get_caller_module_name
 
         with pytest.raises(RuntimeError, match='This function must be used inside another function') as exc_info:
-            with patch('inspect.stack', new=lambda: [..., ...]):
+            with patch('sys._getframe', new=Mock(return_value=Mock(f_back=None))):
                 get_caller_module_name()
-
-        e = exc_info.value
-        assert isinstance(e.__cause__, IndexError)
-        assert isinstance(e.__context__, IndexError)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -745,3 +745,14 @@ def test_get_caller_frame_info_called_from_module(create_module):
         with pytest.raises(RuntimeError, match='This function must be used inside another function'):
             with patch('sys._getframe', side_effect=ValueError('getframe_exc')):
                 get_caller_frame_info()
+
+
+def test_get_caller_frame_info_when_sys_getframe_undefined():
+    from pydantic.generics import get_caller_frame_info
+
+    getframe = sys._getframe
+    del sys._getframe
+    try:
+        assert get_caller_frame_info() == (None, False)
+    finally:  # just to make sure we always setting original attribute back
+        sys._getframe = getframe


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
### Creation time:
- Use `sys._getframe()` instead of slow `inspect.stack()`
- Use `frame.f_globals` instead of slow `inspect.getmodule()` to retrieve caller module name 
- Combine `get_caller_module_name()` with  `is_call_from_module()` into more than 2000x 🙈 faster `get_caller_frame_info()` 

### Concrete names reusing:
- Append `'_'` to global reference name if it's already in use instead of raising `TypeError`

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #2070
fix #2069 

(updated: added "fix" so I don't forget to close both issues, @samuelcolvin)

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
