### PR TITLE
Run mypy test faster

### DIFF
--- a/tests/mypy/async_test_runner.py
+++ b/tests/mypy/async_test_runner.py
@@ -23,7 +23,7 @@ def collect_marks(test_case):
             if isinstance(argnames, str):
                 argnames = argnames.split(',')
         elif mark.name == 'skipif':
-            skip_if = pytest.mark.skipif(*mark.args, **mark.kwargs)
+            skip_if = pytest.mark.skipif(*mark.args, **mark.kwargs)  # noqa (F811 redefinition of unused 'skip_if')
         else:
             raise ValueError(f'@pytest.mark.{mark.name} is unsupported')
 
@@ -34,7 +34,7 @@ def collect_marks(test_case):
 
 
 def create_tests(test_case, argnames, argvalues):
-    decoys: Dict[str, Callable[["Test", str], None]] = {}
+    decoys: Dict[str, Callable[['TestCase', str], None]] = {}
     tests_to_run: Dict[str, Callable[[], Coroutine]] = {}
     exceptions: Dict[str, Exception] = {}
 

--- a/tests/mypy/async_test_runner.py
+++ b/tests/mypy/async_test_runner.py
@@ -1,0 +1,108 @@
+import asyncio
+import os
+from typing import Callable, Coroutine, Dict
+from unittest import TestCase
+
+import pytest
+
+
+def collect_marks(test_case):
+    def skip_if(fn):
+        return fn
+
+    parametrized = False
+    argnames = argvalues = ()
+    for mark in getattr(test_case, 'pytestmark', []):
+        if mark.name == 'parametrize':
+            if parametrized:
+                raise RuntimeError('Cannot parametrize same function more than once')
+            parametrized = True
+            argnames, argvalues, *unsupported_args = (*mark.args, *mark.kwargs.values())
+            if unsupported_args:
+                raise ValueError('Only argnames and argvalues are implemented')
+            if isinstance(argnames, str):
+                argnames = argnames.split(',')
+        elif mark.name == 'skipif':
+            skip_if = pytest.mark.skipif(*mark.args, **mark.kwargs)
+        else:
+            raise ValueError(f'@pytest.mark.{mark.name} is unsupported')
+
+    if not parametrized:
+        raise RuntimeError("Won't run one and only test case async, sorry...")
+
+    return argnames, argvalues, skip_if
+
+
+def create_tests(test_case, argnames, argvalues):
+    decoys: Dict[str, Callable[["Test", str], None]] = {}
+    tests_to_run: Dict[str, Callable[[], Coroutine]] = {}
+    exceptions: Dict[str, Exception] = {}
+
+    reserved_kwargs = {'__key__', '__parametrize_params__'}
+    if reserved_kwargs & set(argnames):
+        raise RuntimeError(f'{reserved_kwargs} kwargs are reserved, please change their names')
+
+    for i, values in enumerate(argvalues):
+        if len(values) != len(argnames):
+            raise ValueError(f'Wrong number of values, expected {len(argnames)}, ' f'got {len(values)}: {i}, {values}')
+
+        parameters = dict(zip(argnames, values))
+        parameters_str = f"[{'-'.join(map(str, values))}]"
+        parametrized_name = 'test_async' + parameters_str
+
+        def decoy_test_method(_self, key=parametrized_name):
+            """
+            Set to Test class below, run as a normal TestCase.test_method,
+
+            Raises exception from parametrized_method
+            """
+            exception = exceptions.get(key)
+            if exception is not None:
+                # raising another error from exception to show traceback,
+                # if you know how to re-raise original error with it's original traceback please rewrite
+                raise AssertionError(str(exception)) from exception
+
+        async def parametrized_method(*args, __parametrize_params__=parameters, __key__=parametrized_name, **kwargs):
+            """
+            Actual test that gonna be executed asynchronously, exception will be raised in decoy_test_method
+            """
+            try:
+                return await test_case(*args, **kwargs, **__parametrize_params__)
+            except Exception as e:
+                exceptions[__key__] = e.with_traceback(e.__traceback__.tb_next)  # store exc with original traceback
+
+        decoy_test_method.__name__ = decoy_test_method.__qualname__ = parametrized_name
+        decoys[parametrized_name] = decoy_test_method
+        tests_to_run[parametrized_name] = parametrized_method
+    return decoys, tests_to_run
+
+
+def run_async(test_case):
+    """
+    Asynchronously run parametrized test cases.
+
+    Supports pytest.mark.skipif, doesn't support any other marks or fixtures (can be implemented if needed)
+    """
+    if not asyncio.iscoroutinefunction(test_case):
+        raise TypeError('run_async supports only async functions')
+
+    argnames, argvalues, skip_if = collect_marks(test_case)
+    decoys, tests_to_run = create_tests(test_case, argnames, argvalues)
+
+    async def run_tests():
+        async with asyncio.Semaphore(os.cpu_count()):
+            await asyncio.wait([asyncio.ensure_future(test()) for test in tests_to_run.values()], timeout=30)
+
+    @skip_if
+    class Test(TestCase):
+        locals().update(decoys)
+
+        @classmethod
+        def setUpClass(cls) -> None:
+            """
+            All tests run here, result exceptions raised later in decoy methods
+            """
+            asyncio.get_event_loop().run_until_complete(run_tests())
+
+    Test.__name__ = Test.__qualname__ = test_case.__name__
+    return Test

--- a/tests/mypy/run_mypy.py
+++ b/tests/mypy/run_mypy.py
@@ -1,0 +1,9 @@
+import sys
+
+from mypy import api as mypy_api
+
+if __name__ == '__main__':
+    stdout, stderr, exit_status = mypy_api.run(['tests/mypy/modules/plugin_success.py', '--config-file', 'tests/mypy/configs/mypy-plugin.ini', '--cache-dir', '.mypy_cache/test-mypy-plugin', '--show-error-codes'])
+    print(stdout, end='')
+    print(stderr, file=sys.stderr)
+    exit(exit_status)

--- a/tests/mypy/run_mypy.py
+++ b/tests/mypy/run_mypy.py
@@ -1,9 +1,0 @@
-import sys
-
-from mypy import api as mypy_api
-
-if __name__ == '__main__':
-    stdout, stderr, exit_status = mypy_api.run(['tests/mypy/modules/plugin_success.py', '--config-file', 'tests/mypy/configs/mypy-plugin.ini', '--cache-dir', '.mypy_cache/test-mypy-plugin', '--show-error-codes'])
-    print(stdout, end='')
-    print(stderr, file=sys.stderr)
-    exit(exit_status)

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -1,9 +1,19 @@
+import ast
 import importlib
+import inspect
 import os
+import pickle
 import re
+import sys
+from functools import wraps
+from multiprocessing import cpu_count
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
+from typing import Dict
+from unittest import TestCase
 
 import pytest
+from _pytest import assertion
 
 try:
     from mypy import api as mypy_api
@@ -27,12 +37,129 @@ cases = [
     ('mypy-default.ini', 'fail1.py', 'fail1.txt'),
     ('mypy-default.ini', 'fail2.py', 'fail2.txt'),
     ('mypy-default.ini', 'fail3.py', 'fail3.txt'),
-    ('mypy-default.ini', 'fail4.py', 'fail4.txt'),
+    ('mypy-default. ini', 'fail4.py', 'fail4.txt'),
     ('mypy-default.ini', 'plugin_success.py', 'plugin_success.txt'),
 ]
 executable_modules = list({fname[:-3] for _, fname, out_fname in cases if out_fname is None})
 
+RUN_MYPY_MODULE = Path(__file__).parent / 'run_mypy.py'
 
+
+def get_run_mypy_cmd(args):
+    return [sys.executable, RUN_MYPY_MODULE, *args]
+
+
+def run_parallel(test_case):
+    parametrized = False
+    argnames = argvalues = ()
+
+    def skip(fn):
+        return fn
+
+    for mark in getattr(test_case, 'pytestmark', []):
+        if mark.name == 'parametrize':
+            parametrized = True
+            argnames, argvalues, *other = mark.args
+            if other or mark.kwargs:
+                raise ValueError('Only positional argnames and argvalues implemented')
+            if isinstance(argnames, str):
+                argnames = argnames.split(',')
+        elif mark.name == 'skipif':
+            def skip(fn):
+                return pytest.mark.skipif(*mark.args, **mark.kwargs)(fn)
+        else:
+            raise ValueError(f'@pytest.mark.{mark.name} is unsupported')
+
+    if not parametrized:
+        raise RuntimeError("Won't run one and only test case parallel, sorry...")
+
+    decoys = {}
+    tests_to_run = {}
+    test_name = test_case.__name__
+
+    # Pytest rewrite reference
+    # https://stackoverflow.com/questions/51839452/can-i-patch-pythons-assert-to-get-the-output-that-py-test-provides
+    source = ''
+    decorators_skipped = False
+    lines, defined_on_line = inspect.getsourcelines(test_case)
+    lines_before_definition = defined_on_line - 1
+    for line in lines:
+        if line.startswith('def '):
+            decorators_skipped = True
+            source += line
+        elif decorators_skipped:
+            source += line
+        else:
+            lines_before_definition += 1
+
+    if not decorators_skipped:
+        raise RuntimeError(f'Unable to find function definition')
+
+    source = '\n' * lines_before_definition + source  # prepend lines before function to get accurate traceback
+
+    tree = ast.parse(source)
+    assertion.rewrite.rewrite_asserts(tree, source)
+    new_code_obj = compile(tree, test_case.__code__.co_filename, 'exec')
+    exec(new_code_obj, test_case.__globals__)
+    test_case = test_case.__globals__[test_case.__name__]
+
+    for i, values in enumerate(argvalues):
+        if len(values) != len(argnames):
+            raise ValueError(
+                f"Wrong number of values, expected {len(argnames)}, "
+                f"got {len(values)}: {i}, {values}"
+            )
+
+        parameters = dict(zip(argnames, values))
+        parameters_str = f'[{"-".join(map(str, values))}]'
+        parametrized_name = 'test_parallel' + parameters_str
+
+        @wraps(test_case)
+        @pytest.mark.skipif(skip, reason=reason)
+        def decoy_method(key=parametrized_name):
+            if key in exceptions:
+                raise exceptions[key]
+
+        def parametrized_method(*args, __parametrize_params__=parameters, **kwargs):
+            return test_case(*args, **kwargs, **__parametrize_params__)
+
+        decoy_method.__name__ = parametrized_name
+        decoy_method.__qualname__ = parametrized_name
+
+        # set global reference as multiprocessing needs to be able to pickle this
+        global_lookup_name = f'_{test_name}{parameters_str.replace(".", "_")}'
+        parametrized_method.__qualname__ = global_lookup_name
+        setattr(sys.modules[parametrized_method.__module__], global_lookup_name, parametrized_method)
+
+        decoys[parametrized_name] = decoy_method
+        tests_to_run[parametrized_name] = parametrized_method
+        pickle.dumps(parametrized_method)
+
+    exceptions: Dict[str, Exception] = {}
+
+    class Test(TestCase):
+        locals().update(decoys)
+
+        @classmethod
+        def setUpClass(cls) -> None:
+            cls.run_methods()
+
+        @classmethod
+        def run_methods(cls):
+            pool = ThreadPool(cpu_count())
+            for task in [
+                pool.apply_async(test, error_callback=lambda e: exceptions.__setitem__('name', e))
+                for name, test in tests_to_run.items()
+            ]:
+                task.get()
+            pool.close()
+            pool.join()
+
+    Test.__name__ = Test.__qualname__ = test_case.__name__
+    return Test
+
+
+@run_parallel
 @pytest.mark.skipif(not (typing_extensions and mypy_api), reason='typing_extensions or mypy are not installed')
 @pytest.mark.parametrize('config_filename,python_filename,output_filename', cases)
 def test_mypy_results(config_filename, python_filename, output_filename):
@@ -43,10 +170,19 @@ def test_mypy_results(config_filename, python_filename, output_filename):
     # Specifying a different cache dir for each configuration dramatically speeds up subsequent execution
     # It also prevents cache-invalidation-related bugs in the tests
     cache_dir = f'.mypy_cache/test-{config_filename[:-4]}'
-    command = [full_filename, '--config-file', full_config_filename, '--cache-dir', cache_dir, '--show-error-codes']
-    print(f"\nExecuting: mypy {' '.join(command)}")  # makes it easier to debug as necessary
-    actual_result = mypy_api.run(command)
+    args = [full_filename, '--config-file', full_config_filename, '--cache-dir', cache_dir, '--show-error-codes']
+    print(f"\nExecuting: mypy {' '.join(args)}")  # makes it easier to debug as necessary
+
+    # result = subprocess.run(get_run_mypy_cmd(args), stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    actual_result = mypy_api.run(args)
+
     actual_out, actual_err, actual_returncode = actual_result
+    # sub_err = result.stderr is not None and result.stderr.decode().strip()
+    # sub_out = result.stdout is not None and result.stdout.decode().strip()
+    # assert sub_err == actual_err
+    # assert sub_out == actual_out
+    # assert result.returncode == actual_returncode
+
     # Need to strip filenames due to differences in formatting by OS
     actual_out = '\n'.join(['.py:'.join(line.split('.py:')[1:]) for line in actual_out.split('\n') if line]).strip()
     actual_out = re.sub(r'\n\s*\n', r'\n', actual_out)

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -1,19 +1,13 @@
-import ast
+import asyncio
 import importlib
-import inspect
 import os
-import pickle
 import re
 import sys
-from functools import wraps
-from multiprocessing import cpu_count
-from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Dict
-from unittest import TestCase
 
 import pytest
-from _pytest import assertion
+
+from tests.mypy.async_test_runner import run_async
 
 try:
     from mypy import api as mypy_api
@@ -37,175 +31,70 @@ cases = [
     ('mypy-default.ini', 'fail1.py', 'fail1.txt'),
     ('mypy-default.ini', 'fail2.py', 'fail2.txt'),
     ('mypy-default.ini', 'fail3.py', 'fail3.txt'),
-    ('mypy-default. ini', 'fail4.py', 'fail4.txt'),
+    ('mypy-default.ini', 'fail4.py', 'fail4.txt'),
     ('mypy-default.ini', 'plugin_success.py', 'plugin_success.txt'),
 ]
 executable_modules = list({fname[:-3] for _, fname, out_fname in cases if out_fname is None})
 
-RUN_MYPY_MODULE = Path(__file__).parent / 'run_mypy.py'
+TEST_DIR = Path(__file__).parent
+CONFIGS_DIR = TEST_DIR / 'configs'
+MODULES_DIR = TEST_DIR / 'modules'
+OUTPUT_DIR = TEST_DIR / 'outputs'
 
 
-def get_run_mypy_cmd(args):
-    return [sys.executable, RUN_MYPY_MODULE, *args]
-
-
-def run_parallel(test_case):
-    parametrized = False
-    argnames = argvalues = ()
-
-    def skip(fn):
-        return fn
-
-    for mark in getattr(test_case, 'pytestmark', []):
-        if mark.name == 'parametrize':
-            parametrized = True
-            argnames, argvalues, *other = mark.args
-            if other or mark.kwargs:
-                raise ValueError('Only positional argnames and argvalues implemented')
-            if isinstance(argnames, str):
-                argnames = argnames.split(',')
-        elif mark.name == 'skipif':
-            def skip(fn):
-                return pytest.mark.skipif(*mark.args, **mark.kwargs)(fn)
-        else:
-            raise ValueError(f'@pytest.mark.{mark.name} is unsupported')
-
-    if not parametrized:
-        raise RuntimeError("Won't run one and only test case parallel, sorry...")
-
-    decoys = {}
-    tests_to_run = {}
-    test_name = test_case.__name__
-
-    # Pytest rewrite reference
-    # https://stackoverflow.com/questions/51839452/can-i-patch-pythons-assert-to-get-the-output-that-py-test-provides
-    source = ''
-    decorators_skipped = False
-    lines, defined_on_line = inspect.getsourcelines(test_case)
-    lines_before_definition = defined_on_line - 1
-    for line in lines:
-        if line.startswith('def '):
-            decorators_skipped = True
-            source += line
-        elif decorators_skipped:
-            source += line
-        else:
-            lines_before_definition += 1
-
-    if not decorators_skipped:
-        raise RuntimeError(f'Unable to find function definition')
-
-    source = '\n' * lines_before_definition + source  # prepend lines before function to get accurate traceback
-
-    tree = ast.parse(source)
-    assertion.rewrite.rewrite_asserts(tree, source)
-    new_code_obj = compile(tree, test_case.__code__.co_filename, 'exec')
-    exec(new_code_obj, test_case.__globals__)
-    test_case = test_case.__globals__[test_case.__name__]
-
-    for i, values in enumerate(argvalues):
-        if len(values) != len(argnames):
-            raise ValueError(
-                f"Wrong number of values, expected {len(argnames)}, "
-                f"got {len(values)}: {i}, {values}"
-            )
-
-        parameters = dict(zip(argnames, values))
-        parameters_str = f'[{"-".join(map(str, values))}]'
-        parametrized_name = 'test_parallel' + parameters_str
-
-        @wraps(test_case)
-        @pytest.mark.skipif(skip, reason=reason)
-        def decoy_method(key=parametrized_name):
-            if key in exceptions:
-                raise exceptions[key]
-
-        def parametrized_method(*args, __parametrize_params__=parameters, **kwargs):
-            return test_case(*args, **kwargs, **__parametrize_params__)
-
-        decoy_method.__name__ = parametrized_name
-        decoy_method.__qualname__ = parametrized_name
-
-        # set global reference as multiprocessing needs to be able to pickle this
-        global_lookup_name = f'_{test_name}{parameters_str.replace(".", "_")}'
-        parametrized_method.__qualname__ = global_lookup_name
-        setattr(sys.modules[parametrized_method.__module__], global_lookup_name, parametrized_method)
-
-        decoys[parametrized_name] = decoy_method
-        tests_to_run[parametrized_name] = parametrized_method
-        pickle.dumps(parametrized_method)
-
-    exceptions: Dict[str, Exception] = {}
-
-    class Test(TestCase):
-        locals().update(decoys)
-
-        @classmethod
-        def setUpClass(cls) -> None:
-            cls.run_methods()
-
-        @classmethod
-        def run_methods(cls):
-            pool = ThreadPool(cpu_count())
-            for task in [
-                pool.apply_async(test, error_callback=lambda e: exceptions.__setitem__('name', e))
-                for name, test in tests_to_run.items()
-            ]:
-                task.get()
-            pool.close()
-            pool.join()
-
-    Test.__name__ = Test.__qualname__ = test_case.__name__
-    return Test
-
-
-@run_parallel
-@pytest.mark.skipif(not (typing_extensions and mypy_api), reason='typing_extensions or mypy are not installed')
-@pytest.mark.parametrize('config_filename,python_filename,output_filename', cases)
-def test_mypy_results(config_filename, python_filename, output_filename):
-    full_config_filename = f'tests/mypy/configs/{config_filename}'
-    full_filename = f'tests/mypy/modules/{python_filename}'
-    output_path = None if output_filename is None else Path(f'tests/mypy/outputs/{output_filename}')
-
+def get_run_mypy_cmd(module_path: Path, config_path: Path):
     # Specifying a different cache dir for each configuration dramatically speeds up subsequent execution
     # It also prevents cache-invalidation-related bugs in the tests
-    cache_dir = f'.mypy_cache/test-{config_filename[:-4]}'
-    args = [full_filename, '--config-file', full_config_filename, '--cache-dir', cache_dir, '--show-error-codes']
-    print(f"\nExecuting: mypy {' '.join(args)}")  # makes it easier to debug as necessary
+    cache_dir = f'.mypy_cache/test-{str(config_path)[:-4]}'
+    mypy = f'{sys.executable} -m mypy'
+    return f'{mypy} {module_path} --config-file {config_path} --cache-dir {cache_dir} --show-error-codes'
 
-    # result = subprocess.run(get_run_mypy_cmd(args), stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-    actual_result = mypy_api.run(args)
 
-    actual_out, actual_err, actual_returncode = actual_result
-    # sub_err = result.stderr is not None and result.stderr.decode().strip()
-    # sub_out = result.stdout is not None and result.stdout.decode().strip()
-    # assert sub_err == actual_err
-    # assert sub_out == actual_out
-    # assert result.returncode == actual_returncode
+@run_async
+@pytest.mark.skipif(not (typing_extensions and mypy_api), reason='typing_extensions or mypy are not installed')
+@pytest.mark.parametrize('config_filename,module_filename,output_filename', cases)
+async def test_mypy_results(config_filename, module_filename, output_filename):
+    cmd = get_run_mypy_cmd(MODULES_DIR / module_filename, CONFIGS_DIR / config_filename)
+    proc = await asyncio.create_subprocess_shell(cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+    stdout, stderr = await proc.communicate()
+    assert stderr.strip() == b''
+    assert stdout is not None
 
     # Need to strip filenames due to differences in formatting by OS
-    actual_out = '\n'.join(['.py:'.join(line.split('.py:')[1:]) for line in actual_out.split('\n') if line]).strip()
+    actual_out = '\n'.join(
+        ['.py:'.join(line.split('.py:')[1:]) for line in stdout.decode().split('\n') if line]
+    ).strip()
     actual_out = re.sub(r'\n\s*\n', r'\n', actual_out)
 
     if actual_out:
-        print('{0}\n{1:^100}\n{0}\n{2}\n{0}'.format('=' * 100, 'mypy output', actual_out))
+        params = map(str, (config_filename, module_filename, output_filename))
+        print(
+            '{0}\n'
+            '{1:^100}\n'
+            '{0}\n'
+            '{2}\n'
+            '{0}\n'.format('=' * 100, f'{test_mypy_results.__name__}({", ".join(params)})', actual_out)
+        )
 
-    assert actual_err == ''
-    expected_returncode = 0 if output_filename is None else 1
-    assert actual_returncode == expected_returncode
+    if output_filename is not None:
+        output_path = OUTPUT_DIR / output_filename
+        if not output_path.exists():
+            output_path.write_text(actual_out)
+            raise RuntimeError(f'wrote actual output to {output_path} since file did not exist')
+        expected_out = output_path.read_text()
+        expected_returncode = 1
+    else:
+        expected_out = ''
+        expected_returncode = 0
 
-    if output_path and not output_path.exists():
-        output_path.write_text(actual_out)
-        raise RuntimeError(f'wrote actual output to {output_path} since file did not exist')
-
-    expected_out = Path(output_path).read_text() if output_path else ''
-    assert actual_out == expected_out, actual_out
+    assert proc.returncode == expected_returncode
+    assert actual_out == expected_out
 
 
 @pytest.mark.parametrize('module', executable_modules)
 def test_success_cases_run(module):
     """
-    Ensure the "success" files can actually be executed
+    Ensure the 'success' files can actually be executed
     """
     importlib.import_module(f'tests.mypy.modules.{module}')
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Use `asyncio.subprocess` and some hacky stuff to run parametrized `test_mypy_result`

### Results on MacBook Pro (15-inch, 2017)
#### With cache:

##### PR: `============================== 10 passed in 1.33s ==============================`
##### Master: `============================== 10 passed in 2.63s ==============================`
#### Without cache:
##### PR `============================== 10 passed in 5.19s ==============================`
##### Master: `============================== 10 passed in 8.38s ==============================`


Not sure, if this results worth introduced hackery though, so it's ok if this won't be merged :) 

<!-- Please give a short summary of the changes. -->

## Related issue number
https://github.com/samuelcolvin/pydantic/pull/2035#issuecomment-716448824
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
