### PR TITLE
fix: ignore `__doc__` as valid private attribute

### DIFF
--- a/changes/2090-PrettyWood.md
+++ b/changes/2090-PrettyWood.md
@@ -1,0 +1,1 @@
+Ignore `__doc__` as private attribute when `Config.underscore_attrs_are_private` is set

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -631,4 +631,10 @@ def is_valid_field(name: str) -> bool:
 
 
 def is_valid_private_name(name: str) -> bool:
-    return not is_valid_field(name) and name not in {'__annotations__', '__classcell__', '__module__', '__qualname__'}
+    return not is_valid_field(name) and name not in {
+        '__annotations__',
+        '__classcell__',
+        '__doc__',
+        '__module__',
+        '__qualname__',
+    }

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -55,6 +55,8 @@ def test_private_attribute_factory():
 
 def test_private_attribute_annotation():
     class Model(BaseModel):
+        """The best model"""
+
         __foo__: str
 
         class Config:
@@ -63,6 +65,7 @@ def test_private_attribute_annotation():
     assert Model.__slots__ == {'__foo__'}
     assert repr(Model.__foo__) == "<member '__foo__' of 'Model' objects>"
     assert Model.__private_attributes__ == {'__foo__': PrivateAttr(Undefined)}
+    assert repr(Model.__doc__) == "'The best model'"
 
     m = Model()
     with pytest.raises(AttributeError):


### PR DESCRIPTION
## Change Summary
`__doc__` was not ignored when setting private attributes

## Related issue number
closes #2090

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
