### PR TITLE
feat: Add the ability to add extra settings sources

### DIFF
--- a/changes/2107-kozlek.md
+++ b/changes/2107-kozlek.md
@@ -1,0 +1,1 @@
+Add the ability to customize settings source (add / disable / change priority order).

--- a/changes/2107-kozlek.md
+++ b/changes/2107-kozlek.md
@@ -1,1 +1,1 @@
-Add the ability to customize settings source (add / disable / change priority order).
+Add the ability to customize settings sources (add / disable / change priority order).

--- a/docs/examples/settings_add_custom_source.py
+++ b/docs/examples/settings_add_custom_source.py
@@ -1,33 +1,41 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Dict, Any
 
-from pydantic import BaseSettings, PostgresDsn
-from pydantic.env_settings import SettingsSourceCallable
+from pydantic import BaseSettings
 
 
 def json_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     """
     A simple settings source that loads variables from a JSON file
     at the project's root.
+
+    Here we happen to choose to use the `env_file_encoding` from Config
+    when reading `config.json`
     """
-    return json.loads(Path('config.json').read_text().strip())
+    encoding = settings.__config__.env_file_encoding
+    return json.loads(Path('config.json').read_text(encoding))
 
 
 class Settings(BaseSettings):
-    database_dsn: PostgresDsn
+    foobar: str
 
     class Config:
+        env_file_encoding = 'utf-8'
+
         @classmethod
         def customise_sources(
             cls,
-            init_settings: SettingsSourceCallable,
-            env_settings: SettingsSourceCallable,
-            file_secret_settings: SettingsSourceCallable,
-        ) -> Tuple[SettingsSourceCallable, ...]:
+            init_settings,
+            env_settings,
+            file_secret_settings,
+        ):
             return (
                 init_settings,
+                json_config_settings_source,
                 env_settings,
                 file_secret_settings,
-                json_config_settings_source,
             )
+
+
+print(Settings())

--- a/docs/examples/settings_add_custom_source.py
+++ b/docs/examples/settings_add_custom_source.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from pydantic import BaseSettings, PostgresDsn
+from pydantic.env_settings import SettingsSourceCallable
+
+
+def json_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
+    """
+    A simple settings source that loads variables from a JSON file
+    at the project's root.
+    """
+    return json.loads(Path('config.json').read_text().strip())
+
+
+class Settings(BaseSettings):
+    database_dsn: PostgresDsn
+
+    class Config:
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: SettingsSourceCallable,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> Tuple[SettingsSourceCallable, ...]:
+            return (
+                init_settings,
+                env_settings,
+                file_secret_settings,
+                json_config_settings_source,
+            )

--- a/docs/examples/settings_disable_source.py
+++ b/docs/examples/settings_disable_source.py
@@ -1,11 +1,11 @@
 from typing import Tuple
 
-from pydantic import BaseSettings, PostgresDsn
+from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable
 
 
 class Settings(BaseSettings):
-    database_dsn: PostgresDsn
+    my_api_key: str
 
     class Config:
         @classmethod
@@ -15,5 +15,8 @@ class Settings(BaseSettings):
             env_settings: SettingsSourceCallable,
             file_secret_settings: SettingsSourceCallable,
         ) -> Tuple[SettingsSourceCallable, ...]:
-            # here we choose to disable entirely environ and .env file sources
-            return init_settings, file_secret_settings
+            # here we choose to ignore arguments from init_settings
+            return env_settings, file_secret_settings
+
+
+print(Settings(my_api_key='this is ignored'))

--- a/docs/examples/settings_disable_source.py
+++ b/docs/examples/settings_disable_source.py
@@ -1,0 +1,19 @@
+from typing import Tuple
+
+from pydantic import BaseSettings, PostgresDsn
+from pydantic.env_settings import SettingsSourceCallable
+
+
+class Settings(BaseSettings):
+    database_dsn: PostgresDsn
+
+    class Config:
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: SettingsSourceCallable,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> Tuple[SettingsSourceCallable, ...]:
+            # here we choose to disable entirely environ and .env file sources
+            return init_settings, file_secret_settings

--- a/docs/examples/settings_env_priority.py
+++ b/docs/examples/settings_env_priority.py
@@ -1,5 +1,4 @@
 from typing import Tuple
-
 from pydantic import BaseSettings, PostgresDsn
 from pydantic.env_settings import SettingsSourceCallable
 
@@ -16,3 +15,6 @@ class Settings(BaseSettings):
             file_secret_settings: SettingsSourceCallable,
         ) -> Tuple[SettingsSourceCallable, ...]:
             return env_settings, init_settings, file_secret_settings
+
+
+print(Settings(database_dsn='postgres://postgres@localhost:5432/kwargs_db'))

--- a/docs/examples/settings_env_priority.py
+++ b/docs/examples/settings_env_priority.py
@@ -1,0 +1,18 @@
+from typing import Tuple
+
+from pydantic import BaseSettings, PostgresDsn
+from pydantic.env_settings import SettingsSourceCallable
+
+
+class Settings(BaseSettings):
+    database_dsn: PostgresDsn
+
+    class Config:
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: SettingsSourceCallable,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> Tuple[SettingsSourceCallable, ...]:
+            return env_settings, init_settings, file_secret_settings

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -214,18 +214,7 @@ the selected value is determined as follows (in descending order of priority):
 If the default order of priority doesn't match your needs, it's possible to change it by overriding a config method:
 
 ```py
-class Settings(BaseSettings):
-    ...
-    
-    class Config:
-        @classmethod
-        def customise_sources(
-            cls,
-            init_settings: SettingsSourceCallable,
-            env_settings: SettingsSourceCallable,
-            file_secret_settings: SettingsSourceCallable,
-        ) -> Tuple[SettingsSourceCallable, ...]:
-            return env_settings, init_settings, file_secret_settings
+{!.tmp_examples/settings_env_priority.py!}
 ```
 
 By flipping `env_settings` and `init_settings`, environment variables have now precedence on init kwargs.
@@ -237,88 +226,12 @@ However, changing the order of priority might not be enough in some complex envi
 to add a custom settings source:
 
 ```py
-def json_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
-    """
-    A simple settings source that loads variables from a JSON file at the project's root.
-    """
-    return json.loads(Path('config.json').read_text().strip())
-
-
-class Settings(BaseSettings):
-    ...
-
-    class Config:
-        @classmethod
-        def customise_sources(
-            cls,
-            init_settings: SettingsSourceCallable,
-            env_settings: SettingsSourceCallable,
-            file_secret_settings: SettingsSourceCallable,
-        ) -> Tuple[SettingsSourceCallable, ...]:
-            return init_settings, env_settings, file_secret_settings, json_config_settings_source
-```
-
-If you want to create reusable and configurable settings source, you can also write a class based settings source:
-
-```py
-class RestSecretSettingsSource:
-    """
-    A configurable settings source that request settings variables on a REST server.
-    """
-    
-    def __init__(self, base_url: str, api_token: str):
-        self.base_url = base_url
-        self.api_token = api_token
-        
-    def retrieve_variable(self, var_name: str) -> Any:
-        response = httpx.get(
-            f'{self.base_url}/{var_name}',
-            headers={'Authorization': f'Bearer {self.api_token}'}
-        )
-        response.raise_for_status()
-        return response.json()['value']
-        
-    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
-        return {
-            field.alias: self.retrieve_variable(var_name=field.name)
-            for field in settings.__fields__.values()
-        }  
-
-
-class Settings(BaseSettings):
-    ...
-
-    class Config:
-        @classmethod
-        def customise_sources(
-            cls,
-            init_settings: SettingsSourceCallable,
-            env_settings: SettingsSourceCallable,
-            file_secret_settings: SettingsSourceCallable,
-        ) -> Tuple[SettingsSourceCallable, ...]:
-            return (
-                init_settings,
-                env_settings,
-                file_secret_settings,
-                RestSecretSettingsSource(api_token='TOKEN', base_url='https://env.lan')
-            )
+{!.tmp_examples/settings_add_custom_source.py!}
 ```
 
 You might also want to disable a source:
 
 ```py
-class Settings(BaseSettings):
-    ...
-
-    class Config:
-        @classmethod
-        def customise_sources(
-            cls,
-            init_settings: SettingsSourceCallable,
-            env_settings: SettingsSourceCallable,
-            file_secret_settings: SettingsSourceCallable,
-        ) -> Tuple[SettingsSourceCallable, ...]:
-            # here we choose to disable entirely environ and .env file sources
-            return init_settings, file_secret_settings
+{!.tmp_examples/settings_disable_source.py!}
 ```
 

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -209,29 +209,45 @@ the selected value is determined as follows (in descending order of priority):
 4. Variables loaded from the secrets directory.
 5. The default field values for the `Settings` model.
 
-### Customise settings sources priority
+## Customise settings sources
 
-If the default order of priority doesn't match your needs, it's possible to change it by overriding a config method:
+If the default order of priority doesn't match your needs, it's possible to change it by overriding
+the `customise_sources` method on the `Config` class of your `Settings` .
+
+`customise_sources` takes three callables as arguments and returns any number of callables as a tuple. In turn these
+callables are called to build the inputs to the fields of the settings class.
+
+Each callable should take an instance of the settings class as its sole argument and return a `dict`.
+
+### Changing Priority
+
+The order of the returned callables decides the priority of inputs; first item is the highest priority.
 
 ```py
 {!.tmp_examples/settings_env_priority.py!}
 ```
+_(This script is complete, it should run "as is")_
 
-By flipping `env_settings` and `init_settings`, environment variables have now precedence on init kwargs.
+By flipping `env_settings` and `init_settings`, environment variables now have precedence over `__init__` kwargs.
 
-## Add and remove settings sources
+### Adding sources
 
-As explained earlier, *pydantic* ships with multiples built-in settings sources.
-However, changing the order of priority might not be enough in some complex environments, and you may need 
-to add a custom settings source:
+As explained earlier, *pydantic* ships with multiples built-in settings sources. However, you may occationally
+need to add your own custom sources, `customise_sources` makes this very easy:
 
 ```py
 {!.tmp_examples/settings_add_custom_source.py!}
 ```
+_(This script is complete, it should run "as is")_
+
+### Removing sources
 
 You might also want to disable a source:
 
 ```py
 {!.tmp_examples/settings_disable_source.py!}
 ```
+_(This script is complete, it should run "as is", here you might need to set the `my_api_key` environment variable)_
 
+Because of the callables approach of `customise_sources`, evaluation of sources is lazy so unused sources don't
+have an adverse effect on performance.

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -59,7 +59,12 @@ class BaseSettings(BaseModel):
         sources = self.__config__.customise_sources(
             init_settings=init_settings, env_settings=env_settings, file_secret_settings=file_secret_settings
         )
-        return deep_update(*reversed([source(self) for source in sources]))
+        if sources:
+            return deep_update(*reversed([source(self) for source in sources]))
+        else:
+            # no one should mean to do this, but I think returning an empty dict is marginally preferable
+            # to an informative error and much better than a confusing error
+            return {}
 
     class Config(BaseConfig):
         env_prefix = ''

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -120,6 +120,9 @@ class InitSettingsSource:
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
         return self.init_kwargs
 
+    def __repr__(self) -> str:
+        return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'
+
 
 class EnvSettingsSource:
     __slots__ = ('env_file', 'env_file_encoding')
@@ -167,6 +170,9 @@ class EnvSettingsSource:
             d[field.alias] = env_val
         return d
 
+    def __repr__(self) -> str:
+        return f'EnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r})'
+
 
 class SecretsSettingsSource:
     __slots__ = ('secrets_dir',)
@@ -202,6 +208,9 @@ class SecretsSettingsSource:
                     )
 
         return secrets
+
+    def __repr__(self) -> str:
+        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
 
 
 def read_env_file(file_path: Path, *, encoding: str = None, case_sensitive: bool = False) -> Dict[str, Optional[str]]:

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from pathlib import Path
-from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Union
+from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 from .fields import ModelField
 from .main import BaseConfig, BaseModel, Extra
@@ -9,6 +9,8 @@ from .typing import display_as_type
 from .utils import deep_update, path_type, sequence_like
 
 env_file_sentinel = str(object())
+
+SettingsSourceCallable = Callable[['BaseSettings'], Dict[str, Any]]
 
 
 class SettingsError(ValueError):
@@ -44,82 +46,20 @@ class BaseSettings(BaseModel):
         _env_file_encoding: Optional[str] = None,
         _secrets_dir: Union[Path, str, None] = None,
     ) -> Dict[str, Any]:
-        return deep_update(
-            self._build_secrets_files(_secrets_dir), self._build_environ(_env_file, _env_file_encoding), init_kwargs
+        # Configure built-in sources
+        init_settings = InitSettingsSource(init_kwargs=init_kwargs)
+        env_settings = EnvSettingsSource(
+            env_file=(_env_file if _env_file != env_file_sentinel else self.__config__.env_file),
+            env_file_encoding=(
+                _env_file_encoding if _env_file_encoding is not None else self.__config__.env_file_encoding
+            ),
         )
-
-    def _build_secrets_files(self, _secrets_dir: Union[Path, str, None] = None) -> Dict[str, Optional[str]]:
-        """
-        Build fields from "secrets" files.
-        """
-        secrets: Dict[str, Optional[str]] = {}
-
-        secrets_dir = _secrets_dir or self.__config__.secrets_dir
-        if secrets_dir is None:
-            return secrets
-
-        secrets_path = Path(secrets_dir).expanduser()
-
-        if not secrets_path.exists():
-            raise SettingsError(f'directory "{secrets_path}" does not exist')
-        if not secrets_path.is_dir():
-            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(secrets_path)}')
-
-        for field in self.__fields__.values():
-            for env_name in field.field_info.extra['env_names']:
-                path = secrets_path / env_name
-                if path.is_file():
-                    secrets[field.alias] = path.read_text().strip()
-                elif path.exists():
-                    warnings.warn(
-                        f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
-                        stacklevel=4,
-                    )
-
-        return secrets
-
-    def _build_environ(
-        self, _env_file: Union[Path, str, None] = None, _env_file_encoding: Optional[str] = None
-    ) -> Dict[str, Optional[str]]:
-        """
-        Build environment variables suitable for passing to the Model.
-        """
-        d: Dict[str, Optional[str]] = {}
-
-        if self.__config__.case_sensitive:
-            env_vars: Mapping[str, Optional[str]] = os.environ
-        else:
-            env_vars = {k.lower(): v for k, v in os.environ.items()}
-
-        env_file = _env_file if _env_file != env_file_sentinel else self.__config__.env_file
-        env_file_encoding = _env_file_encoding if _env_file_encoding is not None else self.__config__.env_file_encoding
-        if env_file is not None:
-            env_path = Path(env_file).expanduser()
-            if env_path.is_file():
-                env_vars = {
-                    **read_env_file(
-                        env_path, encoding=env_file_encoding, case_sensitive=self.__config__.case_sensitive
-                    ),
-                    **env_vars,
-                }
-
-        for field in self.__fields__.values():
-            env_val: Optional[str] = None
-            for env_name in field.field_info.extra['env_names']:
-                env_val = env_vars.get(env_name)
-                if env_val is not None:
-                    break
-
-            if env_val is None:
-                continue
-
-            if field.is_complex():
-                try:
-                    env_val = self.__config__.json_loads(env_val)  # type: ignore
-                except ValueError as e:
-                    raise SettingsError(f'error parsing JSON for "{env_name}"') from e
-            d[field.alias] = env_val
-        return d
+        file_secret_settings = SecretsSettingsSource(secrets_dir=_secrets_dir or self.__config__.secrets_dir)
+        # Provide a hook to set built-in sources priority and add / remove sources
+        sources = self.__config__.customise_sources(
+            init_settings=init_settings, env_settings=env_settings, file_secret_settings=file_secret_settings
+        )
+        return deep_update(*reversed([source(self) for source in sources]))
 
     class Config(BaseConfig):
         env_prefix = ''
@@ -159,7 +99,109 @@ class BaseSettings(BaseModel):
                 env_names = env_names.__class__(n.lower() for n in env_names)
             field.field_info.extra['env_names'] = env_names
 
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: SettingsSourceCallable,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> Tuple[SettingsSourceCallable, ...]:
+            return init_settings, env_settings, file_secret_settings
+
     __config__: Config  # type: ignore
+
+
+class InitSettingsSource:
+    __slots__ = ('init_kwargs',)
+
+    def __init__(self, init_kwargs: Dict[str, Any]):
+        self.init_kwargs = init_kwargs
+
+    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
+        return self.init_kwargs
+
+
+class EnvSettingsSource:
+    __slots__ = ('env_file', 'env_file_encoding')
+
+    def __init__(self, env_file: Union[Path, str, None], env_file_encoding: Optional[str]):
+        self.env_file: Union[Path, str, None] = env_file
+        self.env_file_encoding: Optional[str] = env_file_encoding
+
+    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
+        """
+        Build environment variables suitable for passing to the Model.
+        """
+        d: Dict[str, Optional[str]] = {}
+
+        if settings.__config__.case_sensitive:
+            env_vars: Mapping[str, Optional[str]] = os.environ
+        else:
+            env_vars = {k.lower(): v for k, v in os.environ.items()}
+
+        if self.env_file is not None:
+            env_path = Path(self.env_file).expanduser()
+            if env_path.is_file():
+                env_vars = {
+                    **read_env_file(
+                        env_path, encoding=self.env_file_encoding, case_sensitive=settings.__config__.case_sensitive
+                    ),
+                    **env_vars,
+                }
+
+        for field in settings.__fields__.values():
+            env_val: Optional[str] = None
+            for env_name in field.field_info.extra['env_names']:
+                env_val = env_vars.get(env_name)
+                if env_val is not None:
+                    break
+
+            if env_val is None:
+                continue
+
+            if field.is_complex():
+                try:
+                    env_val = settings.__config__.json_loads(env_val)  # type: ignore
+                except ValueError as e:
+                    raise SettingsError(f'error parsing JSON for "{env_name}"') from e
+            d[field.alias] = env_val
+        return d
+
+
+class SecretsSettingsSource:
+    __slots__ = ('secrets_dir',)
+
+    def __init__(self, secrets_dir: Union[Path, str, None]):
+        self.secrets_dir: Union[Path, str, None] = secrets_dir
+
+    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
+        """
+        Build fields from "secrets" files.
+        """
+        secrets: Dict[str, Optional[str]] = {}
+
+        if self.secrets_dir is None:
+            return secrets
+
+        secrets_path = Path(self.secrets_dir).expanduser()
+
+        if not secrets_path.exists():
+            raise SettingsError(f'directory "{secrets_path}" does not exist')
+        if not secrets_path.is_dir():
+            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(secrets_path)}')
+
+        for field in settings.__fields__.values():
+            for env_name in field.field_info.extra['env_names']:
+                path = secrets_path / env_name
+                if path.is_file():
+                    secrets[field.alias] = path.read_text().strip()
+                elif path.exists():
+                    warnings.warn(
+                        f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
+                        stacklevel=4,
+                    )
+
+        return secrets
 
 
 def read_env_file(file_path: Path, *, encoding: str = None, case_sensitive: bool = False) -> Dict[str, Optional[str]]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -940,6 +940,20 @@ def test_external_settings_sources_filter_env_vars():
     assert Settings().dict() == {'apple': 'value 0', 'banana': 'value 2'}
 
 
+def test_customise_sources_empty():
+    class Settings(BaseSettings):
+        apple: str = 'default'
+        banana: str = 'default'
+
+        class Config:
+            @classmethod
+            def customise_sources(cls, *args):
+                return ()
+
+    assert Settings().dict() == {'apple': 'default', 'banana': 'default'}
+    assert Settings(apple='xxx').dict() == {'apple': 'default', 'banana': 'default'}
+
+
 def test_builtins_settings_source_repr():
     assert (
         repr(InitSettingsSource(init_kwargs={'apple': 'value 0', 'banana': 'value 1'}))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -947,7 +947,7 @@ def test_customise_sources_empty():
 
         class Config:
             @classmethod
-            def customise_sources(cls, *args):
+            def customise_sources(cls, *args, **kwargs):
                 return ()
 
     assert Settings().dict() == {'apple': 'default', 'banana': 'default'}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,7 +7,14 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import pytest
 
 from pydantic import BaseModel, BaseSettings, Field, HttpUrl, NoneStr, SecretStr, ValidationError, dataclasses
-from pydantic.env_settings import SettingsError, SettingsSourceCallable, read_env_file
+from pydantic.env_settings import (
+    EnvSettingsSource,
+    InitSettingsSource,
+    SecretsSettingsSource,
+    SettingsError,
+    SettingsSourceCallable,
+    read_env_file,
+)
 
 try:
     import dotenv
@@ -931,3 +938,15 @@ def test_external_settings_sources_filter_env_vars():
                 )
 
     assert Settings().dict() == {'apple': 'value 0', 'banana': 'value 2'}
+
+
+def test_builtins_settings_source_repr():
+    assert (
+        repr(InitSettingsSource(init_kwargs={'apple': 'value 0', 'banana': 'value 1'}))
+        == "InitSettingsSource(init_kwargs={'apple': 'value 0', 'banana': 'value 1'})"
+    )
+    assert (
+        repr(EnvSettingsSource(env_file='.env', env_file_encoding='utf-8'))
+        == "EnvSettingsSource(env_file='.env', env_file_encoding='utf-8')"
+    )
+    assert repr(SecretsSettingsSource(secrets_dir='/secrets')) == "SecretsSettingsSource(secrets_dir='/secrets')"


### PR DESCRIPTION
## Change Summary

- refactor BaseSettings internal logic
- expose `filter_relevant_env_vars` and `load_env_vars_from_source ` functions to ease creation of external sources plugins
- add `extra_settings_sources ` ModelConfig key for BaseSettings

More info in the linked issue.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/2106

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
