### PR TITLE
Fixes a regression where Enum fields would not propagate keyword arguments to the schema

### DIFF
--- a/changes/2109-bm424.md
+++ b/changes/2109-bm424.md
@@ -1,0 +1,1 @@
+Fix a regression where Enum fields would not propagate keyword arguments to the schema

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -260,7 +260,9 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
     f_schema: Dict[str, Any] = {}
 
     if lenient_issubclass(field.type_, Enum):
-        # schema is already updated by `enum_process_schema`
+        # schema is already updated by `enum_process_schema`; just update with field extra
+        if field.field_info.extra:
+            f_schema.update(field.field_info.extra)
         return f_schema
 
     if lenient_issubclass(field.type_, (str, bytes)):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -376,28 +376,28 @@ def test_enum_and_model_have_same_behaviour():
 
 def test_list_enum_schema_extras():
     class FoodChoice(str, Enum):
-        spam = "spam"
-        egg = "egg"
-        chips = "chips"
+        spam = 'spam'
+        egg = 'egg'
+        chips = 'chips'
 
     class Model(BaseModel):
-        foods: List[FoodChoice] = Field(examples=[["spam", "egg"]])
+        foods: List[FoodChoice] = Field(examples=[['spam', 'egg']])
 
     assert Model.schema() == {
         'definitions': {
             'FoodChoice': {
                 'description': 'An enumeration.',
-                'enum': ["spam", "egg", "chips"],
+                'enum': ['spam', 'egg', 'chips'],
                 'title': 'FoodChoice',
                 'type': 'string',
             }
         },
         'properties': {
-            'foods': {'type': 'array', 'items': {'$ref': '#/definitions/FoodChoice'}, 'examples': [["spam", "egg"]]},
+            'foods': {'type': 'array', 'items': {'$ref': '#/definitions/FoodChoice'}, 'examples': [['spam', 'egg']]},
         },
         'required': ['foods'],
-        'title': "Model",
-        'type': "object",
+        'title': 'Model',
+        'type': 'object',
     }
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -373,6 +373,41 @@ def test_enum_and_model_have_same_behaviour():
         'type': 'object',
     }
 
+def test_list_enum_schema_extras():
+
+    class FoodChoice(str, Enum):
+        spam = "spam"
+        egg = "egg"
+        chips = "chips"
+
+    class Model(BaseModel):
+        foods: List[FoodChoice] = Field(examples=[["spam", "egg"]])
+
+    assert Model.schema() == {
+        'definitions': {
+            'FoodChoice': {
+                'description': 'An enumeration.',
+                'enum': ["spam", "egg", "chips"],
+                'title': 'FoodChoice',
+                'type': 'string',
+            }
+        },
+        'properties': {
+            'foods': {
+                'type': 'array',
+                'items': {
+                    '$ref': '#/definitions/FoodChoice'
+                },
+                'examples': [
+                    ["spam", "egg"]
+                ]
+            },
+        },
+        'required': ['foods'],
+        'title': "Model",
+        'type': "object",
+    }
+
 
 def test_json_schema():
     class Model(BaseModel):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -373,8 +373,8 @@ def test_enum_and_model_have_same_behaviour():
         'type': 'object',
     }
 
-def test_list_enum_schema_extras():
 
+def test_list_enum_schema_extras():
     class FoodChoice(str, Enum):
         spam = "spam"
         egg = "egg"
@@ -393,15 +393,7 @@ def test_list_enum_schema_extras():
             }
         },
         'properties': {
-            'foods': {
-                'type': 'array',
-                'items': {
-                    '$ref': '#/definitions/FoodChoice'
-                },
-                'examples': [
-                    ["spam", "egg"]
-                ]
-            },
+            'foods': {'type': 'array', 'items': {'$ref': '#/definitions/FoodChoice'}, 'examples': [["spam", "egg"]]},
         },
         'required': ['foods'],
         'title': "Model",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
## Change Summary
Ensures `Enum` fields defined with additional keyword arguments have their schema updated in the same way as other fields.

ℹ️ Regression introduced by #1749 in v1.7.0

## Related issue number
#2108

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
