### PR TITLE
Updated validators.md with the type of field

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -13,7 +13,7 @@ A few things to note on validators:
 * you can also add any subset of the following arguments to the signature (the names **must** match):
     * `values`: a dict containing the name-to-value mapping of any previously-validated fields
     * `config`: the model config
-    * `field`: the field being validated
+    * `field`: the field being validated. Type of object is `pydantic.fields.ModelField`.
     * `**kwargs`: if provided, this will include the arguments above not explicitly listed in the signature
 * validators should either return the parsed value or raise a `ValueError`, `TypeError`, or `AssertionError`
   (``assert`` statements may be used).


### PR DESCRIPTION
As someone started using pydantic, it can be very convenient to know what type we can rely the returned field is, so we know what we can check on it and what fields it has.
After searching the code I found out it has to be of type ModelField and that's why I'm offering it here as something that I think should be clarified in the documentation.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
