### PR TITLE
Fix #2111: support pickle for built-in dataclasses

### DIFF
--- a/changes/2111-aimestereo.md
+++ b/changes/2111-aimestereo.md
@@ -1,0 +1,1 @@
+Allow pickling of `pydantic.dataclasses.dataclass` dynamically created from a built-in `dataclasses.dataclass`.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -132,7 +132,7 @@ def _process_class(
                 '__post_init__': _pydantic_post_init,
                 # attrs for pickle to find this class
                 '__module__': __name__,
-                '__qualname__': f'{uniq_class_name}',
+                '__qualname__': uniq_class_name,
             },
         )
         globals()[uniq_class_name] = _cls

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -119,10 +119,19 @@ def _process_class(
     #   __post_init__ = _pydantic_post_init
     # ```
     # with the exact same fields as the base dataclass
+    # and register it on module level to address pickle problem:
+    # https://github.com/samuelcolvin/pydantic/issues/2111
     if is_builtin_dataclass(_cls):
+        class_name = f'_Pydantic{_cls.__name__}'
         _cls = type(
-            _cls.__name__, (_cls,), {'__annotations__': _cls.__annotations__, '__post_init__': _pydantic_post_init}
+            class_name,
+            (_cls,),
+            {
+                '__annotations__': _cls.__annotations__,
+                '__post_init__': _pydantic_post_init,
+            },
         )
+        globals()[class_name] = _cls
     else:
         _cls.__post_init__ = _pydantic_post_init
     cls: Type['Dataclass'] = dataclasses.dataclass(  # type: ignore

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -122,16 +122,20 @@ def _process_class(
     # and register it on module level to address pickle problem:
     # https://github.com/samuelcolvin/pydantic/issues/2111
     if is_builtin_dataclass(_cls):
-        class_name = f'_Pydantic{_cls.__name__}'
+        uniq_class_name = f'_Pydantic_{_cls.__name__}_{id(_cls)}'
         _cls = type(
-            class_name,
+            # for pretty output new class will have the name as original
+            _cls.__name__,
             (_cls,),
             {
                 '__annotations__': _cls.__annotations__,
                 '__post_init__': _pydantic_post_init,
+                # attrs for pickle to find this class
+                '__module__': __name__,
+                '__qualname__': f'{uniq_class_name}',
             },
         )
-        globals()[class_name] = _cls
+        globals()[uniq_class_name] = _cls
     else:
         _cls.__post_init__ = _pydantic_post_init
     cls: Type['Dataclass'] = dataclasses.dataclass(  # type: ignore

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -801,25 +801,21 @@ def test_forward_stdlib_dataclass_params():
         e.item.name = 'pika2'
 
 
+@dataclasses.dataclass
+class BuiltInDataclass:
+    value: int
+
+
+class PydanticModel(pydantic.BaseModel):
+    """
+    pickle can only work with instances of locally-defined classes
+    if we promote them to top level.
+    """
+
+    built_in_dataclass: BuiltInDataclass
+
+
 def test_pickle_overriden_builtin_dataclass():
-    @dataclasses.dataclass
-    class BuiltInDataclass:
-        value: int
-
-    class PydanticModel(pydantic.BaseModel):
-        built_in_dataclass: BuiltInDataclass
-
-    # pickle can only work with instances of locally-defined classes
-    # if we promote them to top level.
-    PydanticModel.__qualname__ = PydanticModel.__name__
-    BuiltInDataclass.__qualname__ = BuiltInDataclass.__name__
-    globals().update(
-        {
-            PydanticModel.__name__: PydanticModel,
-            BuiltInDataclass.__name__: BuiltInDataclass,
-        }
-    )
-
     value = 5
     obj = PydanticModel(built_in_dataclass=BuiltInDataclass(value=value))
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -801,32 +801,35 @@ def test_forward_stdlib_dataclass_params():
         e.item.name = 'pika2'
 
 
+def test_pickle_overriden_builtin_dataclass(create_module):
+    module = create_module(
+        # language=Python
+        """\
+import dataclasses
+import pydantic
+
+
 @dataclasses.dataclass
 class BuiltInDataclassForPickle:
     value: int
 
-
 class ModelForPickle(pydantic.BaseModel):
-    """
-    pickle can only work with top level classes as it imports them
-    """
+    # pickle can only work with top level classes as it imports them
 
     dataclass: BuiltInDataclassForPickle
 
     class Config:
         validate_assignment = True
-
-
-def test_pickle_overriden_builtin_dataclass():
-    value = 5
-    obj = ModelForPickle(dataclass=BuiltInDataclassForPickle(value=value))
+        """
+    )
+    obj = module.ModelForPickle(dataclass=module.BuiltInDataclassForPickle(value=5))
 
     pickled_obj = pickle.dumps(obj)
     restored_obj = pickle.loads(pickled_obj)
 
-    assert restored_obj.dataclass.value == value
+    assert restored_obj.dataclass.value == 5
     assert restored_obj == obj
 
     # ensure the restored dataclass is still a pydantic dataclass
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match='value\n +value is not a valid integer'):
         restored_obj.dataclass.value = 'value of a wrong type'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -829,4 +829,4 @@ def test_pickle_overriden_builtin_dataclass():
 
     # ensure the restored dataclass is still a pydantic dataclass
     with pytest.raises(ValidationError):
-        restored_obj.dataclass.value = 'value of a wrong_type'
+        restored_obj.dataclass.value = 'value of a wrong type'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

When built-in `dataclasses.dataclass` is detected and `pydantic.dataclasses.dataclass` is dynamically created for it, we should register it on module level with unique name to allow pickle work with it. Specific name (`_Pydantic...`) insures that there're no name collisions.

Note: I've also tried another approach to manually handle pickle, by defining `__reduce__` for dynamically created class. `__reduce__` can be used to avoid register newly created class in globals(), by specifying how instance is pickled: one of the parameters can be function, that will recreate this class when needed (e.g. on `pickle.loads`) and create its instance. This works perfectly for simple cases, but here, `config` parameter is also a dynamically created class (fails to be pickled) so, the already complex problem only become bigger.

ℹ️ Regression introduced by #1817 in v1.7.0

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
closes https://github.com/samuelcolvin/pydantic/issues/2111

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
