### PR TITLE
Implement MongoDsn field types

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -50,6 +50,7 @@ __all__ = [
     'IPvAnyNetwork',
     'PostgresDsn',
     'RedisDsn',
+    'MongoSrvDsn',
     'validate_email',
     # parse
     'Protocol',

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -40,6 +40,7 @@ __all__ = [
     'IPvAnyNetwork',
     'PostgresDsn',
     'RedisDsn',
+    'MongoSrvDsn',
     'validate_email',
 ]
 
@@ -280,6 +281,10 @@ class PostgresDsn(AnyUrl):
 
 class RedisDsn(AnyUrl):
     allowed_schemes = {'redis'}
+
+
+class MongoSrvDsn(AnyUrl):
+    allowed_schemes = {'mongodb+srv'}
 
 
 def stricturl(

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,6 +1,17 @@
 import pytest
 
-from pydantic import AnyUrl, BaseModel, EmailStr, HttpUrl, NameEmail, PostgresDsn, RedisDsn, ValidationError, stricturl
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    EmailStr,
+    HttpUrl,
+    MongoSrvDsn,
+    NameEmail,
+    PostgresDsn,
+    RedisDsn,
+    ValidationError,
+    stricturl,
+)
 from pydantic.networks import validate_email
 
 try:
@@ -335,6 +346,21 @@ def test_redis_dsns():
     assert m.a == 'redis://localhost:5432/app'
     assert m.a.user is None
     assert m.a.password is None
+
+
+def test_mongo_srv_dsns():
+    class Model(BaseModel):
+        a: MongoSrvDsn
+
+    m = Model(a='mongodb+srv://server.example.com/mydatabase?tls=false')
+    assert m.a == 'mongodb+srv://server.example.com/mydatabase?tls=false'
+    assert m.a.user is None
+    assert m.a.password is None
+    assert m.a.query == 'tls=false'
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='http://example.org')
+    assert exc_info.value.errors()[0]['type'] == 'value_error.url.scheme'
 
 
 def test_custom_schemes():


### PR DESCRIPTION
## Change Summary

Add  two DSN field types for MongoDB:
- MongoDsn for regular `mongodb://...` connection strings (still todo)
- MongoSrvDsn handling `mongodb+srv://...` aka  [DNS Seed List](https://docs.mongodb.com/manual/reference/connection-string/#dns-seed-list-connection-format) connection strings

## Related issue number

Implements and resolves #2117.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
