### PR TITLE
fix: update all modified field values in `root_validator` when `validate_assignment` is on

### DIFF
--- a/changes/2116-PrettyWood.md
+++ b/changes/2116-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: update all modified field values in `root_validator` when `validate_assignment` is on

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -406,7 +406,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             if errors:
                 raise ValidationError(errors, self.__class__)
 
-        self.__dict__[name] = value
+            # update the whole __dict__ as other values than just `value`
+            # may be changed (e.g. with `root_validator`)
+            object_setattr(self, '__dict__', new_values)
+        else:
+            self.__dict__[name] = value
+
         self.__fields_set__.add(name)
 
     def __getstate__(self) -> 'DictAny':

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -666,6 +666,28 @@ def test_validating_assignment_post_root_validator_fail():
     ]
 
 
+def test_root_validator_many_values_change():
+    """It should run root_validator on assignment and update ALL concerned fields"""
+
+    class Rectangle(BaseModel):
+        width: float
+        height: float
+        area: float = None
+
+        class Config:
+            validate_assignment = True
+
+        @root_validator
+        def set_ts_now(cls, values):
+            values['area'] = values['width'] * values['height']
+            return values
+
+    r = Rectangle(width=1, height=1)
+    assert r.area == 1
+    r.height = 5
+    assert r.area == 5
+
+
 def test_enum_values():
     FooEnum = Enum('FooEnum', {'foo': 'foo', 'bar': 'bar'})
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -678,7 +678,7 @@ def test_root_validator_many_values_change():
             validate_assignment = True
 
         @root_validator
-        def set_ts_now(cls, values):
+        def set_area(cls, values):
             values['area'] = values['width'] * values['height']
             return values
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Following #1971 we now run `root_validator` on assignment when `Config.validate_assignment` is set.
But we still only updated the assigned field and not all concerned fields

ℹ️ Not really a regression but more a fix to #1972 in v1.7.0

## Related issue number
closes #2116
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
