### PR TITLE
feat: add `validate` method on function to validate input without calling it

### DIFF
--- a/changes/2127-PrettyWood.md
+++ b/changes/2127-PrettyWood.md
@@ -1,0 +1,2 @@
+Add a bound method `validate` to functions decorated with `validate_arguments`
+to validate parameters without actually calling the function

--- a/docs/examples/validation_decorator_validate.py
+++ b/docs/examples/validation_decorator_validate.py
@@ -1,0 +1,17 @@
+from pydantic import validate_arguments, ValidationError
+
+
+@validate_arguments
+def slow_sum(a: int, b: int) -> int:
+    print(f'Called with a={a}, b={b}')
+    return a + b
+
+
+slow_sum(1, 1)
+
+slow_sum.validate(2, 2)
+
+try:
+    slow_sum.validate(1, 'b')
+except ValidationError as exc:
+    print(exc)

--- a/docs/usage/validation_decorator.md
+++ b/docs/usage/validation_decorator.md
@@ -29,9 +29,10 @@ As with the rest of *pydantic*, types can be coerced by the decorator before the
 _(This script is complete, it should run "as is")_
 
 A few notes:
-* through they're passed as strings `path` and `regex` are converted to a `Path` object and regex respectively,
-  by the decorator
-* `max` has no type annotation, so will be considered as `Any` by the decorator
+
+- though they're passed as strings, `path` and `regex` are converted to a `Path` object and regex respectively
+by the decorator
+- `max` has no type annotation, so will be considered as `Any` by the decorator
 
 Type coercion like this can be extremely helpful but also confusing or not desired,
 see [below](#coercion-and-strictness) for a discussion of `validate_arguments`'s limitations in this regard.
@@ -60,6 +61,17 @@ The `validate_arguments` decorator should work "out of the box" with [mypy](http
 defined to return a function with the same signature as the function it decorates. The only limitation is that
 since we trick mypy into thinking the function returned by the decorator is the same as the function being
 decorated; access to the [raw function](#raw-function) or other attributes will require `type: ignore`.
+
+## Validate without calling the function
+
+By default, arguments validation is done by directly calling the decorated function with parameters.
+But what if you wanted to validate them without *actually* calling the function?
+To do that you can call the `validate` method bound to the decorated function.
+
+```py
+{!.tmp_examples/validation_decorator_validate.py!}
+```
+_(This script is complete, it should run "as is")_
 
 ## Raw function
 

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -52,6 +52,7 @@ def validate_arguments(func: Optional['AnyCallableT'] = None, *, config: 'Config
             return vd.call(*args, **kwargs)
 
         wrapper_function.vd = vd  # type: ignore
+        wrapper_function.validate = vd.init_model_instance  # type: ignore
         wrapper_function.raw_function = vd.raw_function  # type: ignore
         wrapper_function.model = vd.model  # type: ignore
         return wrapper_function
@@ -134,9 +135,12 @@ class ValidatedFunction:
 
         self.create_model(fields, takes_args, takes_kwargs, config)
 
-    def call(self, *args: Any, **kwargs: Any) -> Any:
+    def init_model_instance(self, *args: Any, **kwargs: Any) -> BaseModel:
         values = self.build_values(args, kwargs)
-        m = self.model(**values)
+        return self.model(**values)
+
+    def call(self, *args: Any, **kwargs: Any) -> Any:
+        m = self.init_model_instance(*args, **kwargs)
         return self.execute(m)
 
     def build_values(self, args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -318,3 +318,17 @@ def test_config_arbitrary_types_allowed():
             'ctx': {'expected_arbitrary_type': 'EggBox'},
         },
     ]
+
+
+def test_validate(mocker):
+    stub = mocker.stub(name='on_something_stub')
+
+    @validate_arguments
+    def func(s: str, count: int, *, separator: bytes = b''):
+        stub(s, count, separator)
+
+    func.validate('qwe', 2)
+    with pytest.raises(ValidationError):
+        func.validate(['qwe'], 2)
+
+    stub.assert_not_called()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
This is a proposal after #2127 
I feel like it doesn't cost a lot for _pydantic_ to expose a method to validate inputs for a given function without actually calling it.

**If this feature is accepted, I'll add some documentation of course**

## Related issue number
closes #2127 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
