### PR TITLE
Added `StrictBytes` type

### DIFF
--- a/changes/2136-rlizzo.md
+++ b/changes/2136-rlizzo.md
@@ -1,0 +1,1 @@
+Added `StrictBytes` type as well as `strict=False` option to `ConstrianedBytes`.

--- a/changes/2136-rlizzo.md
+++ b/changes/2136-rlizzo.md
@@ -1,1 +1,1 @@
-Added `StrictBytes` type as well as `strict=False` option to `ConstrianedBytes`.
+Added `StrictBytes` type as well as `strict=False` option to `ConstrainedBytes`.

--- a/docs/examples/types_strict.py
+++ b/docs/examples/types_strict.py
@@ -1,4 +1,21 @@
-from pydantic import BaseModel, StrictBool, StrictInt, ValidationError, confloat
+from pydantic import (
+    BaseModel,
+    StrictBytes,
+    StrictBool,
+    StrictInt,
+    ValidationError,
+    confloat,
+)
+
+
+class StrictBytesModel(BaseModel):
+    strict_bytes: StrictBytes
+
+
+try:
+    StrictBytesModel(strict_bytes='hello world')
+except ValidationError as e:
+    print(e)
 
 
 class StrictIntModel(BaseModel):

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -721,14 +721,16 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
 
 ## Strict Types
 
-You can use the `StrictStr`, `StrictInt`, `StrictFloat`, and `StrictBool` types
+You can use the `StrictStr`, `StrictBytes`, `StrictInt`, `StrictFloat`, and `StrictBool` types 
 to prevent coercion from compatible types.
 These types will only pass validation when the validated value is of the respective type or is a subtype of that type.
-This behavior is also exposed via the `strict` field of the `ConstrainedStr`, `ConstrainedFloat` and
-`ConstrainedInt` classes and can be combined with a multitude of complex validation rules.
+This behavior is also exposed via the `strict` field of the `ConstrainedStr`, `ConstrainedBytes`, 
+`ConstrainedFloat` and `ConstrainedInt` classes and can be combined with a multitude of complex validation rules.
 
 The following caveats apply:
 
+- `StrictBytes` (and the `strict` option of `ConstrainedBytes`) will accept both `bytes`,
+   and `bytearray` types. 
 - `StrictInt` (and the `strict` option of `ConstrainedInt`) will not accept `bool` types,
     even though `bool` is a subclass of `int` in Python. Other subclasses will work.
 - `StrictFloat` (and the `strict` option of `ConstrainedFloat`) will not accept `int`.

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -93,6 +93,7 @@ __all__ = [
     'SecretStr',
     'SecretBytes',
     'StrictBool',
+    'StrictBytes',
     'StrictInt',
     'StrictFloat',
     'PaymentCardNumber',

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -39,6 +39,7 @@ from .validators import (
     path_validator,
     set_validator,
     str_validator,
+    strict_bytes_validator,
     strict_float_validator,
     strict_int_validator,
     strict_str_validator,
@@ -80,6 +81,7 @@ __all__ = [
     'SecretStr',
     'SecretBytes',
     'StrictBool',
+    'StrictBytes',
     'StrictInt',
     'StrictFloat',
     'PaymentCardNumber',
@@ -108,6 +110,7 @@ class ConstrainedBytes(bytes):
     strip_whitespace = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
+    strict: bool = False
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
@@ -115,9 +118,13 @@ class ConstrainedBytes(bytes):
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
-        yield bytes_validator
+        yield strict_bytes_validator if cls.strict else bytes_validator
         yield constr_strip_whitespace
         yield constr_length_validator
+
+
+class StrictBytes(ConstrainedBytes):
+    strict = True
 
 
 def conbytes(*, strip_whitespace: bool = False, min_length: int = None, max_length: int = None) -> Type[bytes]:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -82,6 +82,15 @@ def bytes_validator(v: Any) -> bytes:
         raise errors.BytesError()
 
 
+def strict_bytes_validator(v: Any) -> Union[bytes]:
+    if isinstance(v, bytes):
+        return v
+    elif isinstance(v, bytearray):
+        return bytes(v)
+    else:
+        raise errors.BytesError()
+
+
 BOOL_FALSE = {0, '0', 'off', 'f', 'false', 'n', 'no'}
 BOOL_TRUE = {1, '1', 'on', 't', 'true', 'y', 'yes'}
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1274,15 +1274,16 @@ def test_strict_bytes():
         v: StrictBytes
 
     assert Model(v=b'foobar').v == b'foobar'
+    assert Model(v=bytearray('foobar', 'utf-8')).v == b'foobar'
 
     with pytest.raises(ValidationError):
         Model(v='foostring')
 
     with pytest.raises(ValidationError):
-        Model(v=bytearray('foo', 'utf-8'))
+        Model(v=42)
 
     with pytest.raises(ValidationError):
-        Model(v=123)
+        Model(v=0.42)
 
 
 def test_strict_bytes_subclass():
@@ -1292,9 +1293,13 @@ def test_strict_bytes_subclass():
     class Model(BaseModel):
         v: MyStrictBytes
 
-    m = Model(v=MyStrictBytes(b'foobar'))
-    assert isinstance(m.v, MyStrictBytes)
-    assert m.v == b'foobar'
+    a = Model(v=MyStrictBytes(b'foobar'))
+    assert isinstance(a.v, MyStrictBytes)
+    assert a.v == b'foobar'
+
+    b = Model(v=MyStrictBytes(bytearray('foobar', 'utf-8')))
+    assert isinstance(b.v, MyStrictBytes)
+    assert b.v == 'foobar'.encode()
 
 
 def test_strict_str():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -49,6 +49,7 @@ from pydantic import (
     SecretBytes,
     SecretStr,
     StrictBool,
+    StrictBytes,
     StrictFloat,
     StrictInt,
     StrictStr,
@@ -1266,6 +1267,34 @@ def test_float_validation():
             'ctx': {'multiple_of': 0.5},
         },
     ]
+
+
+def test_strict_bytes():
+    class Model(BaseModel):
+        v: StrictBytes
+
+    assert Model(v=b'foobar').v == b'foobar'
+
+    with pytest.raises(ValidationError):
+        Model(v='foostring')
+
+    with pytest.raises(ValidationError):
+        Model(v=bytearray('foo', 'utf-8'))
+
+    with pytest.raises(ValidationError):
+        Model(v=123)
+
+
+def test_strict_bytes_subclass():
+    class MyStrictBytes(StrictBytes):
+        pass
+
+    class Model(BaseModel):
+        v: MyStrictBytes
+
+    m = Model(v=MyStrictBytes(b'foobar'))
+    assert isinstance(m.v, MyStrictBytes)
+    assert m.v == b'foobar'
 
 
 def test_strict_str():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Added `StrictBytes` type which rejects objects which are castable to bytes (ie. `int`, `float`, `str`), but which are not natively `bytes` type. All changes are modeled after `StrictStr`, `StrictInt`, `StrictFloat`, and `StrictBool` types.

<!-- Please give a short summary of the changes. -->

- Added `strict` option to `ConstrainedBytes` class. Default value of the option (`False`) respects downstream code continuity. Any initialization or subclass of `ConstrianedBytes` behaves identically to prior implementations unless the `"strict"` option is explicitly set to `True`).

- Added `strict_bytes_validator` which rejects any object which is not `Union[bytes, bytearray]` type. [Because `bytearray` instances are just mutable versions of `bytes`](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytearray-objects), we accept both as equivalent native `byte` types. This is noted explicitly since the builtin bytearray construtor creates objects with the following behavior:

```python
>>> isinstance(bytearray('foo', 'utf-8'), bytes)
False
```

## Related issue number

n/a

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
