### PR TITLE
fix: support `underscore_attrs_are_private` with generic models

### DIFF
--- a/changes/2138-PrettyWood.md
+++ b/changes/2138-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: support `underscore_attrs_are_private` with generic models

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -636,5 +636,6 @@ def is_valid_private_name(name: str) -> bool:
         '__classcell__',
         '__doc__',
         '__module__',
+        '__orig_bases__',
         '__qualname__',
     }

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -1,9 +1,13 @@
-from typing import ClassVar
+import sys
+from typing import ClassVar, Generic, TypeVar
 
 import pytest
 
 from pydantic import BaseModel, Extra, PrivateAttr
 from pydantic.fields import Undefined
+from pydantic.generics import GenericModel
+
+skip_36 = pytest.mark.skipif(sys.version_info < (3, 7), reason='generics only supported for python 3.7 and above')
 
 
 def test_private_attribute():
@@ -180,3 +184,19 @@ def test_config_override_init():
     m = MyModel(x='hello')
     assert m.dict() == {'x': 'hello'}
     assert m._private_attr == 123
+
+
+@skip_36
+def test_generic_private_attribute():
+    T = TypeVar('T')
+
+    class Model(GenericModel, Generic[T]):
+        value: T
+        _private_value: T
+
+        class Config:
+            underscore_attrs_are_private = True
+
+    m = Model[int](value=1, _private_attr=3)
+    m._private_value = 3
+    assert m.dict() == {'value': 1}


### PR DESCRIPTION
## Change Summary
`__orig_bases__` is not a valid field as it has been added in [PEP 560](https://www.python.org/dev/peps/pep-0560/) for generic classes

ℹ️ Fix to feature introduced by #1679 in v1.7.0

## Related issue number
closes #2138

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
