### PR TITLE
fix: set right default value for required (optional) fields

### DIFF
--- a/changes/2142-PrettyWood.md
+++ b/changes/2142-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: set right default value for required (optional) fields

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -307,7 +307,7 @@ class ModelField(Representation):
         required: 'BoolUndefined' = Undefined
         if value is Required:
             required = True
-            value = None
+            value = Ellipsis
         elif value is not Undefined:
             required = False
         field_info.alias = field_info.alias or field_info_from_config.get('alias')

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -406,7 +406,7 @@ def test_fields():
     fields = user.__pydantic_model__.__fields__
 
     assert fields['id'].required is True
-    assert fields['id'].default is None
+    assert fields['id'].default is Ellipsis
 
     assert fields['name'].required is False
     assert fields['name'].default == 'John Doe'
@@ -425,7 +425,7 @@ def test_default_factory_field():
     fields = user.__pydantic_model__.__fields__
 
     assert fields['id'].required is True
-    assert fields['id'].default is None
+    assert fields['id'].default is Ellipsis
 
     assert fields['aliases'].required is False
     assert fields['aliases'].default == {'John': 'Joey'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -958,6 +958,35 @@ def test_dict_exclude_unset_populated_by_alias_with_extra():
     assert m.dict(exclude_unset=True, by_alias=True) == {'alias_a': 'a', 'c': 'c'}
 
 
+def test_exclude_defaults():
+    class Model(BaseModel):
+        mandatory: str
+        nullable_mandatory: Optional[str] = ...
+        facultative: str = 'x'
+        nullable_facultative: Optional[str] = None
+
+    m = Model(mandatory='a', nullable_mandatory=None)
+    assert m.dict(exclude_defaults=True) == {
+        'mandatory': 'a',
+        'nullable_mandatory': None,
+    }
+
+    m = Model(mandatory='a', nullable_mandatory=None, facultative='y', nullable_facultative=None)
+    assert m.dict(exclude_defaults=True) == {
+        'mandatory': 'a',
+        'nullable_mandatory': None,
+        'facultative': 'y',
+    }
+
+    m = Model(mandatory='a', nullable_mandatory=None, facultative='y', nullable_facultative='z')
+    assert m.dict(exclude_defaults=True) == {
+        'mandatory': 'a',
+        'nullable_mandatory': None,
+        'facultative': 'y',
+        'nullable_facultative': 'z',
+    }
+
+
 def test_dir_fields():
     class MyModel(BaseModel):
         attribute_a: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
When a field was required, the default value was `None` and this would mess up with `dict(exclude_defaults=True)`.
Now we set the default value as `Ellipsis` (`...`), which is actually the real default value needed to make a field required.
This was not caught before because of missing test for this usecase.
But I feel like the refacto that introduced the bug and this fix make the whole code clearer and more coherent

ℹ️ Bug introduced by refacto done in #1755 and added in v1.7.0

## Related issue number
closes #2142
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
