### PR TITLE
chore: fix contributing steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install-benchmarks: install-pydantic
 	pip install -U -r benchmarks/requirements.txt
 
 .PHONY: install
-install: install-testing install-linting
+install: install-testing install-linting install-docs
 	@echo 'installed development requirements'
 
 .PHONY: build-trace

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,7 +33,7 @@ To make contributing as easy and fast as possible, you'll want to run tests and 
 *pydantic* has few dependencies, doesn't require compiling and tests don't need access to databases, etc.
 Because of this, setting up and running the tests should be very simple.
 
-You'll need to have **python 3.6**, **3.7**, or **3.8**, **virtualenv**, **git**, and **make** installed.
+You'll need to have **python 3.6**, **3.7**, **3.8**, or **3.9**, **virtualenv**, **git**, and **make** installed.
 
 ```bash
 # 1. clone your fork and cd into the repo directory
@@ -45,7 +45,7 @@ virtualenv -p `which python3.7` env
 source env/bin/activate
 # (or however you prefer to setup a python environment, 3.6 will work too)
 
-# 3. Install pydantic, dependencies and test dependencies
+# 3. Install pydantic, dependencies, test dependencies and doc dependencies
 make install
 
 # 4. Checkout a new branch and make your changes


### PR DESCRIPTION
## Change Summary
Following #2030, the requirements to build the documentation are not installed
with the rest making `make docs` crash when following the contributing steps.
As `make install` is only used for this purpose (easy onboarding), let's just add
again the installation of the doc requirements with it

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
