### PR TITLE
Add black config to pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := all
 isort = isort pydantic tests
-black = black -S -l 120 --target-version py38 pydantic tests
+black = black pydantic tests
 
 .PHONY: install-linting
 install-linting:

--- a/changes/2151-JacobHayes.md
+++ b/changes/2151-JacobHayes.md
@@ -1,0 +1,1 @@
+Add black config to pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+target-version = ['py38']


### PR DESCRIPTION
## Change Summary

Adds a `pyproject.toml` configuring `black` with the flags that were hard coded in the `Makefile`. This is particularly useful for text editor setups that format-on-write.

## Related issue number

N/A

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)