### PR TITLE
Add config to prioritize environment variables in BaseSettings

### DIFF
--- a/changes/2154-tomgrin10.md
+++ b/changes/2154-tomgrin10.md
@@ -1,0 +1,1 @@
+Add `env_has_priority` config to `BaseSettings` for prioritizing environment variables and secrets. 

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -208,3 +208,5 @@ the selected value is determined as follows (in descending order of priority):
 3. Variables loaded from a dotenv (`.env`) file.
 4. Variables loaded from the secrets directory.
 5. The default field values for the `Settings` model.
+
+

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -46,8 +46,7 @@ class BaseSettings(BaseModel):
     ) -> Dict[str, Any]:
         if self.__config__.env_has_priority:
             return deep_update(
-                init_kwargs, self._build_secrets_files(_secrets_dir),
-                self._build_environ(_env_file, _env_file_encoding)
+                init_kwargs, self._build_secrets_files(_secrets_dir), self._build_environ(_env_file, _env_file_encoding)
             )
         else:
             return deep_update(

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -44,9 +44,15 @@ class BaseSettings(BaseModel):
         _env_file_encoding: Optional[str] = None,
         _secrets_dir: Union[Path, str, None] = None,
     ) -> Dict[str, Any]:
-        return deep_update(
-            self._build_secrets_files(_secrets_dir), self._build_environ(_env_file, _env_file_encoding), init_kwargs
-        )
+        if self.__config__.env_has_priority:
+            return deep_update(
+                init_kwargs, self._build_secrets_files(_secrets_dir),
+                self._build_environ(_env_file, _env_file_encoding)
+            )
+        else:
+            return deep_update(
+                self._build_secrets_files(_secrets_dir), self._build_environ(_env_file, _env_file_encoding), init_kwargs
+            )
 
     def _build_secrets_files(self, _secrets_dir: Union[Path, str, None] = None) -> Dict[str, Optional[str]]:
         """
@@ -130,6 +136,7 @@ class BaseSettings(BaseModel):
         extra = Extra.forbid
         arbitrary_types_allowed = True
         case_sensitive = False
+        env_has_priority = False
 
         @classmethod
         def prepare_field(cls, field: ModelField) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -852,3 +852,15 @@ def test_secrets_dotenv_precedence(tmp_path):
             secrets_dir = tmp_path
 
     assert Settings(_env_file=e).dict() == {'foo': 'foo_env_value_str'}
+
+
+def test_env_has_priority(env):
+    env.set('FOO', "abc")
+
+    class Settings(BaseSettings):
+        foo: str
+
+        class Config:
+            env_has_priority = True
+
+    assert Settings(foo="123").foo == "abc"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -855,7 +855,7 @@ def test_secrets_dotenv_precedence(tmp_path):
 
 
 def test_env_has_priority(env):
-    env.set('FOO', "abc")
+    env.set('FOO', 'abc')
 
     class Settings(BaseSettings):
         foo: str
@@ -863,4 +863,4 @@ def test_env_has_priority(env):
         class Config:
             env_has_priority = True
 
-    assert Settings(foo="123").foo == "abc"
+    assert Settings(foo='123').foo == 'abc'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Added `env_has_priority` config option to `BaseSettings` class.
When set to `True`, the class will prioritize environment variables and secrets instead of constructor arguments.
<!-- Please give a short summary of the changes. -->

## Related issue number
Fixes #2014

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
