### PR TITLE
Tighten color regex

### DIFF
--- a/changes/2017-Zac-HD.md
+++ b/changes/2017-Zac-HD.md
@@ -1,0 +1,1 @@
+Update the regex patterns for RGB, RGBA, and HSL strings to match only valid colors.

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -45,13 +45,13 @@ class RGBA:
 # these are not compiled here to avoid import slowdown, they'll be compiled the first time they're used, then cached
 r_hex_short = r'\s*(?:#|0x)?([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])?\s*'
 r_hex_long = r'\s*(?:#|0x)?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?\s*'
-_r_255 = r'(\d{1,3}(?:\.\d+)?)'
+_r_255 = r'((?:\d|\d\d|[01]\d\d|2[0-4]\d|25[0-4])(?:\.\d+)?|255(?:\.0+)?)'
 _r_comma = r'\s*,\s*'
 r_rgb = fr'\s*rgb\(\s*{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_255}\)\s*'
-_r_alpha = r'(\d(?:\.\d+)?|\.\d+|\d{1,2}%)'
+_r_alpha = r'(0(?:\.\d+)?|1(?:\.0+)?|\.\d+|\d{1,2}%)'
 r_rgba = fr'\s*rgba\(\s*{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_255}{_r_comma}{_r_alpha}\s*\)\s*'
 _r_h = r'(-?\d+(?:\.\d+)?|-?\.\d+)(deg|rad|turn)?'
-_r_sl = r'(\d{1,3}(?:\.\d+)?)%'
+_r_sl = r'(\d\d?(?:\.\d+)?|100(?:\.0+)?)%'
 r_hsl = fr'\s*hsl\(\s*{_r_h}{_r_comma}{_r_sl}{_r_comma}{_r_sl}\s*\)\s*'
 r_hsla = fr'\s*hsl\(\s*{_r_h}{_r_comma}{_r_sl}{_r_comma}{_r_sl}{_r_comma}{_r_alpha}\s*\)\s*'
 


### PR DESCRIPTION
Update the regex patterns for RGB, RGBA, and HSL strings to match only valid colors.

This patch was extracted from #2097, where we use Hypothesis' `from_regex()` strategy to generate test inputs.  It will need to be merged before that PR, but is worth merging and documenting independently - strings like `rgb(300, 300, 300)` now fail to match the regex instead of raising an error later.

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change

There are no new tests for this change, because everything that used to work (or fail) still does work or fail respectively, and we maintain 100% coverage.