### PR TITLE
docs: add explicit example of lower camel-case alias generator

### DIFF
--- a/changes/2163-huonw.md
+++ b/changes/2163-huonw.md
@@ -1,0 +1,1 @@
+docs: add explicit example of lower camel-case alias generator

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -109,8 +109,13 @@ you can automatically generate aliases using `alias_generator`:
 _(This script is complete, it should run "as is")_
 
 Here camel case refers to ["upper camel case"](https://en.wikipedia.org/wiki/Camel_case) aka pascal case
-e.g. `CamelCase`. If you'd like instead to use lower camel case e.g. `camelCase`,
-it should be trivial to modify the `to_camel` function above.
+e.g. `CamelCase`. If you'd like instead to use lower camel case e.g. `camelCase`, an alternative version of `to_camel` might be:
+
+``` py
+def to_camel(string: str) -> str:
+    first, *rest = string.split("_")
+    return first + "".join(word.capitalize() for word in rest)
+```
 
 ## Alias Precedence
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Many APIs use lowerCamelCase for properties. This patch adjusts the
documentation to be explicit about an implementation of
`alias_generator` to automatically create such lower camel-case
aliases.  This hopefully simplifies things for users without making
the documentation significantly harder to understand.

(I totally understand if this isn't an overall improvement, I just feel that lowerCamelCase is likely to be a more common alias than UpperCamelCase or most other forms of aliases, and so is worth calling out.)

## Related issue number

N/A, since this is a small doc change.

## Checklist

* [x] (N/A) Unit tests for the changes exist
* [x] (N/A) Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
