### PR TITLE
fix: required fields default value is the same for static and dynamic models

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -307,7 +307,7 @@ class ModelField(Representation):
         required: 'BoolUndefined' = Undefined
         if value is Required:
             required = True
-            value = Ellipsis
+            value = None
         elif value is not Undefined:
             required = False
         field_info.alias = field_info.alias or field_info_from_config.get('alias')

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -788,12 +788,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         value_include = ValueItems(self, include) if include else None
 
         for field_key, v in self.__dict__.items():
-            if (
-                (allowed_keys is not None and field_key not in allowed_keys)
-                or (exclude_none and v is None)
-                or (exclude_defaults and getattr(self.__fields__.get(field_key), 'default', _missing) == v)
-            ):
+            if (allowed_keys is not None and field_key not in allowed_keys) or (exclude_none and v is None):
                 continue
+            if exclude_defaults:
+                model_field = self.__fields__.get(field_key)
+                if not getattr(model_field, 'required', True) and getattr(model_field, 'default', _missing) == v:
+                    continue
             if by_alias and field_key in self.__fields__:
                 dict_key = self.__fields__[field_key].alias
             else:

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -182,3 +182,15 @@ def test_repeat_base_usage():
     assert model.__fields__.keys() == {'a', 'b'}
     assert model2.__fields__.keys() == {'a', 'c'}
     assert model3.__fields__.keys() == {'a', 'b', 'd'}
+
+
+def test_dynamic_and_static():
+    class A(BaseModel):
+        x: int
+        y: float
+        z: str
+
+    DynamicA = create_model('A', x=(int, ...), y=(float, ...), z=(str, ...))
+
+    for field_name in ('x', 'y', 'z'):
+        assert A.__fields__[field_name].default == DynamicA.__fields__[field_name].default

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -407,7 +407,7 @@ def test_fields():
     fields = user.__pydantic_model__.__fields__
 
     assert fields['id'].required is True
-    assert fields['id'].default is Ellipsis
+    assert fields['id'].default is None
 
     assert fields['name'].required is False
     assert fields['name'].default == 'John Doe'
@@ -426,7 +426,7 @@ def test_default_factory_field():
     fields = user.__pydantic_model__.__fields__
 
     assert fields['id'].required is True
-    assert fields['id'].default is Ellipsis
+    assert fields['id'].default is None
 
     assert fields['aliases'].required is False
     assert fields['aliases'].default == {'John': 'Joey'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
I went a bit fast when fixing #2142.
The issue concerned the `exclude_defaults` param of `BaseModel.dict()` method. The bug appeared because `fields_defaults` has been [removed](https://github.com/samuelcolvin/pydantic/commit/4bc4230df6294c62667fc3779328019a28912147#diff-8708af8d26c26644976866f974e0b810b0940ede43ff487e457057d5a1f07999L218) recently.
I fixed the behaviour by setting the default value to `...` (aka `Ellipsis`) when a field is required.

**BUT** we now have a difference between statically created model and dynamically created model as shown in #2165.
- For dynamic models where we set `x=(int, ...)`, we set the `value` to `...` so [here](https://github.com/samuelcolvin/pydantic/blob/master/pydantic/fields.py#L308) `value` will remain `Ellipsis` (aka `Required`... I didn't need to set it again)
It used to be `None` before
- For static models, we set [in the metaclass](https://github.com/samuelcolvin/pydantic/blob/master/pydantic/main.py#L255) field value to `Undefined` by default, which will then be `None`.

@samuelcolvin 
IMO the best solution would be to use `...` instead of `Undefined` by default in the metaclass but it would probably be a breaking change that could be done for v2 
EDIT: Saw your [remark](https://github.com/samuelcolvin/pydantic/issues/990#issuecomment-558134788) in https://github.com/samuelcolvin/pydantic/issues/990. Glad we agree

This PR doesn't break anything and does what #2142 should have been

## Related issue number
closes #2165

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
