### PR TITLE
Fix url fragment without query

### DIFF
--- a/changes/2168-andrewmwhite.md
+++ b/changes/2168-andrewmwhite.md
@@ -1,0 +1,2 @@
+fix URL regex to parse fragment without query string
+

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -61,7 +61,7 @@ def url_regex() -> Pattern[str]:
             r'(?P<domain>[^\s/:?#]+)'  # domain, validation occurs later
             r')?'
             r'(?::(?P<port>\d+))?'  # port
-            r'(?P<path>/[^\s?]*)?'  # path
+            r'(?P<path>/[^\s?#]*)?'  # path
             r'(?:\?(?P<query>[^\s#]+))?'  # query
             r'(?:#(?P<fragment>\S+))?',  # fragment
             re.IGNORECASE,

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -199,6 +199,15 @@ def test_at_in_path():
     assert url.path == '/@handle'
 
 
+def test_fragment_without_query():
+    url = validate_url('https://pydantic-docs.helpmanual.io/usage/types/#constrained-types')
+    assert url.scheme == 'https'
+    assert url.host == 'pydantic-docs.helpmanual.io'
+    assert url.path == '/usage/types/'
+    assert url.query is None
+    assert url.fragment == 'constrained-types'
+
+
 @pytest.mark.parametrize(
     'value',
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Fixes the URL regex to correctly parse URLs with a fragment but no query string.

<!-- Please give a short summary of the changes. -->

## Related issue number

Fixes #2168

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] (n/a) Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
