### PR TITLE
Fixed KeyError when creating schema from models with same names declared within different classes

### DIFF
--- a/changes/1912-JSextonn.md
+++ b/changes/1912-JSextonn.md
@@ -1,0 +1,1 @@
+Fixed issue causing KeyError to be raised when building schema from multiple `BaseModel` with the same names declared in separate classes.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -395,7 +395,7 @@ def get_flat_models_from_models(models: Sequence[Type['BaseModel']]) -> TypeMode
 
 
 def get_long_model_name(model: TypeModelOrEnum) -> str:
-    return f'{model.__module__}__{model.__name__}'.replace('.', '__')
+    return f'{model.__module__}__{model.__qualname__}'.replace('.', '__')
 
 
 def field_type_schema(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2132,7 +2132,7 @@ class NestedModel(BaseModel):
         'ModelTwo',
         f'{module.__name__}__ModelOne__NestedModel',
         f'{module.__name__}__ModelTwo__NestedModel',
-        f'{module.__name__}__NestedModel'
+        f'{module.__name__}__NestedModel',
     }
     assert model_names == expected_model_names
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2097,3 +2097,19 @@ def test_new_type():
         'properties': {'a': {'title': 'A', 'type': 'string'}},
         'required': ['a'],
     }
+
+
+def test_multiple_nested_model_declarations_do_not_raise_error():
+    class ModelOne(BaseModel):
+        class NestedModel(BaseModel):
+            a: float
+
+        nested: NestedModel
+
+    class ModelTwo(BaseModel):
+        class NestedModel(BaseModel):
+            b: float
+
+        nested: NestedModel
+
+    schema([ModelOne, ModelTwo])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2105,11 +2105,13 @@ def test_multiple_models_with_same_name(create_module):
         """
 from pydantic import BaseModel
 
+
 class ModelOne(BaseModel):
     class NestedModel(BaseModel):
         a: float
 
     nested: NestedModel
+
 
 class ModelTwo(BaseModel):
     class NestedModel(BaseModel):
@@ -2117,9 +2119,10 @@ class ModelTwo(BaseModel):
 
     nested: NestedModel
 
+
 class NestedModel(BaseModel):
     c: float
- """
+        """
     )
 
     models = [module.ModelOne, module.ModelTwo, module.NestedModel]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2099,20 +2099,39 @@ def test_new_type():
     }
 
 
-def test_multiple_nested_model_declarations_do_not_raise_error():
-    class ModelOne(BaseModel):
-        class NestedModel(BaseModel):
-            a: float
+def test_multiple_models_with_same_name(create_module):
+    module = create_module(
+        # language=Python
+        """
+from pydantic import BaseModel
 
-        nested: NestedModel
+class ModelOne(BaseModel):
+    class NestedModel(BaseModel):
+        a: float
 
-    class ModelTwo(BaseModel):
-        class NestedModel(BaseModel):
-            b: float
+    nested: NestedModel
 
-        nested: NestedModel
+class ModelTwo(BaseModel):
+    class NestedModel(BaseModel):
+        b: float
 
-    schema([ModelOne, ModelTwo])
+    nested: NestedModel
+
+class NestedModel(BaseModel):
+    c: float
+ """
+    )
+
+    models = [module.ModelOne, module.ModelTwo, module.NestedModel]
+    model_names = set(schema(models)['definitions'].keys())
+    expected_model_names = {
+        f'ModelOne',
+        f'ModelTwo',
+        f'{module.__name__}__ModelOne__NestedModel',
+        f'{module.__name__}__ModelTwo__NestedModel',
+        f'{module.__name__}__NestedModel'
+    }
+    assert model_names == expected_model_names
 
 
 def test_multiple_enums_with_same_name(create_module):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2125,8 +2125,8 @@ class NestedModel(BaseModel):
     models = [module.ModelOne, module.ModelTwo, module.NestedModel]
     model_names = set(schema(models)['definitions'].keys())
     expected_model_names = {
-        f'ModelOne',
-        f'ModelTwo',
+        'ModelOne',
+        'ModelTwo',
         f'{module.__name__}__ModelOne__NestedModel',
         f'{module.__name__}__ModelTwo__NestedModel',
         f'{module.__name__}__NestedModel'


### PR DESCRIPTION
## Change Summary

Conflicting class names were being resolved but did not account for the possibility of classes to be declared within other classes. The resolving "long name" only consisted of the module and class name.

This PR updates the "long name" to be the full type name which does not lose the context required for distinguishing nested class declarations.

## Related issue number
closes #1912
closes #2225

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/1912-JSextonn.md` file added describing change
