### PR TITLE
Added expanded message for enum validation errors

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -223,7 +223,7 @@ class EnumMemberError(PydanticTypeError):
 
     def __str__(self) -> str:
         permitted = ', '.join(repr(v.value) for v in self.enum_values)  # type: ignore
-        return f'value <{self.attempted_value}> is not a valid enumeration member; permitted: {permitted}'
+        return f'value <{self.att_value}> is not a valid enumeration member; permitted: {permitted}'  # type: ignore
 
 
 class IntegerError(PydanticTypeError):

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -223,7 +223,7 @@ class EnumMemberError(PydanticTypeError):
 
     def __str__(self) -> str:
         permitted = ', '.join(repr(v.value) for v in self.enum_values)  # type: ignore
-        return f'value is not a valid enumeration member; permitted: {permitted}'
+        return f'Value <{self.attempted_value}> is not a valid enumeration member; permitted: {permitted}'
 
 
 class IntegerError(PydanticTypeError):

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -223,7 +223,7 @@ class EnumMemberError(PydanticTypeError):
 
     def __str__(self) -> str:
         permitted = ', '.join(repr(v.value) for v in self.enum_values)  # type: ignore
-        return f'Value <{self.attempted_value}> is not a valid enumeration member; permitted: {permitted}'
+        return f'value <{self.attempted_value}> is not a valid enumeration member; permitted: {permitted}'
 
 
 class IntegerError(PydanticTypeError):

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -269,7 +269,7 @@ def enum_member_validator(v: Any, field: 'ModelField', config: 'BaseConfig') -> 
         enum_v = field.type_(v)
     except ValueError:
         # field.type_ should be an enum, so will be iterable
-        raise errors.EnumMemberError(attempted_value=v, enum_values=list(field.type_))
+        raise errors.EnumMemberError(att_value=v, enum_values=list(field.type_))
     return enum_v.value if config.use_enum_values else enum_v
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -269,7 +269,7 @@ def enum_member_validator(v: Any, field: 'ModelField', config: 'BaseConfig') -> 
         enum_v = field.type_(v)
     except ValueError:
         # field.type_ should be an enum, so will be iterable
-        raise errors.EnumMemberError(enum_values=list(field.type_))
+        raise errors.EnumMemberError(attempted_value=v, enum_values=list(field.type_))
     return enum_v.value if config.use_enum_values else enum_v
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -723,7 +723,7 @@ def test_enum_fails():
             'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench], 'attempted_value': 3},
         }
     ]
-    assert len(exc_info.value.json()) == 217
+    assert len(exc_info.value.json()) == 249
 
 
 def test_int_enum_successful_for_str_int():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -720,7 +720,8 @@ def test_enum_fails():
             'loc': ('tool',),
             'msg': 'value <3> is not a valid enumeration member; permitted: 1, 2',
             'type': 'type_error.enum',
-            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench]},
+            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench],
+                    'attempted_value': 3},
         }
     ]
     assert len(exc_info.value.json()) == 217

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -718,7 +718,7 @@ def test_enum_fails():
     assert exc_info.value.errors() == [
         {
             'loc': ('tool',),
-            'msg': 'value is not a valid enumeration member; permitted: 1, 2',
+            'msg': 'value <3> is not a valid enumeration member; permitted: 1, 2',
             'type': 'type_error.enum',
             'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench]},
         }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -720,8 +720,7 @@ def test_enum_fails():
             'loc': ('tool',),
             'msg': 'value <3> is not a valid enumeration member; permitted: 1, 2',
             'type': 'type_error.enum',
-            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench],
-                    'attempted_value': 3},
+            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench], 'attempted_value': 3},
         }
     ]
     assert len(exc_info.value.json()) == 217

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -720,10 +720,10 @@ def test_enum_fails():
             'loc': ('tool',),
             'msg': 'value <3> is not a valid enumeration member; permitted: 1, 2',
             'type': 'type_error.enum',
-            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench], 'attempted_value': 3},
+            'ctx': {'enum_values': [ToolEnum.spanner, ToolEnum.wrench], 'att_value': 3},
         }
     ]
-    assert len(exc_info.value.json()) == 249
+    assert len(exc_info.value.json()) == 243
 
 
 def test_int_enum_successful_for_str_int():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This is a small change to add the attempted value that was not a valid member value to the exception string representation for an enum validation. This would have saved many hours of frustration in debugging when using pydantic with third party APIs

