### PR TITLE
Propagate`ClassVar`s to sub-models

### DIFF
--- a/changes/2061-layday.md
+++ b/changes/2061-layday.md
@@ -1,0 +1,1 @@
+allow overwriting `ClassVar`s in sub-models without having to re-annotate them

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -531,9 +531,15 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
     Moreover if you want to validate default values with `validate_all`,
     *pydantic* will need to call the `default_factory`, which could lead to side effects!
 
+## Automatically excluded attributes
+
+Class variables which begin with an underscore and attributes annotated with `typing.ClassVar` will be
+automatically excluded from the model.
+
 ## Private model attributes
 
-If you need to use internal attributes excluded from model fields, you can declare them using `PrivateAttr`:
+If you need to vary or manipulate internal attributes on instances of the model, you can declare them
+using `PrivateAttr`:
 
 ```py
 {!.tmp_examples/private_attributes.py!}

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -16,7 +16,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -216,8 +215,9 @@ class ModelMetaclass(ABCMeta):
 
         pre_root_validators, post_root_validators = [], []
         private_attributes: Dict[str, ModelPrivateAttr] = {}
-        slots: Set[str] = namespace.get('__slots__', ())
+        slots: SetStr = namespace.get('__slots__', ())
         slots = {slots} if isinstance(slots, str) else set(slots)
+        class_vars: SetStr = set()
 
         for base in reversed(bases):
             if _is_base_model_class_defined and issubclass(base, BaseModel) and base != BaseModel:
@@ -227,6 +227,7 @@ class ModelMetaclass(ABCMeta):
                 pre_root_validators += base.__pre_root_validators__
                 post_root_validators += base.__post_root_validators__
                 private_attributes.update(base.__private_attributes__)
+                class_vars.update(base.__class_vars__)
 
         config = inherit_config(namespace.get('Config'), config)
         validators = inherit_validators(extract_validators(namespace), validators)
@@ -242,7 +243,6 @@ class ModelMetaclass(ABCMeta):
 
         prepare_config(config, name)
 
-        class_vars = set()
         if (namespace.get('__module__'), namespace.get('__qualname__')) != ('pydantic.main', 'BaseModel'):
             annotations = resolve_annotations(namespace.get('__annotations__', {}), namespace.get('__module__', None))
             untouched_types = UNTOUCHED_TYPES + config.keep_untouched
@@ -318,6 +318,7 @@ class ModelMetaclass(ABCMeta):
             '__custom_root_type__': _custom_root_type,
             '__private_attributes__': private_attributes,
             '__slots__': slots | private_attributes.keys(),
+            '__class_vars__': class_vars,
             **{n: v for n, v in namespace.items() if n not in exclude_from_namespace},
         }
 
@@ -344,6 +345,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         __custom_root_type__: bool = False
         __signature__: 'Signature'
         __private_attributes__: Dict[str, Any]
+        __class_vars__: SetStr
         __fields_set__: SetStr = set()
 
     Config = BaseConfig

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -908,6 +908,12 @@ def test_class_var():
 
     assert list(MyModel.__fields__.keys()) == ['c']
 
+    class MyOtherModel(MyModel):
+        a = ''
+        b = 2
+
+    assert list(MyOtherModel.__fields__.keys()) == ['c']
+
 
 def test_fields_set():
     class MyModel(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Currently, if a `ClassVar` is defined on a model and re-defined
on a sub-model omitting the `ClassVar` annotation, Pydantic produces an
unrelated error:

    NameError: Field name "..." shadows a BaseModel attribute ...

This check was introduced to prevent shadowing Pydantic's own methods
and attributes defined on the `BaseModel` class.  Following this change,
class variables (that is, variables annotated with `ClassVar`)
defined on parent models will be inherited by sub-models and
will be overwritable without having to reapply the annotation.

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #2061

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
