### PR TITLE
fix: ensure to always return one of the values in `Literal` field type

### DIFF
--- a/changes/2166-PrettyWood.md
+++ b/changes/2166-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: ensure to always return one of the values in `Literal` field type

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -443,9 +443,13 @@ def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
     allowed_choices_set = set(permitted_choices)
 
     def literal_validator(v: Any) -> Any:
-        if v not in allowed_choices_set:
+        # Ensure to return the value in `Literal`, not the passed value
+        # In some cases they can indeed be different (see `test_literal_validator_str_enum`)
+        for x in allowed_choices_set:
+            if v == x:
+                return x
+        else:
             raise errors.WrongConstantError(given=v, permitted=permitted_choices)
-        return v
 
     return literal_validator
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -440,15 +440,17 @@ def int_enum_validator(v: Any) -> IntEnum:
 
 def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
     permitted_choices = all_literal_values(type_)
-    allowed_choices_set = set(permitted_choices)
+
+    # To have a O(1) complexity and still return one of the values set inside the `Literal`,
+    # we create a dict with the set values (a set causes some problems with the way intersection works).
+    # In some cases the set value and checked value can indeed be different (see `test_literal_validator_str_enum`)
+    allowed_choices = {v: v for v in permitted_choices}
 
     def literal_validator(v: Any) -> Any:
-        # Ensure to return the value in `Literal`, not the passed value
-        # In some cases they can indeed be different (see `test_literal_validator_str_enum`)
-        intersection = {v} & allowed_choices_set  # order of operands matters
-        if not intersection:
+        try:
+            return allowed_choices[v]
+        except KeyError:
             raise errors.WrongConstantError(given=v, permitted=permitted_choices)
-        return intersection.pop()
 
     return literal_validator
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -445,11 +445,10 @@ def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
     def literal_validator(v: Any) -> Any:
         # Ensure to return the value in `Literal`, not the passed value
         # In some cases they can indeed be different (see `test_literal_validator_str_enum`)
-        for x in allowed_choices_set:
-            if v == x:
-                return x
-        else:
+        intersection = {v} & allowed_choices_set  # order of operands matters
+        if not intersection:
             raise errors.WrongConstantError(given=v, permitted=permitted_choices)
+        return intersection.pop()
 
     return literal_validator
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,6 @@
 from collections import deque
 from datetime import datetime
+from enum import Enum
 from itertools import product
 from typing import Dict, List, Optional, Tuple
 
@@ -1133,6 +1134,21 @@ def test_literal_validator():
             'ctx': {'given': 'nope', 'permitted': ('foo',)},
         }
     ]
+
+
+@pytest.mark.skipif(not Literal, reason='typing_extensions not installed')
+def test_literal_validator_str_enum():
+    class Bar(str, Enum):
+        FIZ = 'fiz'
+        FUZ = 'fuz'
+
+    class Foo(BaseModel):
+        bar: Bar
+        barfiz: Literal[Bar.FIZ]
+
+    my_foo = Foo.parse_obj({'bar': 'fiz', 'barfiz': 'fiz'})
+    assert my_foo.bar is Bar.FIZ
+    assert my_foo.barfiz is Bar.FIZ
 
 
 @pytest.mark.skipif(not Literal, reason='typing_extensions not installed')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1145,10 +1145,17 @@ def test_literal_validator_str_enum():
     class Foo(BaseModel):
         bar: Bar
         barfiz: Literal[Bar.FIZ]
+        fizfuz: Literal[Bar.FIZ, Bar.FUZ]
 
-    my_foo = Foo.parse_obj({'bar': 'fiz', 'barfiz': 'fiz'})
+    my_foo = Foo.parse_obj({'bar': 'fiz', 'barfiz': 'fiz', 'fizfuz': 'fiz'})
     assert my_foo.bar is Bar.FIZ
     assert my_foo.barfiz is Bar.FIZ
+    assert my_foo.fizfuz is Bar.FIZ
+
+    my_foo = Foo.parse_obj({'bar': 'fiz', 'barfiz': 'fiz', 'fizfuz': 'fuz'})
+    assert my_foo.bar is Bar.FIZ
+    assert my_foo.barfiz is Bar.FIZ
+    assert my_foo.fizfuz is Bar.FUZ
 
 
 @pytest.mark.skipif(not Literal, reason='typing_extensions not installed')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Ensure we always return a value set in `Literal` even though other values are equal (for example a `StrEnum` where a string **can be equal to a enum member but not identical**)

## Related issue number
closes #2166
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
