### PR TITLE
fix: stdlib dataclass converted into pydantic dataclass still equal its stdlib dataclass equivalent

### DIFF
--- a/changes/2162-PrettyWood.md
+++ b/changes/2162-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: stdlib `dataclass` converted into _pydantic_ `dataclass` still equals its stdlib `dataclass` equivalent

--- a/docs/examples/dataclasses_stdlib_to_pydantic_equality.py
+++ b/docs/examples/dataclasses_stdlib_to_pydantic_equality.py
@@ -1,0 +1,14 @@
+import dataclasses
+
+import pydantic
+
+
+@dataclasses.dataclass
+class StdlibUser:
+    name: str
+    age: int
+
+
+PydanticUser = pydantic.dataclasses.dataclass(StdlibUser)
+
+assert StdlibUser(name='pika', age=7) == PydanticUser(name='pika', age='7')

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -59,6 +59,14 @@ them with `pydantic.dataclasses.dataclass`.
 ```
 _(This script is complete, it should run "as is")_
 
+!!! note
+    A _pydantic_ dataclass converted from a stdlib dataclass will still equal its stdlib dataclass equivalent
+
+```py
+{!.tmp_examples/dataclasses_stdlib_to_pydantic_equality.py!}
+```
+_(This script is complete, it should run "as is")_
+
 ### Inherit from stdlib dataclasses
 
 Stdlib dataclasses (nested or not) can also be inherited and _pydantic_ will automatically validate


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
closes #2162
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
