### PR TITLE
Feature/add anystr lower to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ install-linting:
 
 .PHONY: install-pydantic
 install-pydantic:
-	python -m pip install -U wheel pip
+	@echo 'temporarily pin pip to 20.2 while the issues with 20.3 get ironed out'
+	python -m pip install -U wheel pip==20.2
 	pip install -r requirements.txt
 	SKIP_CYTHON=1 pip install -e .
 

--- a/changes/2134-tayoogunbiyi.md
+++ b/changes/2134-tayoogunbiyi.md
@@ -1,1 +1,1 @@
-* added `Config.anystr_lower` and `lower_str` kwarg to `constr`.
+added `Config.anystr_lower` and `lower_str` kwarg to `constr`.

--- a/changes/2134-tayoogunbiyi.md
+++ b/changes/2134-tayoogunbiyi.md
@@ -1,0 +1,1 @@
+* added `Config.anystr_lower` and `lower_str` kwarg to `constr`.

--- a/changes/2134-tayoogunbiyi.md
+++ b/changes/2134-tayoogunbiyi.md
@@ -1,1 +1,1 @@
-added `Config.anystr_lower` and `lower_str` kwarg to `constr`.
+added `Config.anystr_lower` and `to_lower` kwarg to `constr`.

--- a/docs/examples/types_constrained.py
+++ b/docs/examples/types_constrained.py
@@ -22,9 +22,11 @@ from pydantic import (
 
 
 class Model(BaseModel):
+    lower_bytes: conbytes(to_lower=True)
     short_bytes: conbytes(min_length=2, max_length=10)
     strip_bytes: conbytes(strip_whitespace=True)
 
+    lower_str: constr(to_lower=True)
     short_str: constr(min_length=2, max_length=10)
     regex_str: constr(regex=r'^apple (pie|tart|sandwich)$')
     strip_str: constr(strip_whitespace=True)

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -8,6 +8,9 @@ Options:
 **`anystr_strip_whitespace`**
 : whether to strip leading and trailing whitespace for str & byte types (default: `False`)
 
+**`anystr_lower`**
+: whether to make all characters lowercase for str & byte types (default: `False`)
+
 **`min_anystr_length`**
 : the min length for str & byte types (default: `0`)
 

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -727,7 +727,7 @@ The following arguments are available when using the `constr` type function
 - `strict: bool = False`: controls type coercion
 - `min_length: int = None`: minimum length of the string
 - `max_length`: maximum length of the string
-- `curtail_length`: restricts the strings length
+- `curtail_length`: shrinks the string length to the set value when it is longer than the set value
 - `regex: str = None`: regex to validate the string against
 
 ### Arguments to `conbytes`

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -722,21 +722,21 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
 ### Arguments to `constr`
 The following arguments are available when using the `constr` type function
 
--  `strip_whitespace: bool = False`: removes leading and trailing whitespace
-- `to_lower: bool = False`: turns all characters to lowercase
-- `strict: bool = False`: controls type coercion
-- `min_length: int = None`: minimum length of the string
-- `max_length`: maximum length of the string
-- `curtail_length`: shrinks the string length to the set value when it is longer than the set value
-- `regex: str = None`: regex to validate the string against
+-`strip_whitespace: bool = False`: removes leading and trailing whitespace
+-`to_lower: bool = False`: turns all characters to lowercase
+-`strict: bool = False`: controls type coercion
+-`min_length: int = None`: minimum length of the string
+-`max_length: int = None`: maximum length of the string
+-`curtail_length: int = None`: shrinks the string length to the set value when it is longer than the set value
+-`regex: str = None`: regex to validate the string against
 
 ### Arguments to `conbytes`
 The following arguments are available when using the `conbytes` type function
 
--  `strip_whitespace: bool = False`: removes leading and trailing whitespace
-- `to_lower: bool = False`: turns all characters to lowercase
-- `min_length: int = None`: minimum length of the byte string
-- `max_length`: maximum length of the byte string
+-`strip_whitespace: bool = False`: removes leading and trailing whitespace
+-`to_lower: bool = False`: turns all characters to lowercase
+-`min_length: int = None`: minimum length of the byte string
+-`max_length: int = None`: maximum length of the byte string
 
 ## Strict Types
 

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -719,6 +719,25 @@ _(This script is complete, it should run "as is")_
 
 Where `Field` refers to the [field function](schema.md#field-customisation).
 
+### Arguments to `constr`
+The following arguments are available when using the `constr` type function
+
+-  `strip_whitespace: bool = False`: removes leading and trailing whitespace
+- `to_lower: bool = False`: turns all characters to lowercase
+- `strict: bool = False`: controls type coercion
+- `min_length: int = None`: minimum length of the string
+- `max_length`: maximum length of the string
+- `curtail_length`: restricts the strings length
+- `regex: str = None`: regex to validate the string against
+
+### Arguments to `conbytes`
+The following arguments are available when using the `conbytes` type function
+
+-  `strip_whitespace: bool = False`: removes leading and trailing whitespace
+- `to_lower: bool = False`: turns all characters to lowercase
+- `min_length: int = None`: minimum length of the byte string
+- `max_length`: maximum length of the byte string
+
 ## Strict Types
 
 You can use the `StrictStr`, `StrictBytes`, `StrictInt`, `StrictFloat`, and `StrictBool` types 

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -722,21 +722,21 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
 ### Arguments to `constr`
 The following arguments are available when using the `constr` type function
 
--`strip_whitespace: bool = False`: removes leading and trailing whitespace
--`to_lower: bool = False`: turns all characters to lowercase
--`strict: bool = False`: controls type coercion
--`min_length: int = None`: minimum length of the string
--`max_length: int = None`: maximum length of the string
--`curtail_length: int = None`: shrinks the string length to the set value when it is longer than the set value
--`regex: str = None`: regex to validate the string against
+- `strip_whitespace: bool = False`: removes leading and trailing whitespace
+- `to_lower: bool = False`: turns all characters to lowercase
+- `strict: bool = False`: controls type coercion
+- `min_length: int = None`: minimum length of the string
+- `max_length: int = None`: maximum length of the string
+- `curtail_length: int = None`: shrinks the string length to the set value when it is longer than the set value
+- `regex: str = None`: regex to validate the string against
 
 ### Arguments to `conbytes`
 The following arguments are available when using the `conbytes` type function
 
--`strip_whitespace: bool = False`: removes leading and trailing whitespace
--`to_lower: bool = False`: turns all characters to lowercase
--`min_length: int = None`: minimum length of the byte string
--`max_length: int = None`: maximum length of the byte string
+- `strip_whitespace: bool = False`: removes leading and trailing whitespace
+- `to_lower: bool = False`: turns all characters to lowercase
+- `min_length: int = None`: minimum length of the byte string
+- `max_length: int = None`: maximum length of the byte string
 
 ## Strict Types
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -106,6 +106,7 @@ class Extra(str, Enum):
 
 class BaseConfig:
     title = None
+    anystr_lower = False
     anystr_strip_whitespace = False
     min_anystr_length = None
     max_anystr_length = None

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -134,9 +134,13 @@ class StrictBytes(ConstrainedBytes):
     strict = True
 
 
-def conbytes(*, strip_whitespace: bool = False, min_length: int = None, max_length: int = None) -> Type[bytes]:
+def conbytes(
+    *, strip_whitespace: bool = False, lower_str: bool = False, min_length: int = None, max_length: int = None
+) -> Type[bytes]:
     # use kwargs then define conf in a dict to aid with IDE type hinting
-    namespace = dict(strip_whitespace=strip_whitespace, min_length=min_length, max_length=max_length)
+    namespace = dict(
+        strip_whitespace=strip_whitespace, lower_str=lower_str, min_length=min_length, max_length=max_length
+    )
     return type('ConstrainedBytesValue', (ConstrainedBytes,), namespace)
 
 
@@ -262,6 +266,7 @@ class ConstrainedStr(str):
 def constr(
     *,
     strip_whitespace: bool = False,
+    lower_str: bool = False,
     strict: bool = False,
     min_length: int = None,
     max_length: int = None,
@@ -271,6 +276,7 @@ def constr(
     # use kwargs then define conf in a dict to aid with IDE type hinting
     namespace = dict(
         strip_whitespace=strip_whitespace,
+        lower_str=lower_str,
         strict=strict,
         min_length=min_length,
         max_length=max_length,

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -113,7 +113,7 @@ if TYPE_CHECKING:
 
 class ConstrainedBytes(bytes):
     strip_whitespace = False
-    lower_str = False
+    to_lower = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
     strict: bool = False
@@ -135,12 +135,10 @@ class StrictBytes(ConstrainedBytes):
 
 
 def conbytes(
-    *, strip_whitespace: bool = False, lower_str: bool = False, min_length: int = None, max_length: int = None
+    *, strip_whitespace: bool = False, to_lower: bool = False, min_length: int = None, max_length: int = None
 ) -> Type[bytes]:
     # use kwargs then define conf in a dict to aid with IDE type hinting
-    namespace = dict(
-        strip_whitespace=strip_whitespace, lower_str=lower_str, min_length=min_length, max_length=max_length
-    )
+    namespace = dict(strip_whitespace=strip_whitespace, to_lower=to_lower, min_length=min_length, max_length=max_length)
     return type('ConstrainedBytesValue', (ConstrainedBytes,), namespace)
 
 
@@ -230,7 +228,7 @@ def conset(item_type: Type[T], *, min_items: int = None, max_items: int = None) 
 
 class ConstrainedStr(str):
     strip_whitespace = False
-    lower_str = False
+    to_lower = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
     curtail_length: OptionalInt = None
@@ -266,7 +264,7 @@ class ConstrainedStr(str):
 def constr(
     *,
     strip_whitespace: bool = False,
-    lower_str: bool = False,
+    to_lower: bool = False,
     strict: bool = False,
     min_length: int = None,
     max_length: int = None,
@@ -276,7 +274,7 @@ def constr(
     # use kwargs then define conf in a dict to aid with IDE type hinting
     namespace = dict(
         strip_whitespace=strip_whitespace,
-        lower_str=lower_str,
+        to_lower=to_lower,
         strict=strict,
         min_length=min_length,
         max_length=max_length,

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -28,6 +28,7 @@ from .utils import import_string, update_not_none
 from .validators import (
     bytes_validator,
     constr_length_validator,
+    constr_lower,
     constr_strip_whitespace,
     decimal_validator,
     float_validator,
@@ -112,6 +113,7 @@ if TYPE_CHECKING:
 
 class ConstrainedBytes(bytes):
     strip_whitespace = False
+    lower_str = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
     strict: bool = False
@@ -124,6 +126,7 @@ class ConstrainedBytes(bytes):
     def __get_validators__(cls) -> 'CallableGenerator':
         yield strict_bytes_validator if cls.strict else bytes_validator
         yield constr_strip_whitespace
+        yield constr_lower
         yield constr_length_validator
 
 
@@ -223,6 +226,7 @@ def conset(item_type: Type[T], *, min_items: int = None, max_items: int = None) 
 
 class ConstrainedStr(str):
     strip_whitespace = False
+    lower_str = False
     min_length: OptionalInt = None
     max_length: OptionalInt = None
     curtail_length: OptionalInt = None
@@ -239,6 +243,7 @@ class ConstrainedStr(str):
     def __get_validators__(cls) -> 'CallableGenerator':
         yield strict_str_validator if cls.strict else str_validator
         yield constr_strip_whitespace
+        yield constr_lower
         yield constr_length_validator
         yield cls.validate
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -479,7 +479,7 @@ def constr_strip_whitespace(v: 'StrBytes', field: 'ModelField', config: 'BaseCon
 def constr_lower(v: 'StrBytes', field: 'ModelField', config: 'BaseConfig') -> 'StrBytes':
     lower = field.type_.lower_str or config.anystr_lower
     if lower:
-        v = v.strip()
+        v = v.lower()
     return v
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -562,6 +562,7 @@ _VALIDATORS: List[Tuple[Type[Any], List[Any]]] = [
         [
             bytes_validator,
             IfConfig(anystr_strip_whitespace, 'anystr_strip_whitespace'),
+            IfConfig(anystr_lower, 'anystr_lower'),
             IfConfig(anystr_length_validator, 'min_anystr_length', 'max_anystr_length'),
         ],
     ),

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -477,7 +477,7 @@ def constr_strip_whitespace(v: 'StrBytes', field: 'ModelField', config: 'BaseCon
 
 
 def constr_lower(v: 'StrBytes', field: 'ModelField', config: 'BaseConfig') -> 'StrBytes':
-    lower = field.type_.lower_str or config.anystr_lower
+    lower = field.type_.to_lower or config.anystr_lower
     if lower:
         v = v.lower()
     return v

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -199,6 +199,10 @@ def anystr_strip_whitespace(v: 'StrBytes') -> 'StrBytes':
     return v.strip()
 
 
+def anystr_lower(v: 'StrBytes') -> 'StrBytes':
+    return v.lower()
+
+
 def ordered_dict_validator(v: Any) -> 'AnyOrderedDict':
     if isinstance(v, OrderedDict):
         return v
@@ -472,6 +476,13 @@ def constr_strip_whitespace(v: 'StrBytes', field: 'ModelField', config: 'BaseCon
     return v
 
 
+def constr_lower(v: 'StrBytes', field: 'ModelField', config: 'BaseConfig') -> 'StrBytes':
+    lower = field.type_.lower_str or config.anystr_lower
+    if lower:
+        v = v.strip()
+    return v
+
+
 def validate_json(v: Any, config: 'BaseConfig') -> Any:
     if v is None:
         # pass None through to other validators
@@ -542,6 +553,7 @@ _VALIDATORS: List[Tuple[Type[Any], List[Any]]] = [
         [
             str_validator,
             IfConfig(anystr_strip_whitespace, 'anystr_strip_whitespace'),
+            IfConfig(anystr_lower, 'anystr_lower'),
             IfConfig(anystr_length_validator, 'min_anystr_length', 'max_anystr_length'),
         ],
     ),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -114,7 +114,7 @@ def test_constrained_bytes_too_long():
 
 def test_constrained_bytes_lower_enabled():
     class Model(BaseModel):
-        v: conbytes(lower_str=True)
+        v: conbytes(to_lower=True)
 
     m = Model(v=b'ABCD')
     assert m.v == b'abcd'
@@ -122,7 +122,7 @@ def test_constrained_bytes_lower_enabled():
 
 def test_constrained_bytes_lower_disabled():
     class Model(BaseModel):
-        v: conbytes(lower_str=False)
+        v: conbytes(to_lower=False)
 
     m = Model(v=b'ABCD')
     assert m.v == b'ABCD'
@@ -464,7 +464,7 @@ def test_constrained_str_too_long():
 
 def test_constrained_str_lower_enabled():
     class Model(BaseModel):
-        v: constr(lower_str=True)
+        v: constr(to_lower=True)
 
     m = Model(v='ABCD')
     assert m.v == 'abcd'
@@ -472,7 +472,7 @@ def test_constrained_str_lower_enabled():
 
 def test_constrained_str_lower_disabled():
     class Model(BaseModel):
-        v: constr(lower_str=False)
+        v: constr(to_lower=False)
 
     m = Model(v='ABCD')
     assert m.v == 'ABCD'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1521,6 +1521,34 @@ def test_anystr_strip_whitespace_disabled():
     assert m.bytes_check == b'  456  '
 
 
+def test_anystr_lower_enabled():
+    class Model(BaseModel):
+        str_check: str
+        bytes_check: bytes
+
+        class Config:
+            anystr_lower = True
+
+    m = Model(str_check='ABCDefG', bytes_check=b'abCD1Fg')
+
+    assert m.str_check == 'abcdefg'
+    assert m.bytes_check == b'abcd1fg'
+
+
+def test_anystr_lower_disabled():
+    class Model(BaseModel):
+        str_check: str
+        bytes_check: bytes
+
+        class Config:
+            anystr_lower = False
+
+    m = Model(str_check='ABCDefG', bytes_check=b'abCD1Fg')
+
+    assert m.str_check == 'ABCDefG'
+    assert m.bytes_check == b'abCD1Fg'
+
+
 @pytest.mark.parametrize(
     'type_,value,result',
     [

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -112,6 +112,22 @@ def test_constrained_bytes_too_long():
     ]
 
 
+def test_constrained_bytes_lower_enabled():
+    class Model(BaseModel):
+        v: conbytes(lower_str=True)
+
+    m = Model(v=b'ABCD')
+    assert m.v == b'abcd'
+
+
+def test_constrained_bytes_lower_disabled():
+    class Model(BaseModel):
+        v: conbytes(lower_str=False)
+
+    m = Model(v=b'ABCD')
+    assert m.v == b'ABCD'
+
+
 def test_constrained_list_good():
     class ConListModelMax(BaseModel):
         v: conlist(int) = []
@@ -444,6 +460,22 @@ def test_constrained_str_too_long():
             'ctx': {'limit_value': 10},
         }
     ]
+
+
+def test_constrained_str_lower_enabled():
+    class Model(BaseModel):
+        v: constr(lower_str=True)
+
+    m = Model(v='ABCD')
+    assert m.v == 'abcd'
+
+
+def test_constrained_str_lower_disabled():
+    class Model(BaseModel):
+        v: constr(lower_str=False)
+
+    m = Model(v='ABCD')
+    assert m.v == 'ABCD'
 
 
 def test_module_import():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This change adds the anystr_lower field to the BaseConfig class, allowing users to ensure all string fields are kept as lower case.

## Related issue number

fix #2134

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change