### PR TITLE
feat: added port validation feature and tests

### DIFF
--- a/changes/2186-NicholasTing.md
+++ b/changes/2186-NicholasTing.md
@@ -1,1 +1,1 @@
-feat: Added port validation
+feat: Added port validation 0 - 65535 inclusive

--- a/changes/2186-NicholasTing.md
+++ b/changes/2186-NicholasTing.md
@@ -1,0 +1,1 @@
+feat: Added port validation

--- a/docs/build/schema_mapping.py
+++ b/docs/build/schema_mapping.py
@@ -369,6 +369,13 @@ table = [
         'Any argument not passed to the function (not defined) will not be included in the schema.'
     ],
     [
+        'Port',
+        'integer',
+        {'minimum': 0, 'maximum': 65535},
+        'JSON Schema Validation',
+        ''
+    ],
+    [
         'PositiveInt',
         'integer',
         {'exclusiveMinimum': 0},

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -465,6 +465,10 @@ _(This script is complete, it should run "as is")_
 `SecretStr`
 : string where the value is kept partially secret; see [Secrets](#secret-types)
 
+`Port`
+: type method for standard port numbers (between 0 and 65535 inclusive)
+  
+
 `IPvAnyAddress`
 : allows either an `IPv4Address` or an `IPv6Address`
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -74,6 +74,7 @@ __all__ = [
     'PyObject',
     'ConstrainedInt',
     'conint',
+    'Port',
     'PositiveInt',
     'NegativeInt',
     'NonNegativeInt',

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -62,6 +62,7 @@ __all__ = [
     'PyObject',
     'ConstrainedInt',
     'conint',
+    'Port',
     'PositiveInt',
     'NegativeInt',
     'NonNegativeInt',
@@ -384,6 +385,11 @@ def conint(
 
 class PositiveInt(ConstrainedInt):
     gt = 0
+
+
+class Port(ConstrainedInt):
+    ge = 0
+    le = 65535
 
 
 class NegativeInt(ConstrainedInt):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -46,6 +46,7 @@ from pydantic.types import (
     NonNegativeInt,
     NonPositiveFloat,
     NonPositiveInt,
+    Port,
     PositiveFloat,
     PositiveInt,
     PyObject,
@@ -787,6 +788,7 @@ def test_secret_types(field_type, inner_type):
         (NegativeInt, {'exclusiveMaximum': 0}),
         (NonNegativeInt, {'minimum': 0}),
         (NonPositiveInt, {'maximum': 0}),
+        (Port, {'minimum': 0, 'maximum': 65535}),
     ],
 )
 def test_special_int_types(field_type, expected_schema):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -47,6 +47,7 @@ from pydantic import (
     NonNegativeInt,
     NonPositiveFloat,
     NonPositiveInt,
+    Port,
     PositiveFloat,
     PositiveInt,
     PyObject,
@@ -1177,6 +1178,31 @@ def test_sequence_fails(cls, value, errors):
     with pytest.raises(ValidationError) as exc_info:
         Model(v=value)
     assert exc_info.value.errors() == errors
+
+
+def test_port_validation():
+    class Model(BaseModel):
+        a: Port = None
+        b: Port = None
+
+    m = Model(a=0, b=65535)
+    assert m == {'a': 0, 'b': 65535}
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a=-99999, b=99999)
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('a',),
+            'msg': 'ensure this value is greater than or equal to 0',
+            'type': 'value_error.number.not_ge',
+            'ctx': {'limit_value': 0},
+        },
+        {
+            'loc': ('b',),
+            'msg': 'ensure this value is less than or equal to 65535',
+            'type': 'value_error.number.not_le',
+            'ctx': {'limit_value': 65535},
+        },
+    ]
 
 
 def test_int_validation():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Added port validation ( 0 - 65535 inclusive ) because it makes sense to validate the port number since you have IP Validation as well.

## Related issue number

No

## Checklist

* [✅] Unit tests for the changes exist
* [✅] Tests pass on CI and coverage remains at 100%
* [✅] Documentation reflects the changes where applicable
* [✅] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
