### PR TITLE
fix(settings): stop using `Config.env_prefix` for secrets in `BaseSettings`

### DIFF
--- a/changes/2188-PrettyWood.md
+++ b/changes/2188-PrettyWood.md
@@ -1,0 +1,1 @@
+Stop using `Config.env_prefix` for secrets in `BaseSettings`

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -66,15 +66,14 @@ class BaseSettings(BaseModel):
             raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(secrets_path)}')
 
         for field in self.__fields__.values():
-            for env_name in {field.name}:
-                path = secrets_path / env_name
-                if path.is_file():
-                    secrets[field.alias] = path.read_text().strip()
-                elif path.exists():
-                    warnings.warn(
-                        f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
-                        stacklevel=4,
-                    )
+            path = secrets_path / field.name
+            if path.is_file():
+                secrets[field.alias] = path.read_text().strip()
+            elif path.exists():
+                warnings.warn(
+                    f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
+                    stacklevel=4,
+                )
 
         return secrets
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -66,7 +66,7 @@ class BaseSettings(BaseModel):
             raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(secrets_path)}')
 
         for field in self.__fields__.values():
-            for env_name in field.field_info.extra['env_names']:
+            for env_name in {field.name}:
                 path = secrets_path / env_name
                 if path.is_file():
                     secrets[field.alias] = path.read_text().strip()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -852,3 +852,20 @@ def test_secrets_dotenv_precedence(tmp_path):
             secrets_dir = tmp_path
 
     assert Settings(_env_file=e).dict() == {'foo': 'foo_env_value_str'}
+
+
+def test_mix_env_variables_secrets(tmp_path, env):
+    p = tmp_path / 'foo'
+    p.write_text('foo_secret_value_str')
+
+    class Settings(BaseSettings):
+        foo: str  # secret
+        bar: str  # env variable
+
+        class Config:
+            env_prefix = 'PIKA_'
+            secrets_dir = tmp_path
+
+    env.set('PIKA_BAR', 'bar_env_value_str')
+
+    assert Settings().dict() == {'foo': 'foo_secret_value_str', 'bar': 'bar_env_value_str'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
We were using the `env_prefix` for secrets, which doesn't make sense and is very confusing.
Now we just don't

## Related issue number
closes #2188 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
