### PR TITLE
Add a frozenset type annotation to allowed_schemes on stricturl

### DIFF
--- a/changes/2198-Midnighter.md
+++ b/changes/2198-Midnighter.md
@@ -1,0 +1,1 @@
+Add a `FrozenSet[str]` type annotation to the `allowed_schemes` argument on the `strict_url` field type.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -9,7 +9,21 @@ from ipaddress import (
     _BaseAddress,
     _BaseNetwork,
 )
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Pattern, Set, Tuple, Type, Union, cast, no_type_check
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    FrozenSet,
+    Generator,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+    no_type_check,
+)
 
 from . import errors
 from .utils import Representation, update_not_none
@@ -310,7 +324,7 @@ def stricturl(
     min_length: int = 1,
     max_length: int = 2 ** 16,
     tld_required: bool = True,
-    allowed_schemes: Optional[Set[str]] = None,
+    allowed_schemes: Optional[Union[FrozenSet[str], Set[str]]] = None,
 ) -> Type[AnyUrl]:
     # use kwargs then define conf in a dict to aid with IDE type hinting
     namespace = dict(


### PR DESCRIPTION
## Change Summary

I was recently using the `stricturl` field type and declared some constants for the allowed schemes. Semantically, it makes the most sense to me to use `frozenset`s for those constants. Thus I propose to extend the type annotation to include `FrozenSet[str]`.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)

Locally, the test suite fails for me with 

```
pydantic/main.py:367:5: C901 'BaseModel.__setattr__' is too complex (15)
```

but that's unrelated to my change.