### PR TITLE
build(deps): bump to pytest 6.2.1, pytest-mock 3.4.0, mkdocs-material 6.1.7 and codecov-action v1.0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       run: make test
 
     - run: coverage xml
-    - uses: codecov/codecov-action@v1.0.14
+    - uses: codecov/codecov-action@v1.0.15
       with:
         file: ./coverage.xml
         env_vars: COMPILED,DEPS,PYTHON,OS
@@ -87,7 +87,7 @@ jobs:
       run: make test
 
     - run: coverage xml
-    - uses: codecov/codecov-action@v1.0.14
+    - uses: codecov/codecov-action@v1.0.15
       with:
         file: ./coverage.xml
         env_vars: COMPILED,DEPS,PYTHON,OS
@@ -105,7 +105,7 @@ jobs:
       run: make test
 
     - run: coverage xml
-    - uses: codecov/codecov-action@v1.0.14
+    - uses: codecov/codecov-action@v1.0.15
       with:
         file: ./coverage.xml
         env_vars: COMPILED,DEPS,PYTHON,OS
@@ -143,7 +143,7 @@ jobs:
 
     - run: coverage xml
 
-    - uses: codecov/codecov-action@v1.0.14
+    - uses: codecov/codecov-action@v1.0.15
       with:
         file: ./coverage.xml
         env_vars: COMPILED,DEPS,PYTHON,OS

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ flake8==3.8.4
 flake8-quotes==3.2.0
 mkdocs==1.1.2
 mkdocs-exclude==1.0.2
-mkdocs-material==6.1.6
+mkdocs-material==6.1.7
 markdown-include==0.6.0
 sqlalchemy
 orjson

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -12,7 +12,7 @@ def version_info() -> str:
     from .main import compiled
 
     optional_deps = []
-    for p in ('typing-extensions', 'email-validator', 'devtools'):
+    for p in ('devtools', 'dotenv', 'email-validator', 'typing-extensions'):
         try:
             import_module(p.replace('-', '_'))
         except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ class SetEnv:
             os.environ.pop(n)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def env():
     setenv = SetEnv()
 

--- a/tests/requirements-testing.txt
+++ b/tests/requirements-testing.txt
@@ -2,7 +2,7 @@ coverage==5.3
 # pin importlib-metadata as upper versions need typing-extensions to work if on python < 3.8
 importlib-metadata==3.1.0;python_version<"3.8"
 mypy==0.790
-pytest==6.1.2
+pytest==6.2.1
 pytest-cov==2.10.1
-pytest-mock==3.3.1
+pytest-mock==3.4.0
 pytest-sugar==0.9.4


### PR DESCRIPTION
replaces #2206, #2180 and #2164