### PR TITLE
ci: fix it by pinning importlib-metadata

### DIFF
--- a/tests/requirements-testing.txt
+++ b/tests/requirements-testing.txt
@@ -1,4 +1,5 @@
 coverage==5.3
+# pin importlib-metadata as upper versions need typing-extensions to work if on python < 3.8
 importlib-metadata==3.1.0;python_version<"3.8"
 mypy==0.790
 pytest==6.1.2

--- a/tests/requirements-testing.txt
+++ b/tests/requirements-testing.txt
@@ -1,4 +1,5 @@
 coverage==5.3
+importlib-metadata==3.1.0;python_version<"3.8"
 mypy==0.790
 pytest==6.1.2
 pytest-cov==2.10.1


### PR DESCRIPTION
`importlib-metadata` now requires python3.8+ or `typing-extensions` since [3.2.0](https://github.com/python/importlib_metadata/commit/530f5da8dd3a255f1198f29ea0126b8b25e644d8#diff-cc51f8e0c17159a1860664f70a89eba0d48c641f4deafe74912a7274dff91a34R15)
And `pytest` doesn't pin the version of `importlib-metadata`.
So on the CI when we uninstall `typing-extensions` **after** installing `pytest`, it crashes!
Let's pin `importlib-metadata` to 3.1.0 for now

ℹ️ I think this is the safest decision for now but IMO **we could make `typing-extensions` a required dependency in the near future for _pydantic_ on python 3.6 and 3.7** It's a remark that has already been made and it feels like it could be better for everyone.