### PR TITLE
Helpful TypeError when user forgets to return `values` in root valida…

### DIFF
--- a/changes/2209-masalim2.md
+++ b/changes/2209-masalim2.md
@@ -1,1 +1,1 @@
-User-friendly TypeError when a `root_validator` returns `None`.
+Raise a user-friendly TypeError when a root_validator does not return a dict (e.g. None)

--- a/changes/2209-masalim2.md
+++ b/changes/2209-masalim2.md
@@ -1,0 +1,1 @@
+User-friendly TypeError when a `root_validator` returns `None`.

--- a/changes/2209-masalim2.md
+++ b/changes/2209-masalim2.md
@@ -1,1 +1,1 @@
-Raise a user-friendly TypeError when a root_validator does not return a dict (e.g. None)
+Raise a user-friendly `TypeError` when a `root_validator` does not return a `dict` (e.g. `None`)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -360,11 +360,15 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
         if validation_error:
             raise validation_error
+        if values is None:
+            raise TypeError(
+                'BaseModel.__init__ received `None` values. Are you forgetting to return `values` in a root validator?'
+            )
         object_setattr(__pydantic_self__, '__dict__', values)
         object_setattr(__pydantic_self__, '__fields_set__', fields_set)
         __pydantic_self__._init_private_attributes()
 
-    @no_type_check
+    @no_type_check  # noqa: C901 (ignore complexity)
     def __setattr__(self, name, value):  # noqa: C901 (ignore complexity)
         if name in self.__private_attributes__:
             return object_setattr(self, name, value)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -360,11 +360,10 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
         if validation_error:
             raise validation_error
-        if values is None:
-            raise TypeError(
-                'BaseModel.__init__ received `None` values. Are you forgetting to return `values` in a root validator?'
-            )
-        object_setattr(__pydantic_self__, '__dict__', values)
+        try:
+            object_setattr(__pydantic_self__, '__dict__', values)
+        except TypeError as e:
+            raise TypeError('Did you return a valid dict in your root validators?') from e
         object_setattr(__pydantic_self__, '__fields_set__', fields_set)
         __pydantic_self__._init_private_attributes()
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -369,7 +369,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         object_setattr(__pydantic_self__, '__fields_set__', fields_set)
         __pydantic_self__._init_private_attributes()
 
-    @no_type_check  # noqa: C901 (ignore complexity)
+    @no_type_check
     def __setattr__(self, name, value):  # noqa: C901 (ignore complexity)
         if name in self.__private_attributes__:
             return object_setattr(self, name, value)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -363,7 +363,9 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         try:
             object_setattr(__pydantic_self__, '__dict__', values)
         except TypeError as e:
-            raise TypeError('Did you return a valid dict in your root validators?') from e
+            raise TypeError(
+                'Model values must be a dict; you may not have returned a dictionary from a root validator'
+            ) from e
         object_setattr(__pydantic_self__, '__fields_set__', fields_set)
         __pydantic_self__._init_private_attributes()
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -978,7 +978,7 @@ def test_root_validator_returns_none_exception():
         def root_validator_repeated(cls, values):
             return None
 
-    with pytest.raises(TypeError, match='Did you return a valid dict in your root validators?'):
+    with pytest.raises(TypeError, match='Model values must be a dict'):
         Model()
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -978,7 +978,7 @@ def test_root_validator_returns_none_exception():
         def root_validator_repeated(cls, values):
             return None
 
-    with pytest.raises(TypeError, match='Are you forgetting to return `values` in a root validator?'):
+    with pytest.raises(TypeError, match='Did you return a valid dict in your root validators?'):
         Model()
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -970,6 +970,18 @@ def test_root_validator_inheritance():
     assert calls == ["parent validator: {'a': 123}", "child validator: {'extra1': 1, 'a': 123}"]
 
 
+def test_root_validator_returns_none_exception():
+    class Model(BaseModel):
+        a: int = 1
+
+        @root_validator
+        def root_validator_repeated(cls, values):
+            return None
+
+    with pytest.raises(TypeError, match='Are you forgetting to return `values` in a root validator?'):
+        Model()
+
+
 def reusable_validator(num):
     return num * 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

If a user forgot to return the `values` dict in a root validator, they'd see a somewhat opaque exception: 
```
TypeError: __dict__ must be set to a dictionary, not a 'NoneType'`.  
```

Added a quick check in `BaseModel.__init__` to raise a more user-friendly hint in the TypeError:
```
TypeError: BaseModel.__init__ received `None` values. Are you forgetting to return `values` in a root validator?
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
