### PR TITLE
feat: make dict validator strict by default

### DIFF
--- a/changes/1268-PrettyWood.md
+++ b/changes/1268-PrettyWood.md
@@ -1,0 +1,3 @@
+**Possible Breaking Change:** Make dict validator strict so empty strings or lists won't be valid anymore by default
+To keep old behaviour, set `loose_dict_validator = True` in the `Config` of your `BaseModel`.
+To change it globally for all your _pydantic_ models, you can set `BaseConfig.loose_dict_validator = True`.

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -46,10 +46,7 @@ class ValidationError(Representation, ValueError):
 
     def errors(self) -> List[Dict[str, Any]]:
         if self._error_cache is None:
-            try:
-                config = self.model.__config__  # type: ignore
-            except AttributeError:
-                config = self.model.__pydantic_model__.__config__  # type: ignore
+            config = self.model.__config__
             self._error_cache = list(flatten_errors(self.raw_errors, config))
         return self._error_cache
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -703,7 +703,7 @@ class ModelField(Representation):
         self, v: Any, values: Dict[str, Any], loc: 'LocStr', cls: Optional['ModelOrDc']
     ) -> 'ValidateReturn':
         try:
-            v_iter = dict_validator(v)
+            v_iter = dict_validator(v, getattr(cls, '__config__', None))
         except TypeError as exc:
             return v, ErrorWrapper(exc, loc)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -128,6 +128,8 @@ class BaseConfig:
     json_encoders: Dict[Type[Any], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
 
+    loose_dict_validator: bool = False
+
     @classmethod
     def get_field_info(cls, name: str) -> Dict[str, Any]:
         fields_value = cls.fields.get(name)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -15,6 +15,7 @@ from typing import (
     FrozenSet,
     Generator,
     List,
+    Optional,
     Pattern,
     Set,
     Tuple,
@@ -209,13 +210,16 @@ def ordered_dict_validator(v: Any) -> 'AnyOrderedDict':
         raise errors.DictError()
 
 
-def dict_validator(v: Any) -> Dict[Any, Any]:
+def dict_validator(v: Any, config: Optional[Type['BaseConfig']]) -> Dict[Any, Any]:
     if isinstance(v, dict):
         return v
 
-    try:
-        return dict(v)
-    except (TypeError, ValueError):
+    if config is not None and config.loose_dict_validator:
+        try:
+            return dict(v)
+        except (TypeError, ValueError):
+            raise errors.DictError()
+    else:
         raise errors.DictError()
 
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -291,7 +291,7 @@ def test_validate_assigment_long_string_error():
     with pytest.raises(ValidationError) as exc_info:
         d.a = 'xxxx'
 
-    assert issubclass(MyDataclass.__pydantic_model__.__config__, BaseModel.Config)
+    assert issubclass(MyDataclass.__config__, BaseModel.Config)
     assert exc_info.value.errors() == [
         {
             'loc': ('a',),

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -151,6 +151,9 @@ def test_typed_dict(value, result):
     class Model(BaseModel):
         v: Dict[str, int] = ...
 
+        class Config:
+            loose_dict_validator = True
+
     assert Model(v=value).v == result
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -844,6 +844,20 @@ def test_dict():
         v: dict
 
     assert Model(v={1: 10, 2: 20}).v == {1: 10, 2: 20}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v=[(1, 2), (3, 4)])
+    assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
+
+
+def test_dict_loose():
+    class Model(BaseModel):
+        v: dict
+
+        class Config:
+            loose_dict_validator = True
+
+    assert Model(v={1: 10, 2: 20}).v == {1: 10, 2: 20}
     assert Model(v=[(1, 2), (3, 4)]).v == {1: 2, 3: 4}
 
     with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Make the `dict_validator` strict by default.
Add a way to keep old behaviour with `loose_dict_validator` flag in `BaseConfig`

## Related issue number
closes #1268
closes #1982

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
