### PR TITLE
fix: do not ignore annotated fields when type is `Union[Type[...], ...]`

### DIFF
--- a/changes/2213-PrettyWood.md
+++ b/changes/2213-PrettyWood.md
@@ -1,0 +1,1 @@
+Do not ignore annotated fields when type is `Union[Type[...], ...]`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -34,7 +34,15 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import default_ref_template, model_schema
 from .types import PyObject, StrBytes
-from .typing import AnyCallable, ForwardRef, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
+from .typing import (
+    AnyCallable,
+    ForwardRef,
+    get_args,
+    get_origin,
+    is_classvar,
+    resolve_annotations,
+    update_field_forward_refs,
+)
 from .utils import (
     ROOT_KEY,
     ClassAttribute,
@@ -253,10 +261,13 @@ class ModelMetaclass(ABCMeta):
                 elif is_valid_field(ann_name):
                     validate_field_name(bases, ann_name)
                     value = namespace.get(ann_name, Undefined)
+                    allowed_types = get_args(ann_type) if get_origin(ann_type) is Union else (ann_type,)
                     if (
                         isinstance(value, untouched_types)
                         and ann_type != PyObject
-                        and not lenient_issubclass(get_origin(ann_type), Type)
+                        and not any(
+                            lenient_issubclass(get_origin(allowed_type), Type) for allowed_type in allowed_types
+                        )
                     ):
                         continue
                     fields[ann_name] = inferred = ModelField.infer(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2,7 +2,7 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
 import pytest
 
@@ -1122,8 +1122,11 @@ def test_type_on_annotation():
         d: FooBar = FooBar
         e: Type[FooBar]
         f: Type[FooBar] = FooBar
+        g: Sequence[Type[FooBar]] = [FooBar]
+        h: Union[Type[FooBar], Sequence[Type[FooBar]]] = FooBar
+        i: Union[Type[FooBar], Sequence[Type[FooBar]]] = [FooBar]
 
-    assert Model.__fields__.keys() == {'b', 'c', 'e', 'f'}
+    assert Model.__fields__.keys() == {'b', 'c', 'e', 'f', 'g', 'h', 'i'}
 
 
 def test_assign_type():


### PR DESCRIPTION
## Change Summary
Considering a model
```python
class Model(BaseModel):
    ok_field: Type[FooBar] = FooBar
    ignored_field: Union[Type[FooBar], Sequence[Type[FooBar]]] = FooBar
```
The `ignored_field` was not taken into account because in the metaclass we were only handling `Type[...]`.
When the type is `Union[...]` the origin is `Union` and we need to check the valid types inside the `Union`

## Related issue number
closes #2213

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
