### PR TITLE
feat: add support for `NamedTuple` and `TypedDict` types

### DIFF
--- a/changes/2216-PrettyWood.md
+++ b/changes/2216-PrettyWood.md
@@ -1,1 +1,3 @@
-add support for `NamedTuple` and `TypedDict` types
+Add support for `NamedTuple` and `TypedDict` types.
+Those two types are now handled and validated when used inside `BaseModel` or _pydantic_ `dataclass`.
+Two utils are also added `create_model_from_namedtuple` and `create_model_from_typeddict`.

--- a/changes/2216-PrettyWood.md
+++ b/changes/2216-PrettyWood.md
@@ -1,0 +1,1 @@
+add support for `NamedTuple` and `TypedDict` types

--- a/docs/examples/annotated_types_named_tuple.py
+++ b/docs/examples/annotated_types_named_tuple.py
@@ -1,0 +1,20 @@
+from typing import NamedTuple
+
+from pydantic import BaseModel, ValidationError
+
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+
+class Model(BaseModel):
+    p: Point
+
+
+print(Model(p=('1', '2')))
+
+try:
+    Model(p=('1.3', '2'))
+except ValidationError as e:
+    print(e)

--- a/docs/examples/annotated_types_typed_dict.py
+++ b/docs/examples/annotated_types_typed_dict.py
@@ -1,6 +1,6 @@
 from typing import TypedDict
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Extra, ValidationError
 
 
 # `total=False` means keys are non-required
@@ -17,6 +17,9 @@ class User(TypedDict):
 class Model(BaseModel):
     u: User
 
+    class Config:
+        extra = Extra.forbid
+
 
 print(Model(u={'identity': {'name': 'Smith', 'surname': 'John'}, 'age': '37'}))
 
@@ -27,5 +30,16 @@ print(Model(u={'identity': {}, 'age': '37'}))
 
 try:
     Model(u={'identity': {'name': ['Smith'], 'surname': 'John'}, 'age': '24'})
+except ValidationError as e:
+    print(e)
+
+try:
+    Model(
+        u={
+            'identity': {'name': 'Smith', 'surname': 'John'},
+            'age': '37',
+            'email': 'john.smith@me.com',
+        }
+    )
 except ValidationError as e:
     print(e)

--- a/docs/examples/annotated_types_typed_dict.py
+++ b/docs/examples/annotated_types_typed_dict.py
@@ -1,0 +1,31 @@
+from typing import TypedDict
+
+from pydantic import BaseModel, ValidationError
+
+
+# `total=False` means keys are non-required
+class UserIdentity(TypedDict, total=False):
+    name: str
+    surname: str
+
+
+class User(TypedDict):
+    identity: UserIdentity
+    age: int
+
+
+class Model(BaseModel):
+    u: User
+
+
+print(Model(u={'identity': {'name': 'Smith', 'surname': 'John'}, 'age': '37'}))
+
+print(Model(u={'identity': {'name': None, 'surname': 'John'}, 'age': '37'}))
+
+print(Model(u={'identity': {}, 'age': '37'}))
+
+
+try:
+    Model(u={'identity': {'name': ['Smith'], 'surname': 'John'}, 'age': '24'})
+except ValidationError as e:
+    print(e)

--- a/docs/examples/models_from_typeddict.py
+++ b/docs/examples/models_from_typeddict.py
@@ -1,0 +1,21 @@
+from typing import TypedDict
+
+from pydantic import ValidationError, create_model_from_typeddict
+
+
+class User(TypedDict):
+    name: str
+    id: int
+
+
+class Config:
+    extra = 'forbid'
+
+
+UserM = create_model_from_typeddict(User, __config__=Config)
+print(repr(UserM(name=123, id='3')))
+
+try:
+    UserM(name=123, id='3', other='no')
+except ValidationError as e:
+    print(e)

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -384,6 +384,18 @@ You can also add validators by passing a dict to the `__validators__` argument.
 {!.tmp_examples/models_dynamic_validators.py!}
 ```
 
+## Model creation from `NamedTuple` or `TypedDict`
+
+Sometimes you already use in your application classes that inherit from `NamedTuple` or `TypedDict`
+and you don't want to duplicate all your information to have a `BaseModel`.
+For this _pydantic_ provides `create_model_from_namedtuple` and `create_model_from_typeddict` methods.
+Those methods have the exact same keyword arguments as `create_model`.
+
+
+```py
+{!.tmp_examples/models_from_typeddict.py!}
+```
+
 ## Custom Root Types
 
 Pydantic models can be defined with a custom root type by declaring the `__root__` field. 

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -88,11 +88,12 @@ with custom properties and validation.
 `typing.Tuple`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
-`subclass of typing.NamedTuple (or collections.namedtuple)`
-: Same as `tuple` but instantiates with the given namedtuple.  
- _pydantic_ will validate the tuple if you use `typing.NamedTuple` since fields are annotated.  
-  If you use `collections.namedtuple`, no validation will be done.  
+`subclass of typing.NamedTuple`
+: Same as `tuple` but instantiates with the given namedtuple and validates fields since they are annotated.
   See [Annotated Types](#annotated-types) below for more detail on parsing and validation
+
+`subclass of collections.namedtuple`
+: Same as `subclass of typing.NamedTuple` but all fields will have type `Any` since they are not annotated
 
 `typing.Dict`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -420,7 +420,7 @@ _(This script is complete, it should run "as is")_
     This is a new feature of the python standard library as of python 3.8.
     Prior to python 3.8, it requires the [typing-extensions](https://pypi.org/project/typing-extensions/) package.
     But required and optional fields are properly differentiated only since python 3.9.
-    It is hence recommanded using [typing-extensions](https://pypi.org/project/typing-extensions/) with python 3.8 as well.
+    We therefore recommend using [typing-extensions](https://pypi.org/project/typing-extensions/) with python 3.8 as well.
 
 
 ```py

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -85,8 +85,16 @@ with custom properties and validation.
 `typing.Tuple`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
+`subclass of typing.NamedTuple (or collections.namedtuple)`
+: Same as `tuple` but instantiates with the given namedtuple.  
+ _pydantic_ will validate the tuple if you use `typing.NamedTuple` since fields are annotated.  
+  If you use `collections.namedtuple`, no validation will be done.
+
 `typing.Dict`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
+
+`subclass of typing.TypedDict`
+: Same as `dict` but _pydantic_ will validate the dictionary since keys are annotated
 
 `typing.Set`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -408,12 +408,21 @@ _(This script is complete, it should run "as is")_
 ## Annotated Types
 
 ### NamedTuple
+
 ```py
 {!.tmp_examples/annotated_types_named_tuple.py!}
 ```
 _(This script is complete, it should run "as is")_
 
 ### TypedDict
+
+!!! note
+    This is a new feature of the python standard library as of python 3.8.
+    Prior to python 3.8, it requires the [typing-extensions](https://pypi.org/project/typing-extensions/) package.
+    But required and optional fields are properly differentiated only since python 3.9.
+    It is hence recommanded using [typing-extensions](https://pypi.org/project/typing-extensions/) with python 3.8 as well.
+
+
 ```py
 {!.tmp_examples/annotated_types_typed_dict.py!}
 ```

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -91,13 +91,15 @@ with custom properties and validation.
 `subclass of typing.NamedTuple (or collections.namedtuple)`
 : Same as `tuple` but instantiates with the given namedtuple.  
  _pydantic_ will validate the tuple if you use `typing.NamedTuple` since fields are annotated.  
-  If you use `collections.namedtuple`, no validation will be done.
+  If you use `collections.namedtuple`, no validation will be done.  
+  See [Annotated Types](#annotated-types) below for more detail on parsing and validation
 
 `typing.Dict`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
 `subclass of typing.TypedDict`
-: Same as `dict` but _pydantic_ will validate the dictionary since keys are annotated
+: Same as `dict` but _pydantic_ will validate the dictionary since keys are annotated.  
+  See [Annotated Types](#annotated-types) below for more detail on parsing and validation
 
 `typing.Set`
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
@@ -400,6 +402,20 @@ With proper ordering in an annotated `Union`, you can use this to parse types of
 
 ```py
 {!.tmp_examples/types_literal3.py!}
+```
+_(This script is complete, it should run "as is")_
+
+## Annotated Types
+
+### NamedTuple
+```py
+{!.tmp_examples/annotated_types_named_tuple.py!}
+```
+_(This script is complete, it should run "as is")_
+
+### TypedDict
+```py
+{!.tmp_examples/annotated_types_typed_dict.py!}
 ```
 _(This script is complete, it should run "as is")_
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from . import dataclasses
-from .annotated_types import namedtuple_to_model, typeddict_to_model
+from .annotated_types import create_model_from_namedtuple, create_model_from_typeddict
 from .class_validators import root_validator, validator
 from .decorator import validate_arguments
 from .env_settings import BaseSettings
@@ -18,8 +18,8 @@ from .version import VERSION
 # please use "from pydantic.errors import ..." instead
 __all__ = [
     # annotated types utils
-    'namedtuple_to_model',
-    'typeddict_to_model',
+    'create_model_from_namedtuple',
+    'create_model_from_typeddict',
     # dataclasses
     'dataclasses',
     # class_validators

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from . import dataclasses
+from .annotated_types import namedtuple_to_model, typeddict_to_model
 from .class_validators import root_validator, validator
 from .decorator import validate_arguments
 from .env_settings import BaseSettings
@@ -16,6 +17,9 @@ from .version import VERSION
 # WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
 # please use "from pydantic.errors import ..." instead
 __all__ = [
+    # annotated types utils
+    'namedtuple_to_model',
+    'typeddict_to_model',
     # dataclasses
     'dataclasses',
     # class_validators

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -50,10 +50,10 @@ def create_model_from_namedtuple(namedtuple_cls: Type['NamedTuple'], **kwargs: A
     but also with `collections.namedtuple` without any, in which case we consider the type
     of all the fields to be `Any`
     """
-    named_tuple_annotations: Dict[str, Type[Any]] = getattr(
+    namedtuple_annotations: Dict[str, Type[Any]] = getattr(
         namedtuple_cls, '__annotations__', {k: Any for k in namedtuple_cls._fields}
     )
     field_definitions: Dict[str, Any] = {
-        field_name: (field_type, Required) for field_name, field_type in named_tuple_annotations.items()
+        field_name: (field_type, Required) for field_name, field_type in namedtuple_annotations.items()
     }
     return create_model(f'{namedtuple_cls.__name__}Model', **kwargs, **field_definitions)

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:
 
 def create_model_from_typeddict(typeddict_cls: Type['TypedDict'], **kwargs: Any) -> Type['BaseModel']:
     """
-    Convert a `TypedDict` to a `BaseModel`
+    Create a `BaseModel` based on the fields of a `TypedDict`.
     Since `typing.TypedDict` in Python 3.8 does not store runtime information about optional keys,
-    we warn the user if that's the case (see https://bugs.python.org/issue38834)
+    we warn the user if that's the case (see https://bugs.python.org/issue38834).
     """
     field_definitions: Dict[str, Any]
 
@@ -45,10 +45,10 @@ def create_model_from_typeddict(typeddict_cls: Type['TypedDict'], **kwargs: Any)
 
 def create_model_from_namedtuple(namedtuple_cls: Type['NamedTuple'], **kwargs: Any) -> Type['BaseModel']:
     """
-    Convert a named tuple to a `BaseModel`
+    Create a `BaseModel` based on the fields of a named tuple.
     A named tuple can be created with `typing.NamedTuple` and declared annotations
-    but also with `collections.namedtuple` without any, in which case we consider the type
-    of all the fields to be `Any`
+    but also with `collections.namedtuple`, in this case we consider all fields
+    to have type `Any`.
     """
     namedtuple_annotations: Dict[str, Type[Any]] = getattr(
         namedtuple_cls, '__annotations__', {k: Any for k in namedtuple_cls._fields}

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, NamedTuple, Type
+
+from .fields import Required
+from .main import BaseConfig, BaseModel, create_model
+
+if TYPE_CHECKING:
+
+    class TypedDict(Dict[str, Any]):
+        __annotations__: Dict[str, Type[Any]]
+        __total__: bool
+        __required_keys__: FrozenSet[str]
+        __optional_keys__: FrozenSet[str]
+
+
+def typeddict_to_model(typeddict_cls: Type['TypedDict'], *, config: Type['BaseConfig']) -> Type['BaseModel']:
+    """
+    Convert a `TypedDict` to a `BaseModel`
+    Since `typing.TypedDict` in Python 3.8 does not store runtime information about optional keys,
+    we warn the user if that's the case (see https://bugs.python.org/issue38834)
+    """
+    field_definitions: Dict[str, Any]
+
+    # Best case scenario: with python 3.9+ or when `TypedDict` is imported from `typing_extensions`
+    if hasattr(typeddict_cls, '__required_keys__'):
+        field_definitions = {
+            field_name: (field_type, Required if field_name in typeddict_cls.__required_keys__ else None)
+            for field_name, field_type in typeddict_cls.__annotations__.items()
+        }
+    else:
+        import warnings
+
+        warnings.warn(
+            'You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` for better support! '
+            'Without it, there is no way to differentiate required and optional fields when subclassed. '
+            'Fields will therefore be considered all required or all optional depending on class totality.',
+            UserWarning,
+        )
+        default_value = Required if typeddict_cls.__total__ else None
+        field_definitions = {
+            field_name: (field_type, default_value) for field_name, field_type in typeddict_cls.__annotations__.items()
+        }
+
+    return create_model(
+        f'{typeddict_cls.__name__}Model', __config__=config, **field_definitions
+    )
+
+
+def namedtuple_to_model(namedtuple_cls: Type['NamedTuple']) -> Type['BaseModel']:
+    """
+    Convert a named tuple to a `BaseModel`
+    A named tuple can be created with `typing.NamedTuple` and declared annotations
+    but also with `collections.namedtuple` without any, in which case we consider the type
+    of all the fields to be `Any`
+    """
+    named_tuple_annotations: Dict[str, Type[Any]] = getattr(
+        namedtuple_cls, '__annotations__', {k: Any for k in namedtuple_cls._fields}
+    )
+    field_definitions: Dict[str, Any] = {
+        field_name: (field_type, Required) for field_name, field_type in named_tuple_annotations.items()
+    }
+    return create_model(f'{namedtuple_cls.__name__}Model', **field_definitions)

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, FrozenSet, NamedTuple, Type
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, NamedTuple, Optional, Type
 
 from .fields import Required
 from .main import BaseConfig, BaseModel, create_model
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
         __optional_keys__: FrozenSet[str]
 
 
-def typeddict_to_model(typeddict_cls: Type['TypedDict'], *, config: Type['BaseConfig']) -> Type['BaseModel']:
+def typeddict_to_model(
+    typeddict_cls: Type['TypedDict'], *, config: Optional[Type['BaseConfig']] = None
+) -> Type['BaseModel']:
     """
     Convert a `TypedDict` to a `BaseModel`
     Since `typing.TypedDict` in Python 3.8 does not store runtime information about optional keys,
@@ -40,9 +42,7 @@ def typeddict_to_model(typeddict_cls: Type['TypedDict'], *, config: Type['BaseCo
             field_name: (field_type, default_value) for field_name, field_type in typeddict_cls.__annotations__.items()
         }
 
-    return create_model(
-        f'{typeddict_cls.__name__}Model', __config__=config, **field_definitions
-    )
+    return create_model(f'{typeddict_cls.__name__}Model', __config__=config, **field_definitions)
 
 
 def namedtuple_to_model(namedtuple_cls: Type['NamedTuple']) -> Type['BaseModel']:

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, FrozenSet, NamedTuple, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, NamedTuple, Type
 
 from .fields import Required
-from .main import BaseConfig, BaseModel, create_model
+from .main import BaseModel, create_model
 
 if TYPE_CHECKING:
 
@@ -12,9 +12,7 @@ if TYPE_CHECKING:
         __optional_keys__: FrozenSet[str]
 
 
-def typeddict_to_model(
-    typeddict_cls: Type['TypedDict'], *, config: Optional[Type['BaseConfig']] = None
-) -> Type['BaseModel']:
+def create_model_from_typeddict(typeddict_cls: Type['TypedDict'], **kwargs: Any) -> Type['BaseModel']:
     """
     Convert a `TypedDict` to a `BaseModel`
     Since `typing.TypedDict` in Python 3.8 does not store runtime information about optional keys,
@@ -42,10 +40,10 @@ def typeddict_to_model(
             field_name: (field_type, default_value) for field_name, field_type in typeddict_cls.__annotations__.items()
         }
 
-    return create_model(f'{typeddict_cls.__name__}Model', __config__=config, **field_definitions)
+    return create_model(f'{typeddict_cls.__name__}Model', **kwargs, **field_definitions)
 
 
-def namedtuple_to_model(namedtuple_cls: Type['NamedTuple']) -> Type['BaseModel']:
+def create_model_from_namedtuple(namedtuple_cls: Type['NamedTuple'], **kwargs: Any) -> Type['BaseModel']:
     """
     Convert a named tuple to a `BaseModel`
     A named tuple can be created with `typing.NamedTuple` and declared annotations
@@ -58,4 +56,4 @@ def namedtuple_to_model(namedtuple_cls: Type['NamedTuple']) -> Type['BaseModel']
     field_definitions: Dict[str, Any] = {
         field_name: (field_type, Required) for field_name, field_type in named_tuple_annotations.items()
     }
-    return create_model(f'{namedtuple_cls.__name__}Model', **field_definitions)
+    return create_model(f'{namedtuple_cls.__name__}Model', **kwargs, **field_definitions)

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -56,4 +56,4 @@ def create_model_from_namedtuple(namedtuple_cls: Type['NamedTuple'], **kwargs: A
     field_definitions: Dict[str, Any] = {
         field_name: (field_type, Required) for field_name, field_type in namedtuple_annotations.items()
     }
-    return create_model(f'{namedtuple_cls.__name__}Model', **kwargs, **field_definitions)
+    return create_model(namedtuple_cls.__name__, **kwargs, **field_definitions)

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -40,7 +40,7 @@ def create_model_from_typeddict(typeddict_cls: Type['TypedDict'], **kwargs: Any)
             field_name: (field_type, default_value) for field_name, field_type in typeddict_cls.__annotations__.items()
         }
 
-    return create_model(f'{typeddict_cls.__name__}Model', **kwargs, **field_definitions)
+    return create_model(typeddict_cls.__name__, **kwargs, **field_definitions)
 
 
 def create_model_from_namedtuple(namedtuple_cls: Type['NamedTuple'], **kwargs: Any) -> Type['BaseModel']:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -37,6 +37,7 @@ from .typing import (
     get_origin,
     is_literal_type,
     is_new_type,
+    is_typed_dict_type,
     new_type_supertype,
 )
 from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_like, smart_deepcopy
@@ -414,6 +415,8 @@ class ModelField(Representation):
             # python 3.7 only, Pattern is a typing object but without sub fields
             return
         elif is_literal_type(self.type_):
+            return
+        elif is_typed_dict_type(self.type_):
             return
 
         origin = get_origin(self.type_)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -38,7 +38,7 @@ from .typing import (
     get_origin,
     is_literal_type,
     is_new_type,
-    is_typed_dict_type,
+    is_typeddict,
     new_type_supertype,
 )
 from .utils import PyObjectStr, Representation, lenient_issubclass, sequence_like, smart_deepcopy
@@ -417,7 +417,7 @@ class ModelField(Representation):
             return
         elif is_literal_type(self.type_):
             return
-        elif is_typed_dict_type(self.type_):
+        elif is_typeddict(self.type_):
             return
 
         origin = get_origin(self.type_)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -34,7 +34,15 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import default_ref_template, model_schema
 from .types import PyObject, StrBytes
-from .typing import AnyCallable, get_args, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
+from .typing import (
+    AnyCallable,
+    get_args,
+    get_origin,
+    is_classvar,
+    is_namedtuple,
+    resolve_annotations,
+    update_field_forward_refs,
+)
 from .utils import (
     ROOT_KEY,
     ClassAttribute,
@@ -732,7 +740,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             }
 
         elif sequence_like(v):
-            return v.__class__(
+            seq_args = (
                 cls._get_value(
                     v_,
                     to_dict=to_dict,
@@ -747,6 +755,8 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 if (not value_exclude or not value_exclude.is_excluded(i))
                 and (not value_include or value_include.is_included(i))
             )
+
+            return v.__class__(*seq_args) if is_namedtuple(v.__class__) else v.__class__(seq_args)
 
         elif isinstance(v, Enum) and getattr(cls.Config, 'use_enum_values', False):
             return v.value

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -65,6 +65,7 @@ from .typing import (
     get_origin,
     is_callable_type,
     is_literal_type,
+    is_namedtuple,
     literal_values,
 )
 from .utils import ROOT_KEY, get_model, lenient_issubclass, sequence_like
@@ -795,6 +796,16 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         f_schema, schema_overrides = get_field_info_schema(field)
         f_schema.update(get_schema_ref(enum_name, ref_prefix, ref_template, schema_overrides))
         definitions[enum_name] = enum_process_schema(field_type)
+    elif is_namedtuple(field_type):
+        sub_schema, *_ = model_process_schema(
+            field_type.__pydantic_model__,
+            by_alias=by_alias,
+            model_name_map=model_name_map,
+            ref_prefix=ref_prefix,
+            ref_template=ref_template,
+            known_models=known_models,
+        )
+        f_schema.update({'type': 'array', 'items': list(sub_schema['properties'].values())})
     elif not hasattr(field_type, '__pydantic_model__'):
         add_field_type_to_schema(field_type, f_schema)
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -795,7 +795,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         f_schema, schema_overrides = get_field_info_schema(field)
         f_schema.update(get_schema_ref(enum_name, ref_prefix, ref_template, schema_overrides))
         definitions[enum_name] = enum_process_schema(field_type)
-    else:
+    elif not hasattr(field_type, '__pydantic_model__'):
         add_field_type_to_schema(field_type, f_schema)
 
         modify_schema = getattr(field_type, '__modify_schema__', None)

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -188,8 +188,8 @@ __all__ = (
     'is_literal_type',
     'literal_values',
     'Literal',
-    'is_named_tuple_type',
-    'is_typed_dict_type',
+    'is_namedtuple',
+    'is_typeddict',
     'is_new_type',
     'new_type_supertype',
     'is_classvar',
@@ -300,13 +300,20 @@ def all_literal_values(type_: Type[Any]) -> Tuple[Any, ...]:
     return tuple(x for value in values for x in all_literal_values(value))
 
 
-def is_named_tuple_type(type_: Type[Any]) -> bool:
+def is_namedtuple(type_: Type[Any]) -> bool:
+    """
+    Check if a given class is a `NamedTuple`
+    """
     from .utils import lenient_issubclass
 
     return lenient_issubclass(type_, tuple) and hasattr(type_, '_fields')
 
 
-def is_typed_dict_type(type_: Type[Any]) -> bool:
+def is_typeddict(type_: Type[Any]) -> bool:
+    """
+    Check if a given class is a `TypedDict`
+    In 3.10, there will be a public method (https://docs.python.org/3.10/library/typing.html#typing.is_typeddict)
+    """
     from .utils import lenient_issubclass
 
     return lenient_issubclass(type_, dict) and getattr(type_, '__annotations__', None)

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -155,6 +155,8 @@ __all__ = (
     'is_literal_type',
     'literal_values',
     'Literal',
+    'is_named_tuple_type',
+    'is_typed_dict_type',
     'is_new_type',
     'new_type_supertype',
     'is_classvar',
@@ -256,6 +258,18 @@ def all_literal_values(type_: Type[Any]) -> Tuple[Any, ...]:
 
     values = literal_values(type_)
     return tuple(x for value in values for x in all_literal_values(value))
+
+
+def is_named_tuple_type(type_: Type[Any]) -> bool:
+    from .utils import lenient_issubclass
+
+    return lenient_issubclass(type_, tuple) and hasattr(type_, '_fields')
+
+
+def is_typed_dict_type(type_: Type[Any]) -> bool:
+    from .utils import lenient_issubclass
+
+    return lenient_issubclass(type_, dict) and getattr(type_, '__annotations__', None)
 
 
 test_type = NewType('test_type', str)

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -302,7 +302,8 @@ def all_literal_values(type_: Type[Any]) -> Tuple[Any, ...]:
 
 def is_namedtuple(type_: Type[Any]) -> bool:
     """
-    Check if a given class is a `NamedTuple`
+    Check if a given class is a named tuple.
+    It can be either a `typing.NamedTuple` or `collections.namedtuple`
     """
     from .utils import lenient_issubclass
 
@@ -311,12 +312,12 @@ def is_namedtuple(type_: Type[Any]) -> bool:
 
 def is_typeddict(type_: Type[Any]) -> bool:
     """
-    Check if a given class is a `TypedDict`
+    Check if a given class is a typed dict (from `typing` or `typing_extensions`)
     In 3.10, there will be a public method (https://docs.python.org/3.10/library/typing.html#typing.is_typeddict)
     """
     from .utils import lenient_issubclass
 
-    return lenient_issubclass(type_, dict) and getattr(type_, '__annotations__', None)
+    return lenient_issubclass(type_, dict) and hasattr(type_, '__total__')
 
 
 test_type = NewType('test_type', str)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -547,6 +547,7 @@ def make_namedtuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tu
     from .annotated_types import create_model_from_namedtuple
 
     NamedTupleModel = create_model_from_namedtuple(namedtuple_cls)
+    namedtuple_cls.__pydantic_model__ = NamedTupleModel  # type: ignore[attr-defined]
 
     def namedtuple_validator(values: Tuple[Any, ...]) -> NamedTupleT:
         dict_values: Dict[str, Any] = dict(zip(NamedTupleModel.__annotations__, values))

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -543,17 +543,17 @@ def pattern_validator(v: Any) -> Pattern[str]:
 NamedTupleT = TypeVar('NamedTupleT', bound=NamedTuple)
 
 
-def make_named_tuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
+def make_namedtuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
     from .annotated_types import create_model_from_namedtuple
 
     NamedTupleModel = create_model_from_namedtuple(namedtuple_cls)
 
-    def named_tuple_validator(values: Tuple[Any, ...]) -> NamedTupleT:
+    def namedtuple_validator(values: Tuple[Any, ...]) -> NamedTupleT:
         dict_values: Dict[str, Any] = dict(zip(NamedTupleModel.__annotations__, values))
         validated_dict_values: Dict[str, Any] = dict(NamedTupleModel(**dict_values))
         return namedtuple_cls(**validated_dict_values)
 
-    return named_tuple_validator
+    return namedtuple_validator
 
 
 def make_typeddict_validator(
@@ -661,7 +661,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         return
     if is_namedtuple(type_):
         yield tuple_validator
-        yield make_named_tuple_validator(type_)
+        yield make_namedtuple_validator(type_)
         return
     if is_typeddict(type_):
         yield make_typeddict_validator(type_, config)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -544,9 +544,9 @@ NamedTupleT = TypeVar('NamedTupleT', bound=NamedTuple)
 
 
 def make_named_tuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
-    from .annotated_types import namedtuple_to_model
+    from .annotated_types import create_model_from_namedtuple
 
-    NamedTupleModel = namedtuple_to_model(namedtuple_cls)
+    NamedTupleModel = create_model_from_namedtuple(namedtuple_cls)
 
     def named_tuple_validator(values: Tuple[Any, ...]) -> NamedTupleT:
         dict_values: Dict[str, Any] = dict(zip(NamedTupleModel.__annotations__, values))
@@ -559,9 +559,9 @@ def make_named_tuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[T
 def make_typeddict_validator(
     typeddict_cls: Type['TypedDict'], config: Type['BaseConfig']
 ) -> Callable[[Any], Dict[str, Any]]:
-    from .annotated_types import typeddict_to_model
+    from .annotated_types import create_model_from_typeddict
 
-    TypedDictModel = typeddict_to_model(typeddict_cls, config=config)
+    TypedDictModel = create_model_from_typeddict(typeddict_cls, __config__=config)
 
     def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:
         return TypedDictModel(**values).dict(exclude_unset=True)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -553,12 +553,13 @@ def make_typed_dict_validator(type_: Type[Dict[str, Any]]) -> Callable[[Any], Di
     from .main import create_model
 
     field_definitions: Dict[str, Any] = {
-        field_name: (field_type, ...) for field_name, field_type in type_.__annotations__.items()
+        field_name: (field_type, ... if field_name in type_.__required_keys__ else None)
+        for field_name, field_type in type_.__annotations__.items()
     }
     TypedDictModel: Type['BaseModel'] = create_model('TypedDictModel', **field_definitions)
 
     def typed_dict_validator(values: Dict[str, Any]) -> Dict[str, Any]:
-        return dict(TypedDictModel(**values))
+        return TypedDictModel(**values).dict(exclude_unset=True)
 
     return typed_dict_validator
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -584,8 +584,8 @@ def make_typed_dict_validator(type_: Type['TypedDict']) -> Callable[[Any], Dict[
 
         warnings.warn(
             'You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` for better support! '
-            'Without it, there is no way to differentiate required and optional fields. '
-            'All fields will therefore be considered required.',
+            'Without it, there is no way to differentiate required and optional fields when subclassed. '
+            'Fields will therefore be considered all required or all optional depending on class totality.',
             UserWarning,
         )
         default_value = ... if type_.__total__ else None

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -566,7 +566,7 @@ def make_typeddict_validator(
     typeddict_cls.__pydantic_model__ = TypedDictModel  # type: ignore[attr-defined]
 
     def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:
-        return TypedDictModel(**values).dict(exclude_unset=True)
+        return TypedDictModel.parse_obj(values).dict(exclude_unset=True)
 
     return typeddict_validator
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -550,7 +550,12 @@ def make_namedtuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tu
     namedtuple_cls.__pydantic_model__ = NamedTupleModel  # type: ignore[attr-defined]
 
     def namedtuple_validator(values: Tuple[Any, ...]) -> NamedTupleT:
-        dict_values: Dict[str, Any] = dict(zip(NamedTupleModel.__annotations__, values))
+        annotations = NamedTupleModel.__annotations__
+
+        if len(values) > len(annotations):
+            raise errors.ListMaxLengthError(limit_value=len(annotations))
+
+        dict_values: Dict[str, Any] = dict(zip(annotations, values))
         validated_dict_values: Dict[str, Any] = dict(NamedTupleModel(**dict_values))
         return namedtuple_cls(**validated_dict_values)
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -562,6 +562,7 @@ def make_typeddict_validator(
     from .annotated_types import create_model_from_typeddict
 
     TypedDictModel = create_model_from_typeddict(typeddict_cls, __config__=config)
+    typeddict_cls.__pydantic_model__ = TypedDictModel  # type: ignore[attr-defined]
 
     def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:
         return TypedDictModel(**values).dict(exclude_unset=True)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -568,7 +568,7 @@ def make_named_tuple_validator(type_: Type[NamedTupleT]) -> Callable[[Tuple[Any,
     return named_tuple_validator
 
 
-def make_typed_dict_validator(type_: Type['TypedDict']) -> Callable[[Any], Dict[str, Any]]:
+def make_typed_dict_validator(type_: Type['TypedDict'], config: Type['BaseConfig']) -> Callable[[Any], Dict[str, Any]]:
     from .main import create_model
 
     field_definitions: Dict[str, Any]
@@ -593,7 +593,7 @@ def make_typed_dict_validator(type_: Type['TypedDict']) -> Callable[[Any], Dict[
             field_name: (field_type, default_value) for field_name, field_type in type_.__annotations__.items()
         }
 
-    TypedDictModel: Type['BaseModel'] = create_model('TypedDictModel', **field_definitions)
+    TypedDictModel: Type['BaseModel'] = create_model('TypedDictModel', __config__=config, **field_definitions)
 
     def typed_dict_validator(values: 'TypedDict') -> Dict[str, Any]:
         return TypedDictModel(**values).dict(exclude_unset=True)
@@ -696,7 +696,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         yield make_named_tuple_validator(type_)
         return
     if is_typed_dict_type(type_):
-        yield make_typed_dict_validator(type_)
+        yield make_typed_dict_validator(type_, config)
         return
 
     class_ = get_class(type_)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -549,7 +549,7 @@ NamedTupleT = TypeVar('NamedTupleT', bound=NamedTuple)
 def make_named_tuple_validator(type_: Type[NamedTupleT]) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
     from .main import create_model
 
-    # A named tuple can be created with `typing,NamedTuple` with types
+    # A named tuple can be created with `typing.NamedTuple` with types
     # but also with `collections.namedtuple` with just the fields
     # in which case we consider the type to be `Any`
     named_tuple_annotations: Dict[str, Type[Any]] = getattr(type_, '__annotations__', {k: Any for k in type_._fields})
@@ -569,9 +569,9 @@ def make_named_tuple_validator(type_: Type[NamedTupleT]) -> Callable[[Tuple[Any,
 def make_typed_dict_validator(type_: Type['TypedDict']) -> Callable[[Any], Dict[str, Any]]:
     from .main import create_model
 
+    default_value = ... if type_.__total__ else None
     field_definitions: Dict[str, Any] = {
-        field_name: (field_type, ... if type_.__total__ else None)
-        for field_name, field_type in type_.__annotations__.items()
+        field_name: (field_type, default_value) for field_name, field_type in type_.__annotations__.items()
     }
     TypedDictModel: Type['BaseModel'] = create_model('TypedDictModel', **field_definitions)
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -37,8 +37,8 @@ from .typing import (
     get_class,
     is_callable_type,
     is_literal_type,
-    is_named_tuple_type,
-    is_typed_dict_type,
+    is_namedtuple,
+    is_typeddict,
 )
 from .utils import almost_equal_floats, lenient_issubclass, sequence_like
 
@@ -556,17 +556,17 @@ def make_named_tuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[T
     return named_tuple_validator
 
 
-def make_typed_dict_validator(
+def make_typeddict_validator(
     typeddict_cls: Type['TypedDict'], config: Type['BaseConfig']
 ) -> Callable[[Any], Dict[str, Any]]:
     from .annotated_types import typeddict_to_model
 
     TypedDictModel = typeddict_to_model(typeddict_cls, config=config)
 
-    def typed_dict_validator(values: 'TypedDict') -> Dict[str, Any]:
+    def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:
         return TypedDictModel(**values).dict(exclude_unset=True)
 
-    return typed_dict_validator
+    return typeddict_validator
 
 
 class IfConfig:
@@ -659,12 +659,12 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if type_ is IntEnum:
         yield int_enum_validator
         return
-    if is_named_tuple_type(type_):
+    if is_namedtuple(type_):
         yield tuple_validator
         yield make_named_tuple_validator(type_)
         return
-    if is_typed_dict_type(type_):
-        yield make_typed_dict_validator(type_, config)
+    if is_typeddict(type_):
+        yield make_typeddict_validator(type_, config)
         return
 
     class_ = get_class(type_)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Cython==0.29.21;sys_platform!='win32'
 devtools==0.6.1
 email-validator==1.1.2
 dataclasses==0.6; python_version < '3.7'
-typing-extensions==3.7.4.1; python_version < '3.8'
+typing-extensions==3.7.4.3; python_version < '3.9'
 python-dotenv==0.15.0

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -154,3 +154,22 @@ def test_partial_legacy_typed_dict():
                 'type': 'value_error.missing',
             }
         ]
+
+
+@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
+def test_typed_dict_extra():
+    class User(TypedDict):
+        name: str
+        age: int
+
+    class Model(BaseModel):
+        u: User
+
+        class Config:
+            extra = 'forbid'
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(u={'name': 'pika', 'age': 7, 'rank': 1})
+    assert exc_info.value.errors() == [
+        {'loc': ('u', 'rank'), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'},
+    ]

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -106,6 +106,28 @@ def test_namedtuple_schema():
     }
 
 
+def test_namedtuple_right_length():
+    class Point(NamedTuple):
+        x: int
+        y: int
+
+    class Model(BaseModel):
+        p: Point
+
+    assert isinstance(Model(p=(1, 2)), Model)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(p=(1, 2, 3))
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('p',),
+            'msg': 'ensure this value has at most 2 items',
+            'type': 'value_error.list.max_items',
+            'ctx': {'limit_value': 2},
+        }
+    ]
+
+
 @pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
 def test_typeddict():
     class TD(TypedDict):

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -173,3 +173,37 @@ def test_typeddict_extra():
     assert exc_info.value.errors() == [
         {'loc': ('u', 'rank'), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'},
     ]
+
+
+@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
+def test_typeddict_schema():
+    class Data(BaseModel):
+        a: int
+
+    class DataTD(TypedDict):
+        a: int
+
+    class Model(BaseModel):
+        data: Data
+        data_td: DataTD
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'data': {'$ref': '#/definitions/Data'}, 'data_td': {'$ref': '#/definitions/DataTD'}},
+        'required': ['data', 'data_td'],
+        'definitions': {
+            'Data': {
+                'type': 'object',
+                'title': 'Data',
+                'properties': {'a': {'title': 'A', 'type': 'integer'}},
+                'required': ['a'],
+            },
+            'DataTD': {
+                'type': 'object',
+                'title': 'DataTD',
+                'properties': {'a': {'title': 'A', 'type': 'integer'}},
+                'required': ['a'],
+            },
+        },
+    }

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -1,0 +1,107 @@
+"""
+Tests for annotated types that _pydantic_ can validate like
+- NamedTuple
+- TypedDict
+"""
+import sys
+from collections import namedtuple
+from typing import List, NamedTuple
+
+if sys.version_info < (3, 8):
+    try:
+        from typing import TypedDict
+    except ImportError:
+        TypedDict = None
+else:
+    from typing import TypedDict
+
+import pytest
+
+from pydantic import BaseModel, ValidationError
+
+
+def test_named_tuple():
+    Position = namedtuple('Pos', 'x y')
+
+    class Event(NamedTuple):
+        a: int
+        b: int
+        c: int
+        d: str
+
+    class Model(BaseModel):
+        pos: Position
+        events: List[Event]
+
+    model = Model(pos=('1', 2), events=[[b'1', '2', 3, 'qwe']])
+    assert isinstance(model.pos, Position)
+    assert isinstance(model.events[0], Event)
+    assert model.pos.x == '1'
+    assert model.pos == Position('1', 2)
+    assert model.events[0] == Event(1, 2, 3, 'qwe')
+    assert repr(model) == "Model(pos=Pos(x='1', y=2), events=[Event(a=1, b=2, c=3, d='qwe')])"
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(pos=('1', 2), events=[['qwe', '2', 3, 'qwe']])
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('events', 0, 'a'),
+            'msg': 'value is not a valid integer',
+            'type': 'type_error.integer',
+        }
+    ]
+
+
+@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
+def test_typed_dict():
+    class TD(TypedDict):
+        a: int
+        b: int
+        c: int
+        d: str
+
+    class Model(BaseModel):
+        td: TD
+
+    m = Model(td={'a': '3', 'b': b'1', 'c': 4, 'd': 'qwe'})
+    assert m.td == {'a': 3, 'b': 1, 'c': 4, 'd': 'qwe'}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(td={'a': [1], 'b': 2, 'c': 3, 'd': 'qwe'})
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('td', 'a'),
+            'msg': 'value is not a valid integer',
+            'type': 'type_error.integer',
+        }
+    ]
+
+
+@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
+def test_typed_dict_non_total():
+    class FullMovie(TypedDict, total=True):
+        name: str
+        year: int
+
+    class Model(BaseModel):
+        movie: FullMovie
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(movie={'year': '2002'})
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('movie', 'name'),
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        }
+    ]
+
+    class PartialMovie(TypedDict, total=False):
+        name: str
+        year: int
+
+    class Model(BaseModel):
+        movie: PartialMovie
+
+    m = Model(movie={'year': '2002'})
+    assert m.movie == {'year': 2002}

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -5,7 +5,7 @@ Tests for annotated types that _pydantic_ can validate like
 """
 import sys
 from collections import namedtuple
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Tuple
 
 if sys.version_info < (3, 9):
     try:
@@ -57,6 +57,51 @@ def test_namedtuple():
             'type': 'type_error.integer',
         }
     ]
+
+
+def test_namedtuple_schema():
+    class Position1(NamedTuple):
+        x: int
+        y: int
+
+    Position2 = namedtuple('Position2', 'x y')
+
+    class Model(BaseModel):
+        pos1: Position1
+        pos2: Position2
+        pos3: Tuple[int, int]
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {
+            'pos1': {
+                'title': 'Pos1',
+                'type': 'array',
+                'items': [
+                    {'title': 'X', 'type': 'integer'},
+                    {'title': 'Y', 'type': 'integer'},
+                ],
+            },
+            'pos2': {
+                'title': 'Pos2',
+                'type': 'array',
+                'items': [
+                    {'title': 'X'},
+                    {'title': 'Y'},
+                ],
+            },
+            'pos3': {
+                'title': 'Pos3',
+                'type': 'array',
+                'items': [
+                    {'type': 'integer'},
+                    {'type': 'integer'},
+                ],
+            },
+        },
+        'required': ['pos1', 'pos2', 'pos3'],
+    }
 
 
 @pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -3,6 +3,7 @@ Tests for annotated types that _pydantic_ can validate like
 - NamedTuple
 - TypedDict
 """
+import json
 import sys
 from collections import namedtuple
 from typing import List, NamedTuple, Tuple
@@ -47,6 +48,7 @@ def test_namedtuple():
     assert model.pos == Position('1', 2)
     assert model.events[0] == Event(1, 2, 3, 'qwe')
     assert repr(model) == "Model(pos=Pos(x='1', y=2), events=[Event(a=1, b=2, c=3, d='qwe')])"
+    assert model.json() == json.dumps(model.dict()) == '{"pos": ["1", 2], "events": [[1, 2, 3, "qwe"]]}'
 
     with pytest.raises(ValidationError) as exc_info:
         Model(pos=('1', 2), events=[['qwe', '2', 3, 'qwe']])

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -27,7 +27,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 
-def test_named_tuple():
+def test_namedtuple():
     Position = namedtuple('Pos', 'x y')
 
     class Event(NamedTuple):
@@ -60,7 +60,7 @@ def test_named_tuple():
 
 
 @pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
-def test_typed_dict():
+def test_typeddict():
     class TD(TypedDict):
         a: int
         b: int
@@ -85,7 +85,7 @@ def test_typed_dict():
 
 
 @pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
-def test_typed_dict_non_total():
+def test_typeddict_non_total():
     class FullMovie(TypedDict, total=True):
         name: str
         year: int
@@ -115,7 +115,7 @@ def test_typed_dict_non_total():
 
 
 @pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
-def test_partial_new_typed_dict():
+def test_partial_new_typeddict():
     class OptionalUser(TypedDict, total=False):
         name: str
 
@@ -130,7 +130,7 @@ def test_partial_new_typed_dict():
 
 
 @pytest.mark.skipif(not LegacyTypedDict, reason='python 3.9+ is used or typing_extensions is installed')
-def test_partial_legacy_typed_dict():
+def test_partial_legacy_typeddict():
     class OptionalUser(LegacyTypedDict, total=False):
         name: str
 
@@ -157,7 +157,7 @@ def test_partial_legacy_typed_dict():
 
 
 @pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
-def test_typed_dict_extra():
+def test_typeddict_extra():
     class User(TypedDict):
         name: str
         age: int

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1486,3 +1486,34 @@ def test_typed_dict():
             'type': 'type_error.integer',
         }
     ]
+
+
+def test_typed_dict_non_total():
+    from typing import TypedDict
+
+    class FullMovie(TypedDict, total=True):
+        name: str
+        year: int
+
+    class Model(BaseModel):
+        movie: FullMovie
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(movie={'year': '2002'})
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('movie', 'name'),
+            'msg': 'field required',
+            'type': 'value_error.missing',
+        }
+    ]
+
+    class PartialMovie(TypedDict, total=False):
+        name: str
+        year: int
+
+    class Model(BaseModel):
+        movie: PartialMovie
+
+    m = Model(movie={'year': '2002'})
+    assert m.movie == {'year': 2002}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,18 +1,9 @@
 import sys
-from collections import namedtuple
 from enum import Enum
-from typing import Any, Callable, ClassVar, Dict, List, Mapping, NamedTuple, Optional, Type, get_type_hints
+from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Type, get_type_hints
 from uuid import UUID, uuid4
 
 import pytest
-
-if sys.version_info < (3, 8):
-    try:
-        from typing import TypedDict
-    except ImportError:
-        TypedDict = None
-else:
-    from typing import TypedDict
 
 from pydantic import (
     BaseModel,
@@ -1434,90 +1425,3 @@ def test_base_config_type_hinting():
         a: int
 
     get_type_hints(M.__config__)
-
-
-def test_named_tuple():
-    Position = namedtuple('Pos', 'x y')
-
-    class Event(NamedTuple):
-        a: int
-        b: int
-        c: int
-        d: str
-
-    class Model(BaseModel):
-        pos: Position
-        events: List[Event]
-
-    model = Model(pos=('1', 2), events=[[b'1', '2', 3, 'qwe']])
-    assert isinstance(model.pos, Position)
-    assert isinstance(model.events[0], Event)
-    assert model.pos.x == '1'
-    assert model.pos == Position('1', 2)
-    assert model.events[0] == Event(1, 2, 3, 'qwe')
-    assert repr(model) == "Model(pos=Pos(x='1', y=2), events=[Event(a=1, b=2, c=3, d='qwe')])"
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model(pos=('1', 2), events=[['qwe', '2', 3, 'qwe']])
-    assert exc_info.value.errors() == [
-        {
-            'loc': ('events', 0, 'a'),
-            'msg': 'value is not a valid integer',
-            'type': 'type_error.integer',
-        }
-    ]
-
-
-@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
-def test_typed_dict():
-    class TD(TypedDict):
-        a: int
-        b: int
-        c: int
-        d: str
-
-    class Model(BaseModel):
-        td: TD
-
-    m = Model(td={'a': '3', 'b': b'1', 'c': 4, 'd': 'qwe'})
-    assert m.td == {'a': 3, 'b': 1, 'c': 4, 'd': 'qwe'}
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model(td={'a': [1], 'b': 2, 'c': 3, 'd': 'qwe'})
-    assert exc_info.value.errors() == [
-        {
-            'loc': ('td', 'a'),
-            'msg': 'value is not a valid integer',
-            'type': 'type_error.integer',
-        }
-    ]
-
-
-@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
-def test_typed_dict_non_total():
-    class FullMovie(TypedDict, total=True):
-        name: str
-        year: int
-
-    class Model(BaseModel):
-        movie: FullMovie
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model(movie={'year': '2002'})
-    assert exc_info.value.errors() == [
-        {
-            'loc': ('movie', 'name'),
-            'msg': 'field required',
-            'type': 'value_error.missing',
-        }
-    ]
-
-    class PartialMovie(TypedDict, total=False):
-        name: str
-        year: int
-
-    class Model(BaseModel):
-        movie: PartialMovie
-
-    m = Model(movie={'year': '2002'})
-    assert m.movie == {'year': 2002}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,18 @@
 import sys
+from collections import namedtuple
 from enum import Enum
-from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Type, get_type_hints
+from typing import Any, Callable, ClassVar, Dict, List, Mapping, NamedTuple, Optional, Type, get_type_hints
 from uuid import UUID, uuid4
 
 import pytest
+
+if sys.version_info < (3, 8):
+    try:
+        from typing import TypedDict
+    except ImportError:
+        TypedDict = None
+else:
+    from typing import TypedDict
 
 from pydantic import (
     BaseModel,
@@ -1428,9 +1437,6 @@ def test_base_config_type_hinting():
 
 
 def test_named_tuple():
-    from collections import namedtuple
-    from typing import NamedTuple
-
     Position = namedtuple('Pos', 'x y')
 
     class Event(NamedTuple):
@@ -1462,9 +1468,8 @@ def test_named_tuple():
     ]
 
 
+@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
 def test_typed_dict():
-    from typing import TypedDict
-
     class TD(TypedDict):
         a: int
         b: int
@@ -1488,9 +1493,8 @@ def test_typed_dict():
     ]
 
 
+@pytest.mark.skipif(not TypedDict, reason='typing_extensions not installed')
 def test_typed_dict_non_total():
-    from typing import TypedDict
-
     class FullMovie(TypedDict, total=True):
         name: str
         year: int

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -33,10 +33,11 @@ def test_is_namedtuple():
     assert is_namedtuple(Employee) is True
     assert is_namedtuple(NamedTuple('Employee', [('name', str), ('id', int)])) is True
 
-    class SubTuple(tuple):
-        ...
+    class Other(tuple):
+        name: str
+        id: int
 
-    assert is_namedtuple(SubTuple) is False
+    assert is_namedtuple(Other) is False
 
 
 @pytest.mark.parametrize('TypedDict', (t for t in ALL_TYPEDDICT_KINDS if t is not None))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,55 @@
+from collections import namedtuple
+from typing import NamedTuple
+
+import pytest
+
+from pydantic.typing import is_namedtuple, is_typeddict
+
+try:
+    from typing import TypedDict as typing_TypedDict
+except ImportError:
+    typing_TypedDict = None
+
+try:
+    from typing_extensions import TypedDict as typing_extensions_TypedDict
+except ImportError:
+    typing_extensions_TypedDict = None
+
+
+try:
+    from mypy_extensions import TypedDict as mypy_extensions_TypedDict
+except ImportError:
+    mypy_extensions_TypedDict = None
+
+ALL_TYPEDDICT_KINDS = (typing_TypedDict, typing_extensions_TypedDict, mypy_extensions_TypedDict)
+
+
+def test_is_namedtuple():
+    class Employee(NamedTuple):
+        name: str
+        id: int = 3
+
+    assert is_namedtuple(namedtuple('Point', 'x y')) is True
+    assert is_namedtuple(Employee) is True
+    assert is_namedtuple(NamedTuple('Employee', [('name', str), ('id', int)])) is True
+
+    class SubTuple(tuple):
+        ...
+
+    assert is_namedtuple(SubTuple) is False
+
+
+@pytest.mark.parametrize('TypedDict', (t for t in ALL_TYPEDDICT_KINDS if t is not None))
+def test_is_typeddict_typing(TypedDict):
+    class Employee(TypedDict):
+        name: str
+        id: int
+
+    assert is_typeddict(Employee) is True
+    assert is_typeddict(TypedDict('Employee', {'name': str, 'id': int})) is True
+
+    class Other(dict):
+        name: str
+        id: int
+
+    assert is_typeddict(Other) is False


### PR DESCRIPTION
## Change Summary
<img width="716" alt="Screen Shot 2020-12-23 at 1 58 37 AM" src="https://user-images.githubusercontent.com/18406791/102947228-22e9ef00-44c3-11eb-863c-d3b12b2debad.png">

Also expose two utils
- `create_model_from_namedtuple`
- `create_model_from_typeddict`

<img width="805" alt="Screen Shot 2021-01-17 at 11 57 29 PM" src="https://user-images.githubusercontent.com/18406791/104858478-ca6e0c00-591f-11eb-8fb9-3851aa40fe52.png">

## Related issue number

fix #760
fix #1324
fix #1430

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
