### PR TITLE
fix: force need of `update_forward_refs` in recursive models

### DIFF
--- a/changes/1201-PrettyWood.md
+++ b/changes/1201-PrettyWood.md
@@ -1,0 +1,1 @@
+Fix: some recursive models did not require `update_forward_refs` and silently behaved incorrectly

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -25,7 +25,7 @@ from typing import (
 from . import errors as errors_
 from .class_validators import Validator, make_generic_validator, prep_validators
 from .error_wrappers import ErrorWrapper
-from .errors import NoneIsNotAllowedError
+from .errors import ConfigError, NoneIsNotAllowedError
 from .types import Json, JsonWrapper
 from .typing import (
     Callable,
@@ -563,6 +563,12 @@ class ModelField(Representation):
     def validate(
         self, v: Any, values: Dict[str, Any], *, loc: 'LocStr', cls: Optional['ModelOrDc'] = None
     ) -> 'ValidateReturn':
+
+        if self.type_.__class__ is ForwardRef:
+            error_msg = f'field "{self.name}" not yet prepared so type is still a ForwardRef'
+            if cls is not None:
+                error_msg += f', you might need to call {cls.__name__}.update_forward_refs().'
+            raise ConfigError(error_msg)
 
         errors: Optional['ErrorList']
         if self.pre_validators:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -565,10 +565,11 @@ class ModelField(Representation):
     ) -> 'ValidateReturn':
 
         if self.type_.__class__ is ForwardRef:
-            error_msg = f'field "{self.name}" not yet prepared so type is still a ForwardRef'
-            if cls is not None:
-                error_msg += f', you might need to call {cls.__name__}.update_forward_refs().'
-            raise ConfigError(error_msg)
+            assert cls is not None
+            raise ConfigError(
+                f'field "{self.name}" not yet prepared so type is still a ForwardRef, '
+                f'you might need to call {cls.__name__}.update_forward_refs().'
+            )
 
         errors: Optional['ErrorList']
         if self.pre_validators:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -34,15 +34,7 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import default_ref_template, model_schema
 from .types import PyObject, StrBytes
-from .typing import (
-    AnyCallable,
-    ForwardRef,
-    get_args,
-    get_origin,
-    is_classvar,
-    resolve_annotations,
-    update_field_forward_refs,
-)
+from .typing import AnyCallable, get_args, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
 from .utils import (
     ROOT_KEY,
     ClassAttribute,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -34,7 +34,7 @@ from .json import custom_pydantic_encoder, pydantic_encoder
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import default_ref_template, model_schema
 from .types import PyObject, StrBytes
-from .typing import AnyCallable, ForwardRef, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
+from .typing import AnyCallable, get_origin, is_classvar, resolve_annotations, update_field_forward_refs
 from .utils import (
     ROOT_KEY,
     ClassAttribute,
@@ -957,12 +957,6 @@ def validate_model(  # noqa: C901 (ignore complexity)
             return {}, set(), ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], cls_)
 
     for name, field in model.__fields__.items():
-        if field.type_.__class__ == ForwardRef:
-            raise ConfigError(
-                f'field "{field.name}" not yet prepared so type is still a ForwardRef, '
-                f'you might need to call {cls_.__name__}.update_forward_refs().'
-            )
-
         value = input_data.get(field.alias, _missing)
         using_name = False
         if value is _missing and config.allow_population_by_field_name and field.alt_alias:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1,8 +1,9 @@
 import sys
+from typing import Optional, Tuple
 
 import pytest
 
-from pydantic import ConfigError, ValidationError
+from pydantic import BaseModel, ConfigError, ValidationError
 
 skip_pre_37 = pytest.mark.skipif(sys.version_info < (3, 7), reason='testing >= 3.7 behaviour only')
 
@@ -477,3 +478,19 @@ def test_forward_ref_with_create_model(create_module):
         Main = pydantic.create_model('Main', sub=('Sub', ...), __module__=__name__)
         instance = Main(sub={})
         assert instance.sub.dict() == {'foo': 'bar'}
+
+
+def test_nested_forward_ref():
+    class NestedTuple(BaseModel):
+        x: Tuple[int, Optional['NestedTuple']]
+
+    with pytest.raises(ConfigError) as exc_info:
+        NestedTuple.parse_obj({'x': ('1', {'x': ('2', {'x': ('3', None)})})})
+    assert str(exc_info.value) == (
+        'field "x_1" not yet prepared so type is still a ForwardRef, '
+        'you might need to call NestedTuple.update_forward_refs().'
+    )
+
+    NestedTuple.update_forward_refs()
+    obj = NestedTuple.parse_obj({'x': ('1', {'x': ('2', {'x': ('3', None)})})})
+    assert obj.dict() == {'x': (1, {'x': (2, {'x': (3, None)})})}

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -482,7 +482,7 @@ def test_forward_ref_with_create_model(create_module):
 
 def test_nested_forward_ref():
     class NestedTuple(BaseModel):
-        x: Tuple[int, Optional['NestedTuple']]
+        x: Tuple[int, Optional['NestedTuple']]  # noqa: F821
 
     with pytest.raises(ConfigError) as exc_info:
         NestedTuple.parse_obj({'x': ('1', {'x': ('2', {'x': ('3', None)})})})


### PR DESCRIPTION
## Change Summary
Currently in nested models, we only check if the type of the field is `ForwardRef` to raise an error.
But we could have `ForwardRef` inside a `Union`, a `Tuple` or anything else...
By not catching this we get a wrong behaviour

## Related issue number
closes #1201

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
