### PR TITLE
fix(schema): fix schema generation with multiple Enums having the same name

### DIFF
--- a/changes/1857-PrettyWood.md
+++ b/changes/1857-PrettyWood.md
@@ -1,0 +1,1 @@
+fix schema generation with multiple Enums having the same name

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -781,7 +781,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         f_schema['const'] = literal_value
 
     if lenient_issubclass(field_type, Enum):
-        enum_name = normalize_name(field_type.__name__)
+        enum_name = model_name_map[field_type]
         f_schema, schema_overrides = get_field_info_schema(field)
         f_schema.update(get_schema_ref(enum_name, ref_prefix, ref_template, schema_overrides))
         definitions[enum_name] = enum_process_schema(field_type)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2097,3 +2097,55 @@ def test_new_type():
         'properties': {'a': {'title': 'A', 'type': 'string'}},
         'required': ['a'],
     }
+
+
+def test_multiple_enums_with_same_name(create_module):
+    module_1 = create_module(
+        # language=Python
+        """
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class MyEnum(str, Enum):
+    a = 'a'
+    b = 'b'
+    c = 'c'
+
+
+class MyModel(BaseModel):
+    my_enum_1: MyEnum
+        """
+    )
+
+    module_2 = create_module(
+        # language=Python
+        """
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class MyEnum(str, Enum):
+    d = 'd'
+    e = 'e'
+    f = 'f'
+
+
+class MyModel(BaseModel):
+    my_enum_2: MyEnum
+        """
+    )
+
+    class Model(BaseModel):
+        my_model_1: module_1.MyModel
+        my_model_2: module_2.MyModel
+
+    assert len(Model.schema()['definitions']) == 4
+    assert set(Model.schema()['definitions']) == {
+        f'{module_1.__name__}__MyEnum',
+        f'{module_1.__name__}__MyModel',
+        f'{module_2.__name__}__MyEnum',
+        f'{module_2.__name__}__MyModel',
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Two Enums with the same name were overlapping because we were not using the "long name" (module name + `__name__` (soon `__qualname__` but that's another PR...cf #2170))
Since we were already computing the long names for both models and enums, the fix is trivial!

## Related issue number
closes #1857

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
