### PR TITLE
[wip] change field order to have overwritten fields at the end

### DIFF
--- a/changes/2234-PrettyWood.md
+++ b/changes/2234-PrettyWood.md
@@ -1,0 +1,1 @@
+Allow validating overwritten fields (in submodels) based on other fields by putting those overwritten fields at the end of `__fields__`.

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -336,7 +336,6 @@ def test_alias_priority():
             def alias_generator(x):
                 return f'{x}_generator_child'
 
-    # debug([f.alias for f in Parent.__fields__.values()], [f.alias for f in Child.__fields__.values()])
     assert [f.alias for f in Parent.__fields__.values()] == [
         'a_field_parent',
         'b_field_parent',
@@ -345,9 +344,9 @@ def test_alias_priority():
         'e_generator_parent',
     ]
     assert [f.alias for f in Child.__fields__.values()] == [
-        'a_field_child',
         'b_config_child',
         'c_field_parent',
         'd_config_parent',
         'e_generator_child',
+        'a_field_child',
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
When we overwrite parent fields in submodels, we can't trigger validation because the order of the fields is not updated.
⚠️ This PR is just to **showcase** a possible workaround
but it breaks current behaviour and will **NOT** be merged as is of course ⚠️ 

```python
"""
Case that works at the moment on `master` but would break with this PR
"""
from typing import Dict

from pydantic import BaseModel, validator


class M1(BaseModel):
    a: int
    b: int

    @validator('b')
    def assert_b_equal_a(cls, v: int, values: Dict[str, int]) -> int:
        assert 'a' in values and v == values['a']
        return v


class M2(M1):
    a: int = 3

print(repr(M2(b=3)))
# M2(a=3, b=3)
```

```python
"""
Case that would now work and currently fails on `master`
"""
from typing import Dict

from pydantic import BaseModel, validator


class M1(BaseModel):
    a: int
    b: int


class M2(M1):
    a: float = 1.5

    @validator('a', always=True)
    def assert_b_is_twice_a(cls, v: int, values: Dict[str, int]) -> int:
        assert 'b' in values and v == values['b'] / 2
        return v

print(repr(M2(b=3)))
# M2(b=3, a=1.5)
```

## Related issue number
#2234
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
