### PR TITLE
Allow for fragments of models (partials)

### DIFF
--- a/pydantic/fragments.py
+++ b/pydantic/fragments.py
@@ -33,35 +33,22 @@ class Fragment(GenericModel, Generic[T]):
     attributes to be set.
     """
 
-    model_: Type[T]
-
     class Config:
         extra = 'allow'  # essentially everything is extra.
         allow_mutation = False
 
-    def __init__(__pydantic_self__, __model__: Optional[Type[T]] = None, **data: Any):
+    def __init__(__pydantic_self__, **data: Any):
         """Initialises the Fragment by validating against __model__'s fields.
         Args:
             __model__: The model this is a fragment of - positional only.
             **data: The fields expected by the __model__.
         """
 
-        model = __model__  # __model__ is underscored in the method arguments to prevent a name clash.
-
-        if model is None and __pydantic_self__.__concrete__:
-            expected_model_type = __pydantic_self__.__fields__['model_'].type_.__args__[0]
+        if __pydantic_self__.__concrete__:
+            expected_model_type = type(__pydantic_self__)
             model = expected_model_type
-
-        elif model and not __pydantic_self__.__concrete__:
-            # Still generic
-            expected_model_type = model
-
-        elif model is None and not __pydantic_self__.__concrete__:
-            raise TypeError('Fragments must be of another model.')
-
         else:
-            if model != expected_model_type:
-                raise TypeError(f'Expected a fragment of {expected_model_type}.')
+            raise TypeError('Fragments must be of another model.')
 
         values: Dict[str, Any] = {}
         errors = []

--- a/pydantic/fragments.py
+++ b/pydantic/fragments.py
@@ -19,7 +19,7 @@ from pydantic.generics import GenericModel
 
 DictStrAny = Dict[str, Any]
 
-T = TypeVar("T", bound=BaseModel)
+T = TypeVar('T', bound=BaseModel)
 
 _missing = object()
 
@@ -36,10 +36,10 @@ class Fragment(GenericModel, Generic[T]):
     model_: Type[T]
 
     class Config:
-        extra = "allow"  # essentially everything is extra.
+        extra = 'allow'  # essentially everything is extra.
         allow_mutation = False
 
-    def __init__(__pydantic_self__, __model__: Optional[Type[T]] = None, **data):
+    def __init__(__pydantic_self__, __model__: Optional[Type[T]] = None, **data: Any):
         """Initialises the Fragment by validating against __model__'s fields.
         Args:
             __model__: The model this is a fragment of - positional only.
@@ -49,7 +49,7 @@ class Fragment(GenericModel, Generic[T]):
         model = __model__  # __model__ is underscored in the method arguments to prevent a name clash.
 
         if model is None and __pydantic_self__.__concrete__:
-            expected_model_type = __pydantic_self__.__fields__["model_"].type_.__args__[0]
+            expected_model_type = __pydantic_self__.__fields__['model_'].type_.__args__[0]
             model = expected_model_type
 
         elif model and not __pydantic_self__.__concrete__:
@@ -57,11 +57,11 @@ class Fragment(GenericModel, Generic[T]):
             expected_model_type = model
 
         elif model is None and not __pydantic_self__.__concrete__:
-            raise TypeError("Fragments must be of another model.")
+            raise TypeError('Fragments must be of another model.')
 
         else:
             if model != expected_model_type:
-                raise TypeError(f"Expected a fragment of {expected_model_type}.")
+                raise TypeError(f'Expected a fragment of {expected_model_type}.')
 
         values: Dict[str, Any] = {}
         errors = []
@@ -85,39 +85,38 @@ class Fragment(GenericModel, Generic[T]):
         if errors:
             raise (ValidationError(errors, model))
         else:
-            if model.__config__.extra == "allow":
+            if model.__config__.extra == 'allow':
                 values.update(data)
-            values["model_"] = model
-            object.__setattr__(__pydantic_self__, "__dict__", values)
-            object.__setattr__(__pydantic_self__, "__fields_set__", fields_set)
+            values['model_'] = model
+            object.__setattr__(__pydantic_self__, '__dict__', values)
+            object.__setattr__(__pydantic_self__, '__fields_set__', fields_set)
             __pydantic_self__._init_private_attributes()
 
     @classmethod
-    def schema(cls, *args, **kwargs) -> DictStrAny:
+    def schema(cls, *args: Any, **kwargs: Any) -> DictStrAny:
         """Overrides the standard BaseModel schema.
 
         The standard basemodel schema is generated, but all fields
-        are removed from "required". "Fragment" is appended to the title of the schema.
+        are removed from 'required'. 'Fragment' is appended to the title of the schema.
 
         The model_ field is excluded from the schema as it represents a type.
         """
         if cls.__concrete__:
-            model = cls.__fields__["model_"].type_.__args__[0]
+            model = cls.__fields__['model_'].type_.__args__[0]
             model_schema = model.schema(*args, **kwargs)
-            model_schema["required"] = []
-            model_schema["title"] = model_schema["title"] + "Fragment"
-            return model_schema
+            title = model_schema['title'] + 'Fragment'
+            return {**model_schema, **{'required': [], 'title': title}}
         else:
             # todo: no idea what to return of not concrete,
             #       and because classmethod can't use __pydantic_self__.model_
             return {}
 
-    def dict(__pydantic_self__, *args, **kwargs) -> DictStrAny:
-        """Overrides the standard BaseModel dict to exclude "model_"."""
+    def dict(self, *args: Any, **kwargs: Any) -> DictStrAny:
+        """Overrides the standard BaseModel dict to exclude 'model_'."""
         exclude = {
-            "model_",
+            'model_',
         }
-        user_exclude = kwargs.pop("exclude", None)
+        user_exclude = kwargs.pop('exclude', None)
         if user_exclude:
             exclude = exclude.union(user_exclude)
         return super().dict(*args, exclude=exclude, **kwargs)

--- a/pydantic/fragments.py
+++ b/pydantic/fragments.py
@@ -1,0 +1,123 @@
+"""This module defines a fragment model for pydantic.
+
+To do:
+    - schema generation currently only works when done directly
+      on a concrete instance of the model.
+    - calling schema() on a model containing a Fragment will
+      currently fail
+    - is it possible to make Fragment(FullModel, a=1, b=2)
+      equivalent to Fragment[FullModel](a=1, b=2)?
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Generic, Optional, Set, Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+from pydantic.error_wrappers import ErrorWrapper
+from pydantic.generics import GenericModel
+
+DictStrAny = Dict[str, Any]
+
+T = TypeVar("T", bound=BaseModel)
+
+_missing = object()
+
+
+class Fragment(GenericModel, Generic[T]):
+    """Fragment of a pydantic model.
+
+
+    A fragment of a model is a subset of that model, requiring that
+    set attributes are individually valid but not requiring any
+    attributes to be set.
+    """
+
+    model_: Type[T]
+
+    class Config:
+        extra = "allow"  # essentially everything is extra.
+        allow_mutation = False
+
+    def __init__(__pydantic_self__, __model__: Optional[Type[T]] = None, **data):
+        """Initialises the Fragment by validating against __model__'s fields.
+        Args:
+            __model__: The model this is a fragment of - positional only.
+            **data: The fields expected by the __model__.
+        """
+
+        model = __model__  # __model__ is underscored in the method arguments to prevent a name clash.
+
+        if model is None and __pydantic_self__.__concrete__:
+            expected_model_type = __pydantic_self__.__fields__["model_"].type_.__args__[0]
+            model = expected_model_type
+
+        elif model and not __pydantic_self__.__concrete__:
+            # Still generic
+            expected_model_type = model
+
+        elif model is None and not __pydantic_self__.__concrete__:
+            raise TypeError("Fragments must be of another model.")
+
+        else:
+            if model != expected_model_type:
+                raise TypeError(f"Expected a fragment of {expected_model_type}.")
+
+        values: Dict[str, Any] = {}
+        errors = []
+        fields_set: Set[str] = set()
+        for name, field in model.__fields__.items():
+            value = data.pop(field.alias, _missing)
+            # using_name = False
+            if value is _missing and model.__config__.allow_population_by_field_name and field.alt_alias:
+                value = data.get(field.name, _missing)
+                # using_name = True
+            if value is not _missing:
+                # add to field_set?
+                # check_extra?
+                v_, errors_ = field.validate(value, values, loc=field.alias, cls=model)
+                if isinstance(errors_, ErrorWrapper):
+                    errors.append(errors_)
+                elif isinstance(errors_, list):
+                    errors.extend(errors_)
+                else:
+                    values[name] = v_
+        if errors:
+            raise (ValidationError(errors, model))
+        else:
+            if model.__config__.extra == "allow":
+                values.update(data)
+            values["model_"] = model
+            object.__setattr__(__pydantic_self__, "__dict__", values)
+            object.__setattr__(__pydantic_self__, "__fields_set__", fields_set)
+            __pydantic_self__._init_private_attributes()
+
+    @classmethod
+    def schema(cls, *args, **kwargs) -> DictStrAny:
+        """Overrides the standard BaseModel schema.
+
+        The standard basemodel schema is generated, but all fields
+        are removed from "required". "Fragment" is appended to the title of the schema.
+
+        The model_ field is excluded from the schema as it represents a type.
+        """
+        if cls.__concrete__:
+            model = cls.__fields__["model_"].type_.__args__[0]
+            model_schema = model.schema(*args, **kwargs)
+            model_schema["required"] = []
+            model_schema["title"] = model_schema["title"] + "Fragment"
+            return model_schema
+        else:
+            # todo: no idea what to return of not concrete,
+            #       and because classmethod can't use __pydantic_self__.model_
+            return {}
+
+    def dict(__pydantic_self__, *args, **kwargs) -> DictStrAny:
+        """Overrides the standard BaseModel dict to exclude "model_"."""
+        exclude = {
+            "model_",
+        }
+        user_exclude = kwargs.pop("exclude", None)
+        if user_exclude:
+            exclude = exclude.union(user_exclude)
+        return super().dict(*args, exclude=exclude, **kwargs)

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -1,0 +1,47 @@
+import sys
+
+import pytest
+
+from pydantic import BaseModel, conint
+from pydantic.fragments import Fragment
+
+skip_36 = pytest.mark.skipif(sys.version_info < (3, 7), reason='generics only supported for python 3.7 and above')
+
+
+@pytest.fixture
+def OriginalModel():
+    class Cheese(BaseModel):
+        name: str
+        origin: str
+        strength: conint(ge=0, le=10) = 5
+
+    return Cheese
+
+
+@skip_36
+def test_fragment_of_model(OriginalModel):
+    """Test that no ValidationError is raised for missing fields in Fragment."""
+    Fragment[OriginalModel](name='Red Leicester')
+
+
+@skip_36
+def test_dict_export_of_fragment(OriginalModel):
+    """Test that exporting a fragment instance includes only set fields."""
+    expected = {'name': 'Stilton'}
+    crumb = Fragment[OriginalModel](name='Stilton')
+    assert crumb.dict() == expected
+
+
+@skip_36
+def test_schema_of_fragment(OriginalModel):
+    """Test that the only differences to original schema are title and required."""
+    fragment_schema = Fragment[OriginalModel].schema()
+    title = fragment_schema.pop('title')
+    required = fragment_schema.pop('required')
+    title == 'CheeseFragment'
+    required == []
+
+    original_schema = OriginalModel.schema()
+    original_schema.pop('title')
+    original_schema.pop('required')
+    assert str(fragment_schema) == str(original_schema)


### PR DESCRIPTION
## Change Summary

This change allows for fragments of models, described in #1673 as "Partial"s, but I personally don't like the overlap with functools.partial.

A `Fragment` of a model validates all received fields against that model, but doesn't require any. An example use case is an HTTP PATCH.

It is intended to be used like this:
```python
from pydantic import BaseModel, conint
from pydantic.fragments import Fragment

class Customer(BaseModel):
    name: str
    age: conint(ge=18)

Fragment[Customer](name="John") .dict() # {'name': 'John'}
Fragment[Customer](age=14)  # validation error
```

I didn't want to submit this until it was completely ready to go, but I'd appreciate feedback and advice on a couple of things.
1) In my current implementation, trying to access the schema of a model which contains a Fragment field fails - I am not certain of where to address this, nor what the schema should actually be!
2) The current solution has some hacky aspects because I am unable to introspect the type of the original model without having it as a field. I'd appreciate some comments from someone who understands generics better than I do. Most of the code the test doesn't currently cover is stuff that I would remove if I could get around this aspect.

## Related issue number

#1673

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
