### PR TITLE
fix: keep order of fields with `BaseModel.construct()`

### DIFF
--- a/changes/2281-PrettyWood.md
+++ b/changes/2281-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: keep order of fields with `BaseModel.construct()`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -586,9 +586,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         Default values are respected, but no other validation is performed.
         """
         m = cls.__new__(cls)
-        # default field values
-        fields_values = {name: field.get_default() for name, field in cls.__fields__.items() if not field.required}
-        fields_values.update(values)
+        fields_values: Dict[str, Any] = {}
+        for name, field in cls.__fields__.items():
+            if name in values:
+                fields_values[name] = values[name]
+            elif not field.required:
+                fields_values[name] = field.get_default()
         object_setattr(m, '__dict__', fields_values)
         if _fields_set is None:
             _fields_set = set(values.keys())

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -584,6 +584,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         """
         Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.
         Default values are respected, but no other validation is performed.
+        Behaves as if `Config.extra = 'allow'` was set since it adds all passed values
         """
         m = cls.__new__(cls)
         fields_values: Dict[str, Any] = {}
@@ -592,6 +593,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 fields_values[name] = values[name]
             elif not field.required:
                 fields_values[name] = field.get_default()
+        fields_values.update(values)
         object_setattr(m, '__dict__', fields_values)
         if _fields_set is None:
             _fields_set = set(values.keys())

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -35,6 +35,19 @@ def test_construct_fields_set():
     assert m.dict() == {'a': 3, 'b': -1}
 
 
+def test_construct_keep_order():
+    class Foo(BaseModel):
+        a: int
+        b: int = 42
+        c: float
+
+    instance = Foo(a=1, b=321, c=3.14)
+    instance_construct = Foo.construct(**instance.dict())
+    assert instance == instance_construct
+    assert instance.dict() == instance_construct.dict()
+    assert instance.json() == instance_construct.json()
+
+
 def test_large_any_str():
     class Model(BaseModel):
         a: bytes

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -35,6 +35,15 @@ def test_construct_fields_set():
     assert m.dict() == {'a': 3, 'b': -1}
 
 
+def test_construct_allow_extra():
+    """construct() should allow extra fields"""
+
+    class Foo(BaseModel):
+        x: int
+
+    assert Foo.construct(x=1, y=2).dict() == {'x': 1, 'y': 2}
+
+
 def test_construct_keep_order():
     class Foo(BaseModel):
         a: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Order of fields with `BaseModel.construct()` was not maintained with the current implementation.
I changed it a little. It doesn't seem to have a bad impact of performance (which is the whole purpose of `construct`)

```python
from pydantic import BaseModel


class Foo(BaseModel):
    a: int
    b: int = 42
    c: float

values = {k: 1 for k in 'qwertyuiopasdfghjklzxcvbnm'}

def f():
    Foo.construct(**{'a': 1, 'b': 42, 'c': 3.14})
    Foo.construct(**{'a': 1, 'c': 3.14})
    Foo.construct(**{'a': 1, 'c': 3.14, 'qwe': 123, **values})


if __name__ == '__main__':
    import timeit
    print(timeit.timeit("f()", number=10_000_000, setup="from __main__ import f"))

# 133.25740689 BEFORE
# 125.656012296 AFTER
```

## Related issue number
closes #2281

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
