### PR TITLE
fix: update `__fields_set__` in `BaseModel.copy(update=…)`

### DIFF
--- a/changes/2290-PrettyWood.md
+++ b/changes/2290-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: update `__fields_set__` in `BaseModel.copy(update=…)`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -628,9 +628,11 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         m = cls.__new__(cls)
         object_setattr(m, '__dict__', v)
         # new `__fields_set__` can have unset optional fields with a set value in `update` kwarg
-        object_setattr(
-            m, '__fields_set__', {k for k in self.__fields__ if k in self.__fields_set__ | set(update or {})}
-        )
+        if update:
+            fields_set = self.__fields_set__ | update.keys()
+        else:
+            fields_set = set(self.__fields_set__)
+        object_setattr(m, '__fields_set__', fields_set)
         for name in self.__private_attributes__:
             value = getattr(self, name, Undefined)
             if value is not Undefined:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -627,7 +627,10 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         cls = self.__class__
         m = cls.__new__(cls)
         object_setattr(m, '__dict__', v)
-        object_setattr(m, '__fields_set__', self.__fields_set__.copy())
+        # new `__fields_set__` can have unset optional fields with a set value in `update` kwarg
+        object_setattr(
+            m, '__fields_set__', {k for k in self.__fields__ if k in self.__fields_set__ | set(update or {})}
+        )
         for name in self.__private_attributes__:
             value = getattr(self, name, Undefined)
             if value is not Undefined:

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Any, List
+from typing import Any, List, Optional
 
 import pytest
 
@@ -189,6 +189,14 @@ def test_copy_update():
     assert set(m.dict().keys()) == set(m2.dict().keys()) == {'a', 'b', 'c', 'd'}
 
     assert m != m2
+
+
+def test_copy_update_unset():
+    class Foo(BaseModel):
+        foo: Optional[str]
+        bar: Optional[str]
+
+    assert Foo(foo='hello').copy(update={'bar': 'world'}).json(exclude_unset=True) == '{"foo": "hello", "bar": "world"}'
 
 
 def test_copy_set_fields():


### PR DESCRIPTION
## Change Summary
`BaseModel.copy(update=...)` is useful to copy a `BaseModel` while adding or updating a value.
But if we add an optional field that wasn't set before, it does not change the `__fields_set__` attribute used for `dict()`, `json()`, ...

## Related issue number
closes #2290

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
