### PR TITLE
Fix `python_requires` metadata to require >=3.6.1

### DIFF
--- a/changes/2306-hukkinj1.md
+++ b/changes/2306-hukkinj1.md
@@ -1,0 +1,1 @@
+fix: `python_requires` metadata to require >=3.6.1

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
     license='MIT',
     packages=['pydantic'],
     package_data={'pydantic': ['py.typed']},
-    python_requires='>=3.6',
+    python_requires='>=3.6.1',
     zip_safe=False,  # https://mypy.readthedocs.io/en/latest/installed_packages.html
     install_requires=[
         'dataclasses>=0.6;python_version<"3.7"'


### PR DESCRIPTION
At least [this `typing.Deque` import](https://github.com/samuelcolvin/pydantic/blob/bd9c5723c676395363689549268738153e45a7e5/pydantic/validators.py#L13) requires Python version to be >=3.6.1.

This PR fixes `python_requires` metadata.