### PR TITLE
Add docs warning about overwriting validate

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -5,6 +5,11 @@ Custom validation and complex relationships between objects can be achieved usin
 ```
 _(This script is complete, it should run "as is")_
 
+!!! warning
+  Validators should not overwrite `BaseModel.validate()`. Instead, give the validator function a unique name.
+  
+  This may be fixed in v2 - see [samuelcolvin/pydantic#1001](https://github.com/samuelcolvin/pydantic/issues/1001).
+
 A few things to note on validators:
 
 * validators are "class methods", so the first argument value they receive is the `UserModel` class, not an instance

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -6,11 +6,10 @@ Custom validation and complex relationships between objects can be achieved usin
 _(This script is complete, it should run "as is")_
 
 !!! warning
-  Validators should not overwrite `BaseModel.validate()`. Instead, give the validator function a unique name.
-  
-  This may be fixed in v2 - see [samuelcolvin/pydantic#1001](https://github.com/samuelcolvin/pydantic/issues/1001).
+    Validators should not overwrite `BaseModel.validate()`. Instead, give the validator function a unique name.
+    This may be fixed in v2 - see [samuelcolvin/pydantic#1001](https://github.com/samuelcolvin/pydantic/issues/1001).
 
-A few things to note on validators:
+A few other things to note on validators:
 
 * validators are "class methods", so the first argument value they receive is the `UserModel` class, not an instance
   of `UserModel`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Adds a very short warning against overwriting BaseModel.validate() to the validators documentation, as @PrettyWood suggested would be helpful.
<!-- Please give a short summary of the changes. -->

## Related issue number
Closes #2289 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
