### PR TITLE
fix ci on i686 by ensuring order of created list

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1449,7 +1449,6 @@ def test_inherited_model_field_copy():
     assert id(image_2) != id(item.images[1])
 
 
-@pytest.mark.xfail(reason='see https://github.com/samuelcolvin/pydantic/pull/2193#issuecomment-778345456')
 def test_inherited_model_field_untouched():
     """It should not copy models used as fields if explicitly asked"""
 
@@ -1468,7 +1467,7 @@ def test_inherited_model_field_untouched():
     image_1 = Image(path='my_image1.png')
     image_2 = Image(path='my_image2.png')
 
-    item = Item(images={image_1, image_2})
+    item = Item(images=(image_1, image_2))
     assert image_1 in item.images
 
     assert id(image_1) == id(item.images[0])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
The error was so dumb... 🤦 I had a `set` in my example and order of `set` is not guaranteed.
Tested locally in a `quay.io/pypa/manylinux2014_i686` container

### BEFORE
<img width="830" alt="Screen Shot 2021-02-13 at 12 10 27 AM" src="https://user-images.githubusercontent.com/18406791/107832321-67418f00-6d90-11eb-8d05-707f056611fb.png">

### AFTER
<img width="833" alt="Screen Shot 2021-02-13 at 12 11 00 AM" src="https://user-images.githubusercontent.com/18406791/107832324-6ad51600-6d90-11eb-842a-055239df6cfc.png">


<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
