### PR TITLE
Allow to configure models through class kwargs

### DIFF
--- a/changes/2356-MrMrRobat.md
+++ b/changes/2356-MrMrRobat.md
@@ -1,0 +1,1 @@
+Allow configuring models through class kwargs

--- a/docs/examples/model_config_class_kwargs.py
+++ b/docs/examples/model_config_class_kwargs.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, ValidationError, Extra
+
+
+class Model(BaseModel, extra=Extra.forbid):
+    a: str
+
+
+try:
+    Model(a='spam', b='oh no')
+except ValidationError as e:
+    print(e)

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -1,4 +1,4 @@
-Behaviour of _pydantic_ can be controlled via the `Config` class on a model or a _pydantic_ dataclass.
+Behaviour of _pydantic_ can be controlled via the `Config` class on a model, model class kwargs, or a _pydantic_ dataclass.
 
 Options:
 
@@ -89,8 +89,13 @@ not be included in the model schemas. **Note**: this means that attributes on th
 ```
 _(This script is complete, it should run "as is")_
 
-Similarly, if using the `@dataclass` decorator:
+Also, you can specify config options as model class kwargs:
+```py
+{!.tmp_examples/model_config_class_kwargs.py!}
+```
+_(This script is complete, it should run "as is")_
 
+Similarly, if using the `@dataclass` decorator:
 ```py
 {!.tmp_examples/model_config_dataclass.py!}
 ```

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -1,4 +1,4 @@
-Behaviour of _pydantic_ can be controlled via the `Config` class on a model, model class kwargs, or a _pydantic_ dataclass.
+Behaviour of _pydantic_ can be controlled via the `Config` class on a model or a _pydantic_ dataclass.
 
 Options:
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -170,16 +170,16 @@ class BaseConfig:
 
 def inherit_config(self_config: 'ConfigType', parent_config: 'ConfigType', **namespace: Any) -> 'ConfigType':
     if not self_config:
-        base_classes = (parent_config,)
+        base_classes: Tuple['ConfigType', ...] = (parent_config,)
     elif self_config == parent_config:
         base_classes = (self_config,)
     else:
-        base_classes = self_config, parent_config  # type: ignore
-    
+        base_classes = self_config, parent_config
+
     namespace['json_encoders'] = {
-            **getattr(parent_config, 'json_encoders', {}),
-            **getattr(self_config, 'json_encoders', {}),
-        }
+        **getattr(parent_config, 'json_encoders', {}),
+        **getattr(self_config, 'json_encoders', {}),
+    }
 
     return type('Config', base_classes, namespace)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -86,6 +86,7 @@ def test_default_factory_no_type_field():
         return 1
 
     with pytest.raises(ConfigError) as e:
+
         class Model(BaseModel):
             a = Field(default_factory=myfunc)
 
@@ -802,6 +803,7 @@ def test_arbitrary_type_allowed_validation_fails():
 
 def test_arbitrary_types_not_allowed():
     with pytest.raises(RuntimeError) as exc_info:
+
         class ArbitraryTypeNotAllowedModel(BaseModel):
             t: ArbitraryType
 
@@ -893,6 +895,7 @@ def test_annotation_field_name_shadows_attribute():
 def test_value_field_name_shadows_attribute():
     # When defining a model that has an attribute with the name of a built-in attribute, an exception is raised
     with pytest.raises(NameError):
+
         class BadModel(BaseModel):
             schema = 'abc'  # This conflicts with the BaseModel's schema() class method
 
@@ -1071,6 +1074,7 @@ def test_encode_nested_root():
 
 def test_root_failed():
     with pytest.raises(ValueError, match='__root__ cannot be mixed with other fields'):
+
         class MyModel(BaseModel):
             __root__: str
             a: str
@@ -1153,6 +1157,7 @@ def test_custom_types_fail_without_keep_untouched():
     classproperty = _ClassPropertyDescriptor
 
     with pytest.raises(RuntimeError) as e:
+
         class Model(BaseModel):
             @classproperty
             def class_name(cls) -> str:
@@ -1268,6 +1273,7 @@ def test_update_forward_refs_does_not_modify_module_dict():
 
 def test_two_defaults():
     with pytest.raises(ValueError, match='^cannot specify both default and default_factory$'):
+
         class Model(BaseModel):
             a: int = Field(default=3, default_factory=lambda: 3)
 
@@ -1490,6 +1496,7 @@ def test_class_kwargs_config_and_attr_conflict():
     with pytest.raises(
         TypeError, match='Specifying config in two places is ambiguous, use either Config attribute or class kwargs'
     ):
+
         class Model(BaseModel, extra='allow'):
             b: int
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Allow to configure models through class kwargs

```py
from pydantic import BaseModel

class Model(BaseModel, extra='allow'):
    foo: int
    bar: int
```
## Related issue number
Closes #2330

## Implementation details
Any kwargs that are passed into class and match attrs of `BaseConfig` will be included in config. 
All unused kwargs will be passed to `type` untouched so #867 won't break.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
