### PR TITLE
chore(deps-dev): fix `typing-extensions` version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,6 @@ mkdocs-exclude==1.0.2
 mkdocs-material==6.2.8
 markdown-include==0.6.0
 sqlalchemy
-typing-extensions==3.7.4
+typing-extensions==3.7.4.3
 orjson
 ujson


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
`typing-extensions` has been bumped to `3.4.7.3` in #2216 to have a good `DefaultDict` for python 3.8 and less.
But now when running `make install` and `make test`, the `TypedDict` related tests fail because the installed
version is `3.4.7`, which does not have `TypedDict` backport.
This fixes this

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
