### PR TITLE
make "resolve_annotations" more lenient, allowing for missing modules

### DIFF
--- a/changes/2363-samuelcolvin.md
+++ b/changes/2363-samuelcolvin.md
@@ -1,0 +1,1 @@
+Make `resolve_annotations` more lenient, allowing for missing modules

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -289,10 +289,16 @@ def resolve_annotations(raw_annotations: Dict[str, Type[Any]], module_name: Opti
 
     Resolve string or ForwardRef annotations into type objects if possible.
     """
+    base_globals: Optional[Dict[str, Any]] = None
     if module_name:
-        base_globals: Optional[Dict[str, Any]] = sys.modules[module_name].__dict__
-    else:
-        base_globals = None
+        try:
+            module = sys.modules[module_name]
+        except KeyError:
+            # happens occasionally, see https://github.com/samuelcolvin/pydantic/issues/2363
+            pass
+        else:
+            base_globals = module.__dict__
+
     annotations = {}
     for name, value in raw_annotations.items():
         if isinstance(value, str):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,5 +1,5 @@
-import sys
 import importlib.util
+import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
@@ -1780,12 +1780,14 @@ def test_resolve_annotations_module_missing(tmp_path):
     # see https://github.com/samuelcolvin/pydantic/issues/2363
     file_path = tmp_path / 'module_to_load.py'
     # language=Python
-    file_path.write_text("""
+    file_path.write_text(
+        """
 from pydantic import BaseModel
 class User(BaseModel):
     id: int
     name = 'Jane Doe'
-""")
+"""
+    )
 
     spec = importlib.util.spec_from_file_location('my_test_module', file_path)
     module = importlib.util.module_from_spec(spec)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,4 +1,5 @@
 import sys
+import importlib.util
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
@@ -1773,3 +1774,20 @@ return Model
     assert model.a == 10.2
     assert model.b == 10
     return model.get_double_a() == 20.2
+
+
+def test_resolve_annotations_module_missing(tmp_path):
+    # see https://github.com/samuelcolvin/pydantic/issues/2363
+    file_path = tmp_path / 'module_to_load.py'
+    # language=Python
+    file_path.write_text("""
+from pydantic import BaseModel
+class User(BaseModel):
+    id: int
+    name = 'Jane Doe'
+""")
+
+    spec = importlib.util.spec_from_file_location('my_test_module', file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.User(id=12).dict() == {'id': 12, 'name': 'Jane Doe'}


### PR DESCRIPTION
Make `resolve_annotations` more lenient, allowing for missing modules

## Related issue number

fix #2363 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
