### PR TITLE
Include new GitHub Discussions in contributing docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@ We'd love you to contribute to *pydantic*!
 
 ## Issues
 
-Questions, feature requests and bug reports are all welcome as issues. **However, to report a security
+Questions, feature requests and bug reports are all welcome as [discussions or issues](https://github.com/samuelcolvin/pydantic/issues/new/choose). **However, to report a security
 vulnerability, please see our [security policy](https://github.com/samuelcolvin/pydantic/security/policy).**
 
 To make it as simple as possible for us to help you, please include the output of the following call in your issue:


### PR DESCRIPTION
## Change Summary

Per https://github.com/samuelcolvin/pydantic/commit/502570706a09f9bae1c04486f5dd9e5d8a765c37 and https://github.com/samuelcolvin/pydantic/issues/1875#issuecomment-778610845, GitHub Discussions is now the preferred route for various types of communication (questions and feature requests). This PR makes a minor change to the Contributing documentation to reflect this, as well as a link to create an issue, which then has links to discussions as appropriate.

## Related issue number

N/A: trivial.

## Checklist

* [x] (N/A) Unit tests for the changes exist
* [x] (N/A) Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] (N/A) `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
