### PR TITLE
fix(ci): avoid false negative by disabling hypothesis health check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from _pytest.assertion.rewrite import AssertionRewritingHook
 
 # See https://hypothesis.readthedocs.io/en/latest/strategies.html#interaction-with-pytest-cov
 try:
-    import hypothesis  # noqa
+    from hypothesis import given  # noqa
 except ImportError:
     pytest_plugins = []
 else:

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -6,13 +6,12 @@ import pydantic
 from pydantic.networks import import_email_validator
 
 try:
-    from hypothesis import given, strategies as st
+    from hypothesis import HealthCheck, given, settings, strategies as st
 except ImportError:
+    from unittest import mock
 
-    def given(*args, **kwargs):
-        return lambda f: f
-
-    st = type('st', (), {'data': lambda: None})
+    given = settings = lambda *a, **kw: (lambda f: f)  # pass-through decorator
+    HealthCheck = st = mock.Mock()
 
     pytestmark = pytest.mark.skipif(True, reason='"hypothesis" not installed')
 
@@ -105,6 +104,7 @@ def gen_models():
 
 
 @pytest.mark.parametrize('model', gen_models())
+@settings(suppress_health_check={HealthCheck.too_slow})
 @given(data=st.data())
 def test_can_construct_models_with_all_fields(data, model):
     # The value of this test is to confirm that Hypothesis knows how to provide


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Sometimes the CI fails (right now [`master` is red](https://github.com/samuelcolvin/pydantic/runs/1954371907)) due to
```
E   hypothesis.errors.FailedHealthCheck: Data generation is extremely slow:
Only produced 9 valid examples in 1.22 seconds (0 invalid ones and 2 exceeded maximum size).
Try decreasing size of the data you're generating (with e.g.max_size or max_leaves parameters).
```
I suggest we simply remove this health check

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
