### PR TITLE
Add test for generic aliases and lenient_issubclass

### DIFF
--- a/changes/2399-daviskirk.md
+++ b/changes/2399-daviskirk.md
@@ -1,0 +1,1 @@
+fix: allow `utils.lenient_issubclass` to handle `typing.GenericAlias` objects like `list[str]` in python >= 3.9.

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -221,6 +221,7 @@ __all__ = (
     'CallableGenerator',
     'ReprArgs',
     'CallableGenerator',
+    'GenericAlias',
     'get_args',
     'get_origin',
     'typing_base',

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -24,7 +24,7 @@ from typing import (
     no_type_check,
 )
 
-from .typing import NoneType, display_as_type
+from .typing import GenericAlias, NoneType, display_as_type
 from .version import version_info
 
 if TYPE_CHECKING:
@@ -149,7 +149,12 @@ def validate_field_name(bases: List[Type['BaseModel']], field_name: str) -> None
 
 
 def lenient_issubclass(cls: Any, class_or_tuple: Union[Type[Any], Tuple[Type[Any], ...]]) -> bool:
-    return isinstance(cls, type) and issubclass(cls, class_or_tuple)
+    try:
+        return isinstance(cls, type) and issubclass(cls, class_or_tuple)
+    except TypeError:
+        if isinstance(cls, GenericAlias):
+            return False
+        raise  # pragma: no cover
 
 
 def in_ipython() -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,6 +109,14 @@ def test_lenient_issubclass():
     assert lenient_issubclass(A, str) is True
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='generic aliases are not available in python < 3.9')
+def test_lenient_issubclass_with_generic_aliases():
+    from collections.abc import Mapping
+
+    # should not raise an error here:
+    assert lenient_issubclass(list[str], Mapping) is False
+
+
 def test_lenient_issubclass_is_lenient():
     assert lenient_issubclass('a', 'a') is False
 


### PR DESCRIPTION
## Change Summary

Closes #2399

handle generic aliases (`list[str]`, tuple[str, ...] and so on) in lenient_issubclass.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/2399

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
