### PR TITLE
Update mkdocs extensions to fix local syntax highlighting

### DIFF
--- a/changes/2400-daviskirk.md
+++ b/changes/2400-daviskirk.md
@@ -1,0 +1,1 @@
+Update docs extensions to fix local syntax highlighting

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,16 +51,13 @@ nav:
 - changelog.md
 
 markdown_extensions:
-- markdown.extensions.codehilite:
-    guess_lang: false
 - markdown_include.include:
     base_path: docs
 - toc:
     permalink: 🔗
 - admonition
-- codehilite
-- extra
-- attr_list
+- pymdownx.highlight
+- pymdownx.extra
 
 plugins:
 - search


### PR DESCRIPTION
## Change Summary

Update mkdocs extensions to fix local syntax highlighting.

Ran into #2400 as well.

According to https://squidfunk.github.io/mkdocs-material/reference/code-blocks/
the pymdownx.highlight extension supersedes the CodeHilite extension, 
the "extra" extension was still causing the syntax highlighting to disappear (it would show up when taking it out).
But apparently, there's https://facelessuser.github.io/pymdown-extensions/extensions/extra/ which also replaces the "extra" extension, and also fixed the syntax highlighting in combination with pymdownx.highlight.

## Related issue number

Fixed #2400 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
