### PR TITLE
fix: variable length tuples of compound types

### DIFF
--- a/changes/2416-PrettyWood.md
+++ b/changes/2416-PrettyWood.md
@@ -1,0 +1,1 @@
+Support properly variable length tuples of compound types

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -538,6 +538,7 @@ class ModelField(Representation):
             elif len(args) == 2 and args[1] is Ellipsis:  # e.g. Tuple[int, ...]
                 self.type_ = args[0]
                 self.shape = SHAPE_TUPLE_ELLIPSIS
+                self.sub_fields = [self._create_sub_type(args[0], f'{self.name}_0')]
             elif args == ((),):  # Tuple[()] means empty tuple
                 self.shape = SHAPE_TUPLE
                 self.type_ = Any

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -203,12 +203,19 @@ def test_tuple_more():
         empty_tuple: Tuple[()]
         simple_tuple: tuple = None
         tuple_of_different_types: Tuple[int, float, str, bool] = None
+        tuple_of_single_tuples: Tuple[Tuple[int], ...] = ()
 
-    m = Model(empty_tuple=[], simple_tuple=[1, 2, 3, 4], tuple_of_different_types=[4, 3, 2, 1])
+    m = Model(
+        empty_tuple=[],
+        simple_tuple=[1, 2, 3, 4],
+        tuple_of_different_types=[4, 3, 2, 1],
+        tuple_of_single_tuples=(('1',), (2,)),
+    )
     assert m.dict() == {
         'empty_tuple': (),
         'simple_tuple': (1, 2, 3, 4),
         'tuple_of_different_types': (4, 3.0, '2', True),
+        'tuple_of_single_tuples': ((1,), (2,)),
     }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
I changed recently the code related to tuple to be more explicit and support () (empty tuple) but missed the case of variable length tuples of compound types
<!-- Please give a short summary of the changes. -->

## Related issue number
closes #2416
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
