### PR TITLE
fix: do not overwrite declared `__hash__` in subclasses of a model

### DIFF
--- a/changes/2422-PrettyWood.md
+++ b/changes/2422-PrettyWood.md
@@ -1,0 +1,1 @@
+do not overwrite declared `__hash__` in subclasses of a model

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -231,6 +231,7 @@ class ModelMetaclass(ABCMeta):
         slots: SetStr = namespace.get('__slots__', ())
         slots = {slots} if isinstance(slots, str) else set(slots)
         class_vars: SetStr = set()
+        hash_func: Optional[Callable[[Any], int]] = None
 
         for base in reversed(bases):
             if _is_base_model_class_defined and issubclass(base, BaseModel) and base != BaseModel:
@@ -241,6 +242,7 @@ class ModelMetaclass(ABCMeta):
                 post_root_validators += base.__post_root_validators__
                 private_attributes.update(base.__private_attributes__)
                 class_vars.update(base.__class_vars__)
+                hash_func = base.__hash__
 
         config_kwargs = {key: kwargs.pop(key) for key in kwargs.keys() & BaseConfig.__dict__.keys()}
         config_from_namespace = namespace.get('Config')
@@ -332,6 +334,9 @@ class ModelMetaclass(ABCMeta):
             json_encoder = pydantic_encoder
         pre_rv_new, post_rv_new = extract_root_validators(namespace)
 
+        if hash_func is None:
+            hash_func = generate_hash_function(config.frozen)
+
         exclude_from_namespace = fields | private_attributes.keys() | {'__slots__'}
         new_namespace = {
             '__config__': config,
@@ -344,7 +349,7 @@ class ModelMetaclass(ABCMeta):
             '__custom_root_type__': _custom_root_type,
             '__private_attributes__': private_attributes,
             '__slots__': slots | private_attributes.keys(),
-            '__hash__': generate_hash_function(config.frozen),
+            '__hash__': hash_func,
             '__class_vars__': class_vars,
             **{n: v for n, v in namespace.items() if n not in exclude_from_namespace},
         }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -395,6 +395,27 @@ def test_not_frozen_are_not_hashable():
     assert "unhashable type: 'TestModel'" in exc_info.value.args[0]
 
 
+def test_with_declared_hash():
+    class Foo(BaseModel):
+        x: int
+
+        def __hash__(self):
+            return self.x ** 2
+
+    class Bar(Foo):
+        y: int
+
+        def __hash__(self):
+            return self.y ** 3
+
+    class Buz(Bar):
+        z: int
+
+    assert hash(Foo(x=2)) == 4
+    assert hash(Bar(x=2, y=3)) == 27
+    assert hash(Buz(x=2, y=3, z=4)) == 27
+
+
 def test_frozen_with_hashable_fields_are_hashable():
     class TestModel(BaseModel):
         a: int = 10


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Declared `__hash__` was overwritten and not passed to child models

## Related issue number
closes #2422
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
