### PR TITLE
fix: do not ignore `Config` fields information in `dataclass`

### DIFF
--- a/changes/2426-PrettyWood.md
+++ b/changes/2426-PrettyWood.md
@@ -1,0 +1,1 @@
+Do not ignore `Config` fields information in `dataclass`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -169,7 +169,7 @@ class BaseConfig:
         pass
 
 
-def inherit_config(self_config: 'ConfigType', parent_config: 'ConfigType', **namespace: Any) -> 'ConfigType':
+def inherit_config(self_config: Optional['ConfigType'], parent_config: 'ConfigType', **namespace: Any) -> 'ConfigType':
     if not self_config:
         base_classes: Tuple['ConfigType', ...] = (parent_config,)
     elif self_config == parent_config:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -901,3 +901,14 @@ class ModelForPickle(pydantic.BaseModel):
     # ensure the restored dataclass is still a pydantic dataclass
     with pytest.raises(ValidationError, match='value\n +value is not a valid integer'):
         restored_obj.dataclass.value = 'value of a wrong type'
+
+
+def test_config_field():
+    class Config:
+        fields = {'a': {'description': 'descr'}}
+
+    @pydantic.dataclasses.dataclass(config=Config)
+    class Ad:
+        a: str
+
+    assert Ad.__pydantic_model__.schema()['properties']['a']['description'] == 'descr'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
We used to keep only the default value and the type when creating a `dataclass`, which would then follow the default workflow. But now we can use `metadata` in `dataclasses.field` or directly a `pydantic.Field` instance. We hence ignore the information set in the `Config`

<!-- Please give a short summary of the changes. -->

## Related issue number
Closes #2426
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
