### PR TITLE
fix: avoid `RecursionError` when using some types like `Enum` or `Literal` with generic models

### DIFF
--- a/changes/2436-PrettyWood.md
+++ b/changes/2436-PrettyWood.md
@@ -1,0 +1,1 @@
+Support properly `Enum` when combined with generic models

--- a/changes/2436-PrettyWood.md
+++ b/changes/2436-PrettyWood.md
@@ -1,1 +1,1 @@
-Support properly `Enum` when combined with generic models
+Avoid `RecursionError` when using some types like `Enum` or `Literal` with generic models

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,13 +1,11 @@
 import sys
 import typing
-from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
     Dict,
     Generic,
-    Iterable,
     Iterator,
     List,
     Mapping,
@@ -206,13 +204,16 @@ def check_parameters_count(cls: Type[GenericModel], parameters: Tuple[Any, ...])
         raise TypeError(f'Too {description} parameters for {cls.__name__}; actual {actual}, expected {expected}')
 
 
+DictValues: Type[Any] = {}.values().__class__
+
+
 def iter_contained_typevars(v: Any) -> Iterator[TypeVarType]:
     """Recursively iterate through all subtypes and type args of `v` and yield any typevars that are found."""
     if isinstance(v, TypeVar):
         yield v
     elif hasattr(v, '__parameters__') and not get_origin(v) and lenient_issubclass(v, GenericModel):
         yield from v.__parameters__
-    elif isinstance(v, Iterable) and not lenient_issubclass(v, Enum):
+    elif isinstance(v, (DictValues, list)):
         for var in v:
             yield from iter_contained_typevars(var)
     else:

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,5 +1,6 @@
 import sys
 import typing
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -211,7 +212,7 @@ def iter_contained_typevars(v: Any) -> Iterator[TypeVarType]:
         yield v
     elif hasattr(v, '__parameters__') and not get_origin(v) and lenient_issubclass(v, GenericModel):
         yield from v.__parameters__
-    elif isinstance(v, Iterable):
+    elif isinstance(v, Iterable) and not lenient_issubclass(v, Enum):
         for var in v:
             yield from iter_contained_typevars(var)
     else:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any, Callable, ClassVar, Dict, Generic, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 import pytest
+from typing_extensions import Literal
 
 from pydantic import BaseModel, Field, ValidationError, root_validator, validator
 from pydantic.generics import GenericModel, _generic_types_cache, iter_contained_typevars, replace_types
@@ -1057,3 +1058,16 @@ def test_generic_enum():
 
     m = MyModel.parse_obj({'my_gen': {'some_field': 'A'}})
     assert m.my_gen.some_field is SomeStringEnum.A
+
+
+@skip_36
+def test_generic_literal():
+    FieldType = TypeVar('FieldType')
+    ValueType = TypeVar('ValueType')
+
+    class GModel(GenericModel, Generic[FieldType, ValueType]):
+        field: Dict[FieldType, ValueType]
+
+    Fields = Literal['foo', 'bar']
+    m = GModel[Fields, str](field={'foo': 'x'})
+    assert m.dict() == {'field': {'foo': 'x'}}

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1039,3 +1039,21 @@ def test_generic_recursive_models(create_module):
     Model2 = module.Model2
     result = Model1[str].parse_obj(dict(ref=dict(ref=dict(ref=dict(ref=123)))))
     assert result == Model1(ref=Model2(ref=Model1(ref=Model2(ref='123'))))
+
+
+@skip_36
+def test_generic_enum():
+    T = TypeVar('T')
+
+    class SomeGenericModel(GenericModel, Generic[T]):
+        some_field: T
+
+    class SomeStringEnum(str, Enum):
+        A = 'A'
+        B = 'B'
+
+    class MyModel(BaseModel):
+        my_gen: SomeGenericModel[SomeStringEnum]
+
+    m = MyModel.parse_obj({'my_gen': {'some_field': 'A'}})
+    assert m.my_gen.some_field is SomeStringEnum.A


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Since an `Enum` is an Iterable, which would cause an infinite loop.

## Related issue number
closes #2436
closes #2454
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
