### PR TITLE
Allow for generation of a constrained float with multiple_of argument for hypothesis plugin

### DIFF
--- a/changes/2442-tobi-lipede-oodle.md
+++ b/changes/2442-tobi-lipede-oodle.md
@@ -1,0 +1,1 @@
+enable the Hypothesis plugin to generate a constrained float when the `multiple_of` argument is specified.

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -74,6 +74,7 @@ def gen_models():
         conintmul: pydantic.conint(ge=10, le=100, multiple_of=7)
         confloatt: pydantic.confloat(gt=10, lt=100)
         confloate: pydantic.confloat(ge=10, le=100)
+        confloatmul: pydantic.confloat(ge=10, le=100, multiple_of=4.2)
         condecimalt: pydantic.condecimal(gt=10, lt=100)
         condecimale: pydantic.condecimal(ge=10, le=100)
 
@@ -104,7 +105,7 @@ def gen_models():
 
 
 @pytest.mark.parametrize('model', gen_models())
-@settings(suppress_health_check={HealthCheck.too_slow})
+@settings(suppress_health_check={HealthCheck.too_slow, HealthCheck.filter_too_much})
 @given(data=st.data())
 def test_can_construct_models_with_all_fields(data, model):
     # The value of this test is to confirm that Hypothesis knows how to provide

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -105,7 +105,7 @@ def gen_models():
 
 
 @pytest.mark.parametrize('model', gen_models())
-@settings(suppress_health_check={HealthCheck.too_slow, HealthCheck.filter_too_much})
+@settings(suppress_health_check={HealthCheck.too_slow})
 @given(data=st.data())
 def test_can_construct_models_with_all_fields(data, model):
     # The value of this test is to confirm that Hypothesis knows how to provide

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -74,7 +74,8 @@ def gen_models():
         conintmul: pydantic.conint(ge=10, le=100, multiple_of=7)
         confloatt: pydantic.confloat(gt=10, lt=100)
         confloate: pydantic.confloat(ge=10, le=100)
-        confloatmul: pydantic.confloat(ge=10, le=100, multiple_of=4.2)
+        confloatemul: pydantic.confloat(ge=10, le=100, multiple_of=4.2)
+        confloattmul: pydantic.confloat(gt=10, lt=100, multiple_of=10)
         condecimalt: pydantic.condecimal(gt=10, lt=100)
         condecimale: pydantic.condecimal(ge=10, le=100)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This enables Hypothesis to generate a `ConstrainedFloat` with the `multiple_of` argument enabled.

<!-- Please give a short summary of the changes. -->

## Related issue number
https://github.com/samuelcolvin/pydantic/discussions/2443

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
