### PR TITLE
refactor: set `Pattern` encoder in `ENCODERS_BY_TYPE`

### DIFF
--- a/changes/2444-PrettyWood.md
+++ b/changes/2444-PrettyWood.md
@@ -1,0 +1,1 @@
+expose `Pattern` encoder to `fastapi`

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -1,12 +1,20 @@
 import datetime
+import re
+import sys
 from collections import deque
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from types import GeneratorType
-from typing import Any, Callable, Dict, Pattern, Type, Union
+from typing import Any, Callable, Dict, Type, Union
 from uuid import UUID
+
+if sys.version_info >= (3, 7):
+    Pattern = re.Pattern
+else:
+    # python 3.6
+    Pattern = re.compile('a').__class__
 
 from .color import Color
 from .types import SecretBytes, SecretStr
@@ -58,6 +66,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     IPv6Interface: str,
     IPv6Network: str,
     Path: str,
+    Pattern: lambda o: o.pattern,
     SecretBytes: str,
     SecretStr: str,
     set: list,
@@ -74,9 +83,6 @@ def pydantic_encoder(obj: Any) -> Any:
         return obj.dict()
     elif is_dataclass(obj):
         return asdict(obj)
-
-    if isinstance(obj, Pattern):
-        return obj.pattern
 
     # Check the class type and its superclasses for a matching encoder
     for base in obj.__class__.__mro__[:-1]:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Set `Pattern` encoder directly in `ENCODERS_BY_TYPE` to be used by `fastapi`
<!-- Please give a short summary of the changes. -->

## Related issue number
#2045

> Well `fastapi` uses its own json encoder and reuses `ENCODERS_BY_TYPE` from _pydantic_ here
> https://github.com/tiangolo/fastapi/blob/5614b94ccc9f72f1de2f63aae63f5fe90b86c8b5/fastapi/encoders.py#L126-L127
> We could maybe add `Pattern` directly in `ENCODERS_BY_TYPE` to make it work


<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
