### PR TITLE
added `KafkaDsn` to `networks.py` and add default ports for `HttpUrl` 

### DIFF
--- a/changes/2447-MihanixA.md
+++ b/changes/2447-MihanixA.md
@@ -1,1 +1,3 @@
 added `KafkaDsn` to the `pydantic/networks.py`
+added default port 443 for `https` and 80 for `http` at `HttpUrl` model
+added `display_port=False` at `HttpUrl` model 

--- a/changes/2447-MihanixA.md
+++ b/changes/2447-MihanixA.md
@@ -1,3 +1,3 @@
-added `KafkaDsn` to the `pydantic/networks.py`
-added default port 443 for `https` and 80 for `http` at `HttpUrl` model
-added `display_port=False` at `HttpUrl` model 
+ - added `KafkaDsn` to the `pydantic/networks.py`
+ - added `get_default_parts` and `apply_default_parts` methods to `AnyUrl`
+ - `HttpUrl` now inherits `AnyHttpUrl` instead of `AnyUrl`

--- a/changes/2447-MihanixA.md
+++ b/changes/2447-MihanixA.md
@@ -1,0 +1,1 @@
+added `KafkaDsn` to the `pydantic/networks.py`

--- a/changes/2447-MihanixA.md
+++ b/changes/2447-MihanixA.md
@@ -1,3 +1,4 @@
  - added `KafkaDsn` to the `pydantic/networks.py`
  - added `get_default_parts` and `apply_default_parts` methods to `AnyUrl`
  - `HttpUrl` now inherits `AnyHttpUrl` instead of `AnyUrl`
+ - `HttpUrl` now has default port 80 for http and 443 for https

--- a/changes/2447-MihanixA.md
+++ b/changes/2447-MihanixA.md
@@ -1,4 +1,2 @@
- - added `KafkaDsn` to the `pydantic/networks.py`
- - added `get_default_parts` and `apply_default_parts` methods to `AnyUrl`
- - `HttpUrl` now inherits `AnyHttpUrl` instead of `AnyUrl`
+ - add `KafkaDsn` type
  - `HttpUrl` now has default port 80 for http and 443 for https

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     'IPvAnyNetwork',
     'PostgresDsn',
     'RedisDsn',
+    'KafkaDsn',
     'validate_email',
     # parse
     'Protocol',

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -307,11 +307,12 @@ class HttpUrl(AnyUrl):
     tld_required = True
     # https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
     max_length = 2083
-    display_port = False
 
     @classmethod
     def validate_parts(cls, parts: Dict[str, str]) -> Dict[str, str]:
-        parts['port'] = '443' if parts['scheme'] == 'https' else '80'
+        if parts['port'] is None:
+            parts['port'] = '443' if parts['scheme'] == 'https' else '80'
+            cls.display_port = False
         return super().validate_parts(parts)
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -111,6 +111,7 @@ class AnyUrl(str):
     tld_required: bool = False
     user_required: bool = False
     default_parts: Optional[Set[Tuple[str, str]]] = None
+    display_port: bool = True
 
     __slots__ = ('scheme', 'user', 'password', 'host', 'tld', 'host_type', 'port', 'path', 'query', 'fragment')
 
@@ -167,7 +168,7 @@ class AnyUrl(str):
         if user or password:
             url += '@'
         url += host
-        if port:
+        if port and cls.display_port:
             url += ':' + port
         if path:
             url += path
@@ -306,6 +307,12 @@ class HttpUrl(AnyUrl):
     tld_required = True
     # https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
     max_length = 2083
+    display_port = False
+
+    @classmethod
+    def validate_parts(cls, parts: Dict[str, str]) -> Dict[str, str]:
+        parts['port'] = '443' if parts['scheme'] == 'https' else '80'
+        return super().validate_parts(parts)
 
 
 class PostgresDsn(AnyUrl):

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -115,7 +115,7 @@ class AnyUrl(str):
 
     @no_type_check
     def __new__(cls, url: Optional[str], **kwargs) -> object:
-        return str.__new__(cls, cls.build(**kwargs) if url is None else url)  # noqa
+        return str.__new__(cls, cls.build(**kwargs) if url is None else url)
 
     def __init__(
         self,
@@ -353,7 +353,7 @@ def stricturl(
         tld_required=tld_required,
         allowed_schemes=allowed_schemes,
     )
-    return type('UrlValue', (AnyUrl,), namespace)  # noqa
+    return type('UrlValue', (AnyUrl,), namespace)
 
 
 def import_email_validator() -> None:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -125,7 +125,7 @@ class AnyUrl(str):
     allowed_schemes: Optional[Set[str]] = None
     tld_required: bool = False
     user_required: bool = False
-    hidden_parts: Optional[Set[str]] = None
+    hidden_parts: Set[str] = set()
 
     __slots__ = ('scheme', 'user', 'password', 'host', 'tld', 'host_type', 'port', 'path', 'query', 'fragment')
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -182,7 +182,7 @@ class AnyUrl(str):
         if user or password:
             url += '@'
         url += host
-        if port and ('port' not in cls.hidden_parts):
+        if port and 'port' not in cls.hidden_parts:
             url += ':' + port
         if path:
             url += path

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -326,24 +326,23 @@ def test_parses_tld(input, output):
     assert Model(v=input).v.tld == output
 
 
-@pytest.mark.parametrize(
-    'url,port',
-    [
-        ('https://www.example.com', '443'),
-        ('https://www.example.com:443', '443'),
-        ('https://www.example.com:8089', '8089'),
-        ('http://www.example.com', '80'),
-        ('http://www.example.com:80', '80'),
-        ('http://www.example.com:8080', '8080'),
-    ],
-)
-def test_http_urls_default_port(url, port):
-    class Model(BaseModel):
-        v: HttpUrl
+def test_get_default_parts():
+    class MyConnectionString(AnyUrl):
+        @staticmethod
+        def get_default_parts(parts):
+            # get default parts allows to generate custom conn strings to services
+            return {
+                'user': 'admin',
+                'password': '123',
+            }
 
-    m = Model(v=url)
-    assert m.v.port == port
-    assert m.v == url
+    class C(BaseModel):
+        connection: MyConnectionString
+
+    c = C(connection='protocol://service:8080')
+    assert c.connection == 'protocol://admin:123@service:8080'
+    assert c.connection.user == 'admin'
+    assert c.connection.password == '123'
 
 
 def test_postgres_dsns():

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -326,6 +326,19 @@ def test_parses_tld(input, output):
     assert Model(v=input).v.tld == output
 
 
+def test_http_urls_default_port():
+    class Model(BaseModel):
+        v: HttpUrl
+
+    m = Model(v='https://www.example.com')
+    assert m.v.port == '443'
+    assert m.v == 'https://www.example.com'
+
+    m = Model(v='http://www.example.com')
+    assert m.v.port == '80'
+    assert m.v == 'http://www.example.com'
+
+
 def test_postgres_dsns():
     class Model(BaseModel):
         a: PostgresDsn

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -326,17 +326,24 @@ def test_parses_tld(input, output):
     assert Model(v=input).v.tld == output
 
 
-def test_http_urls_default_port():
+@pytest.mark.parametrize(
+    'url,port',
+    [
+        ('https://www.example.com', '443'),
+        ('https://www.example.com:443', '443'),
+        ('https://www.example.com:8089', '8089'),
+        ('http://www.example.com', '80'),
+        ('http://www.example.com:80', '80'),
+        ('http://www.example.com:8080', '8080'),
+    ],
+)
+def test_http_urls_default_port(url, port):
     class Model(BaseModel):
         v: HttpUrl
 
-    m = Model(v='https://www.example.com')
-    assert m.v.port == '443'
-    assert m.v == 'https://www.example.com'
-
-    m = Model(v='http://www.example.com')
-    assert m.v.port == '80'
-    assert m.v == 'http://www.example.com'
+    m = Model(v=url)
+    assert m.v.port == port
+    assert m.v == url
 
 
 def test_postgres_dsns():

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -345,6 +345,26 @@ def test_get_default_parts():
     assert c.connection.password == '123'
 
 
+@pytest.mark.parametrize(
+    'url,port',
+    [
+        ('https://www.example.com', '443'),
+        ('https://www.example.com:443', '443'),
+        ('https://www.example.com:8089', '8089'),
+        ('http://www.example.com', '80'),
+        ('http://www.example.com:80', '80'),
+        ('http://www.example.com:8080', '8080'),
+    ],
+)
+def test_http_urls_default_port(url, port):
+    class Model(BaseModel):
+        v: HttpUrl
+
+    m = Model(v=url)
+    assert m.v.port == port
+    assert m.v == url
+
+
 def test_postgres_dsns():
     class Model(BaseModel):
         a: PostgresDsn


### PR DESCRIPTION
❤️ pydantic

## Change Summary

- Added `KafkaDsn` class e.g. already existing `RedisDsn`  :fire:
- Added `default_parts` member and `apply_default_parts` method to the `AnyUrl` class

## Related issue number

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
