### PR TITLE
fix: validation with a `BaseModel` field and a custom root type

### DIFF
--- a/changes/2449-PrettyWood.md
+++ b/changes/2449-PrettyWood.md
@@ -1,0 +1,1 @@
+fix validation with a `BaseModel` field and a custom root type

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -717,11 +717,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
     @classmethod
     def validate(cls: Type['Model'], value: Any) -> 'Model':
+        if isinstance(value, cls):
+            return value.copy() if cls.__config__.copy_on_model_validation else value
+
         value = cls._enforce_dict_if_root(value)
         if isinstance(value, dict):
             return cls(**value)
-        elif isinstance(value, cls):
-            return value.copy() if cls.__config__.copy_on_model_validation else value
         elif cls.__config__.orm_mode:
             return cls.from_orm(value)
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1137,6 +1137,17 @@ def test_root_list():
     assert m.__root__ == ['a']
 
 
+def test_root_nested():
+    class MyList(BaseModel):
+        __root__: List[str]
+
+    class MyModel(BaseModel):
+        my_list: MyList
+
+    my_list = MyList(__root__=['pika'])
+    assert MyModel(my_list=my_list).dict() == {'my_list': ['pika']}
+
+
 def test_encode_nested_root():
     house_dict = {'pets': ['dog', 'cats']}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
`__root__` key was added by mistake when the value to validate was already of right type 

## Related issue number
closes #2449
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
