### PR TITLE
allow Config.field to update a Field

### DIFF
--- a/changes/2461-samuelcolvin.md
+++ b/changes/2461-samuelcolvin.md
@@ -1,0 +1,1 @@
+fix: allow elements of `Config.field` to update elements of a `Field`

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -106,7 +106,8 @@ class FieldInfo(Representation):
         'extra',
     )
 
-    __field_constraints__ = {  # field constraints with the default value
+    # field constraints with the default value, it's also used in update_from_config below
+    __field_constraints__ = {
         'min_length': None,
         'max_length': None,
         'regex': None,
@@ -164,7 +165,7 @@ class FieldInfo(Representation):
                 # attr_name is not an attribute of FieldInfo, it should therefore be added to extra
                 self.extra[attr_name] = value
             else:
-                if current_value is None:
+                if current_value is self.__field_constraints__.get(attr_name, None):
                     setattr(self, attr_name, value)
 
     def _validate(self) -> None:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -358,12 +358,17 @@ class ModelField(Representation):
                     raise ValueError(f'`Field` default cannot be set in `Annotated` for {field_name!r}')
                 if value not in (Undefined, Ellipsis):
                     field_info.default = value
+
         if isinstance(value, FieldInfo):
             if field_info is not None:
                 raise ValueError(f'cannot specify `Annotated` and value `Field`s together for {field_name!r}')
             field_info = value
-        if field_info is None:
+            for key, value in field_info_from_config.items():
+                if getattr(field_info, key, True) is None:
+                    setattr(field_info, key, value)
+        elif field_info is None:
             field_info = FieldInfo(value, **field_info_from_config)
+
         field_info.alias = field_info.alias or field_info_from_config.get('alias')
         value = None if field_info.default_factory is not None else field_info.default
         field_info._validate()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -142,6 +142,10 @@ class BaseConfig:
 
     @classmethod
     def get_field_info(cls, name: str) -> Dict[str, Any]:
+        """
+        Get properties of FieldInfo from the `fields` property of the config class.
+        """
+
         fields_value = cls.fields.get(name)
 
         if isinstance(fields_value, str):

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -24,12 +24,12 @@ from pydantic.fields import Undefined
         ),
         # Test valid Annotated Field uses
         pytest.param(
-            lambda: Annotated[int, Field(description='Test')],
+            lambda: Annotated[int, Field(description='Test')],  # noqa: F821
             5,
             id='annotated-field-value-default',
         ),
         pytest.param(
-            lambda: Annotated[int, Field(default_factory=lambda: 5, description='Test')],
+            lambda: Annotated[int, Field(default_factory=lambda: 5, description='Test')],  # noqa: F821
             Undefined,
             id='annotated-field-default_factory',
         ),
@@ -134,7 +134,7 @@ def test_field_reuse():
 
 def test_config_field_info():
     class Foo(BaseModel):
-        a: Annotated[int, Field(foobar='hello')]
+        a: Annotated[int, Field(foobar='hello')]  # noqa: F821
 
         class Config:
             fields = {'a': {'description': 'descr'}}

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -2,12 +2,10 @@ import sys
 from typing import get_type_hints
 
 import pytest
+from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field
 from pydantic.fields import Undefined
-from pydantic.typing import Annotated
-
-pytestmark = pytest.mark.skipif(not Annotated, reason='typing_extensions not installed')
 
 
 @pytest.mark.parametrize(
@@ -132,3 +130,15 @@ def test_field_reuse():
         one: Annotated[int, field]
 
     assert AnnotatedModel(one=1).dict() == {'one': 1}
+
+
+def test_config_field_info():
+    class Foo(BaseModel):
+        a: Annotated[int, Field(foobar='hello')]
+
+        class Config:
+            fields = {'a': {'description': 'descr'}}
+
+    assert Foo.schema(by_alias=True)['properties'] == {
+        'a': {'title': 'A', 'description': 'descr', 'foobar': 'hello', 'type': 'integer'},
+    }

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic import BaseModel, Extra, ValidationError, create_model, errors, validator
+from pydantic import BaseModel, Extra, Field, ValidationError, create_model, errors, validator
 
 
 def test_create_model():
@@ -194,3 +194,14 @@ def test_dynamic_and_static():
 
     for field_name in ('x', 'y', 'z'):
         assert A.__fields__[field_name].default == DynamicA.__fields__[field_name].default
+
+
+def test_config_field_info_create_model():
+    class Config:
+        fields = {'a': {'description': 'descr'}}
+
+    m1 = create_model('M1', __config__=Config, a=(str, ...))
+    assert m1.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+
+    m2 = create_model('M2', __config__=Config, a=(str, Field(...)))
+    assert m2.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -901,3 +901,22 @@ class ModelForPickle(pydantic.BaseModel):
     # ensure the restored dataclass is still a pydantic dataclass
     with pytest.raises(ValidationError, match='value\n +value is not a valid integer'):
         restored_obj.dataclass.value = 'value of a wrong type'
+
+
+def test_config_field_info_create_model():
+    # works
+    class A1(BaseModel):
+        a: str
+
+        class Config:
+            fields = {'a': {'description': 'descr'}}
+
+    assert A1.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+
+    @pydantic.dataclasses.dataclass(config=A1.Config)
+    class A2:
+        a: str
+
+    assert A2.__pydantic_model__.schema()['properties'] == {
+        'a': {'title': 'A', 'description': 'descr', 'type': 'string'}
+    }

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1811,3 +1811,16 @@ def test_config_field_info_merge():
     assert Foo.schema(by_alias=True)['properties'] == {
         'a': {'bar': 'Bar', 'foo': 'Foo', 'title': 'A', 'type': 'string'}
     }
+
+
+def test_config_field_info_allow_mutation():
+    """
+    allow_mutation cannot be customised via Config.field because it has a default which is not None
+    """
+    class Foo(BaseModel):
+        a: str = Field(...)
+
+        class Config:
+            fields = {'a': {'allow_mutation': False}}
+
+    assert Foo.__fields__['a'].field_info.allow_mutation is True

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1779,3 +1779,13 @@ def test_iter_coverage():
         y: str = 'a'
 
     assert list(MyModel()._iter(by_alias=True)) == [('x', 1), ('y', 'a')]
+
+
+def test_config_field_info():
+    class Foo(BaseModel):
+        a: str = Field(...)
+
+        class Config:
+            fields = {'a': {'description': 'descr'}}
+
+    assert Foo.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1814,13 +1814,28 @@ def test_config_field_info_merge():
 
 
 def test_config_field_info_allow_mutation():
-    """
-    allow_mutation cannot be customised via Config.field because it has a default which is not None
-    """
     class Foo(BaseModel):
         a: str = Field(...)
 
         class Config:
-            fields = {'a': {'allow_mutation': False}}
+            validate_assignment = True
 
     assert Foo.__fields__['a'].field_info.allow_mutation is True
+
+    f = Foo(a='x')
+    f.a = 'y'
+    assert f.dict() == {'a': 'y'}
+
+    class Bar(BaseModel):
+        a: str = Field(...)
+
+        class Config:
+            fields = {'a': {'allow_mutation': False}}
+            validate_assignment = True
+
+    assert Bar.__fields__['a'].field_info.allow_mutation is False
+
+    b = Bar(a='x')
+    with pytest.raises(TypeError):
+        b.a = 'y'
+    assert b.dict() == {'a': 'x'}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1788,4 +1788,26 @@ def test_config_field_info():
         class Config:
             fields = {'a': {'description': 'descr'}}
 
-    assert Foo.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+    assert Foo.schema(by_alias=True)['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+
+
+def test_config_field_info_alias():
+    class Foo(BaseModel):
+        a: str = Field(...)
+
+        class Config:
+            fields = {'a': {'alias': 'b'}}
+
+    assert Foo.schema(by_alias=True)['properties'] == {'b': {'title': 'B', 'type': 'string'}}
+
+
+def test_config_field_info_merge():
+    class Foo(BaseModel):
+        a: str = Field(..., foo='Foo')
+
+        class Config:
+            fields = {'a': {'bar': 'Bar'}}
+
+    assert Foo.schema(by_alias=True)['properties'] == {
+        'a': {'bar': 'Bar', 'foo': 'Foo', 'title': 'A', 'type': 'string'}
+    }


### PR DESCRIPTION
## Change Summary

Allow element of `Config.field` to update elements of a `Field`

Example of usage:

## Related issue number

fix #2426

supersedes #2437

## Questions

* could this break any assumed existing behaviour?
* do any docs need to be updated? If so, what?

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
