### PR TITLE
feat(schema): set `minItems` and `maxItems` in JSON schema for tuples

### DIFF
--- a/changes/2497-PrettyWood.md
+++ b/changes/2497-PrettyWood.md
@@ -1,0 +1,1 @@
+Set `minItems` and `maxItems` in generated JSON schema for fixed-length tuples

--- a/docs/build/schema_mapping.py
+++ b/docs/build/schema_mapping.py
@@ -82,9 +82,16 @@ table = [
         'And equivalently for any other sub type, e.g. `List[int]`.'
     ],
     [
+        'Tuple[str, ...]',
+        'array',
+        {'items': {'type': 'string'}},
+        'JSON Schema Validation',
+        'And equivalently for any other sub type, e.g. `Tuple[int, ...]`.'
+    ],
+    [
         'Tuple[str, int]',
         'array',
-        {'items': [{'type': 'string'}, {'type': 'integer'}]},
+        {'items': [{'type': 'string'}, {'type': 'integer'}], 'minItems': 2, 'maxItems': 2},
         'JSON Schema Validation',
         (
             'And equivalently for any other set of subtypes. Note: If using schemas for OpenAPI, '

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -490,15 +490,17 @@ def field_type_schema(
             definitions.update(sf_definitions)
             nested_models.update(sf_nested_models)
             sub_schema.append(sf_schema)
-        if len(sub_schema) == 1:
-            if field.shape == SHAPE_GENERIC:
-                f_schema = sub_schema[0]
-            else:
-                f_schema = {'type': 'array', 'items': sub_schema[0]}
-        else:
-            f_schema = {'type': 'array', 'items': sub_schema}
+
         if field.shape == SHAPE_GENERIC:
+            f_schema = sub_schema[0] if len(sub_schema) == 1 else {'type': 'array', 'items': sub_schema}
             f_schema = {'allOf': [f_schema]}
+        else:
+            tuple_len = len(sub_fields)
+            f_schema = {'type': 'array', 'minItems': tuple_len, 'maxItems': tuple_len}
+            if tuple_len == 1:
+                f_schema['items'] = sub_schema[0]
+            elif tuple_len > 1:
+                f_schema['items'] = sub_schema
     else:
         assert field.shape in {SHAPE_SINGLETON, SHAPE_GENERIC}, field.shape
         f_schema, f_definitions, f_nested_models = field_singleton_schema(
@@ -835,7 +837,15 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
             ref_template=ref_template,
             known_models=known_models,
         )
-        f_schema.update({'type': 'array', 'items': list(sub_schema['properties'].values())})
+        items_schemas = list(sub_schema['properties'].values())
+        f_schema.update(
+            {
+                'type': 'array',
+                'items': items_schemas,
+                'minItems': len(items_schemas),
+                'maxItems': len(items_schemas),
+            }
+        )
     elif not hasattr(field_type, '__pydantic_model__'):
         add_field_type_to_schema(field_type, f_schema)
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -502,7 +502,7 @@ def field_type_schema(
                 'maxItems': sub_fields_len,
             }
             if sub_fields_len >= 1:
-                f_schema['items'] = sub_schema[0] if sub_fields_len == 1 else sub_schema
+                f_schema['items'] = sub_schema
     else:
         assert field.shape in {SHAPE_SINGLETON, SHAPE_GENERIC}, field.shape
         f_schema, f_definitions, f_nested_models = field_singleton_schema(

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -491,16 +491,18 @@ def field_type_schema(
             nested_models.update(sf_nested_models)
             sub_schema.append(sf_schema)
 
+        sub_fields_len = len(sub_fields)
         if field.shape == SHAPE_GENERIC:
-            f_schema = sub_schema[0] if len(sub_schema) == 1 else {'type': 'array', 'items': sub_schema}
-            f_schema = {'allOf': [f_schema]}
+            all_of_schemas = sub_schema[0] if sub_fields_len == 1 else {'type': 'array', 'items': sub_schema}
+            f_schema = {'allOf': [all_of_schemas]}
         else:
-            tuple_len = len(sub_fields)
-            f_schema = {'type': 'array', 'minItems': tuple_len, 'maxItems': tuple_len}
-            if tuple_len == 1:
-                f_schema['items'] = sub_schema[0]
-            elif tuple_len > 1:
-                f_schema['items'] = sub_schema
+            f_schema = {
+                'type': 'array',
+                'minItems': sub_fields_len,
+                'maxItems': sub_fields_len,
+            }
+            if sub_fields_len >= 1:
+                f_schema['items'] = sub_schema[0] if sub_fields_len == 1 else sub_schema
     else:
         assert field.shape in {SHAPE_SINGLETON, SHAPE_GENERIC}, field.shape
         f_schema, f_definitions, f_nested_models = field_singleton_schema(

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -79,6 +79,8 @@ def test_namedtuple_schema():
                     {'title': 'X', 'type': 'integer'},
                     {'title': 'Y', 'type': 'integer'},
                 ],
+                'minItems': 2,
+                'maxItems': 2,
             },
             'pos2': {
                 'title': 'Pos2',
@@ -87,6 +89,8 @@ def test_namedtuple_schema():
                     {'title': 'X'},
                     {'title': 'Y'},
                 ],
+                'minItems': 2,
+                'maxItems': 2,
             },
             'pos3': {
                 'title': 'Pos3',
@@ -95,6 +99,8 @@ def test_namedtuple_schema():
                     {'type': 'integer'},
                     {'type': 'integer'},
                 ],
+                'minItems': 2,
+                'maxItems': 2,
             },
         },
         'required': ['pos1', 'pos2', 'pos3'],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -526,34 +526,36 @@ def test_const_false():
 
 
 @pytest.mark.parametrize(
-    'field_type,expected_schema',
+    'field_type,extra_props',
     [
-        (tuple, {}),
+        (tuple, {'items': {}}),
         (
             Tuple[str, int, Union[str, int, float], float],
-            [
-                {'type': 'string'},
-                {'type': 'integer'},
-                {'anyOf': [{'type': 'string'}, {'type': 'integer'}, {'type': 'number'}]},
-                {'type': 'number'},
-            ],
+            {
+                'items': [
+                    {'type': 'string'},
+                    {'type': 'integer'},
+                    {'anyOf': [{'type': 'string'}, {'type': 'integer'}, {'type': 'number'}]},
+                    {'type': 'number'},
+                ],
+                'minItems': 4,
+                'maxItems': 4,
+            },
         ),
-        (Tuple[str], {'type': 'string'}),
+        (Tuple[str], {'items': {'type': 'string'}, 'minItems': 1, 'maxItems': 1}),
+        (Tuple[()], {'maxItems': 0, 'minItems': 0}),
     ],
 )
-def test_tuple(field_type, expected_schema):
+def test_tuple(field_type, extra_props):
     class Model(BaseModel):
         a: field_type
 
-    base_schema = {
+    assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'array'}},
+        'properties': {'a': {'title': 'A', 'type': 'array', **extra_props}},
         'required': ['a'],
     }
-    base_schema['properties']['a']['items'] = expected_schema
-
-    assert Model.schema() == base_schema
 
 
 def test_bool():
@@ -1923,6 +1925,8 @@ def test_model_with_extra_forbidden():
                     {'exclusiveMinimum': 0, 'type': 'integer'},
                     {'exclusiveMinimum': 0, 'type': 'integer'},
                 ],
+                'minItems': 3,
+                'maxItems': 3,
             },
         ),
         (
@@ -2312,6 +2316,8 @@ def test_namedtuple_default():
                 'default': Coordinates(x=0, y=0),
                 'type': 'array',
                 'items': [{'title': 'X', 'type': 'number'}, {'title': 'Y', 'type': 'number'}],
+                'minItems': 2,
+                'maxItems': 2,
             }
         },
     }
@@ -2403,11 +2409,19 @@ def test_advanced_generic_schema():
                 'examples': 'examples',
             },
             'data3': {'title': 'Data3', 'type': 'array', 'items': {}},
-            'data4': {'title': 'Data4', 'type': 'array', 'items': {'$ref': '#/definitions/CustomType'}},
+            'data4': {
+                'title': 'Data4',
+                'type': 'array',
+                'items': {'$ref': '#/definitions/CustomType'},
+                'minItems': 1,
+                'maxItems': 1,
+            },
             'data5': {
                 'title': 'Data5',
                 'type': 'array',
                 'items': [{'$ref': '#/definitions/CustomType'}, {'type': 'string'}],
+                'minItems': 2,
+                'maxItems': 2,
             },
         },
         'required': ['data0', 'data1', 'data2', 'data3', 'data4', 'data5'],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -542,7 +542,7 @@ def test_const_false():
                 'maxItems': 4,
             },
         ),
-        (Tuple[str], {'items': {'type': 'string'}, 'minItems': 1, 'maxItems': 1}),
+        (Tuple[str], {'items': [{'type': 'string'}], 'minItems': 1, 'maxItems': 1}),
         (Tuple[()], {'maxItems': 0, 'minItems': 0}),
     ],
 )
@@ -2412,7 +2412,7 @@ def test_advanced_generic_schema():
             'data4': {
                 'title': 'Data4',
                 'type': 'array',
-                'items': {'$ref': '#/definitions/CustomType'},
+                'items': [{'$ref': '#/definitions/CustomType'}],
                 'minItems': 1,
                 'maxItems': 1,
             },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
We didn't enforce the length of the tuple in the JSON schema. We could hence set smaller or longer tuples.
Also handles case of empty tuple by not setting `items` at all to fix #2496 

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
