### PR TITLE
add strict_int config

### DIFF
--- a/changes/2509-amirfru.md
+++ b/changes/2509-amirfru.md
@@ -1,0 +1,1 @@
+Added **`strict_int`** option to config

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -116,6 +116,9 @@ _(This script is complete, it should run "as is")_
 **`copy_on_model_validation`**
 : whether or not inherited models used as fields should be reconstructed (copied) on validation instead of being kept untouched (default: `True`)
 
+**`strict_int`**
+: whether to treat `int` fields as strict.
+
 ## Change behaviour globally
 
 If you wish to change the behaviour of _pydantic_ globally, you can create your own custom `BaseModel`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -136,6 +136,7 @@ class BaseConfig:
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[Type[Any], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
+    strict_int: bool = False
 
     # Whether or not inherited models as fields should be reconstructed as base model
     copy_on_model_validation: bool = True

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -621,7 +621,7 @@ _VALIDATORS: List[Tuple[Type[Any], List[Any]]] = [
         ],
     ),
     (bool, [bool_validator]),
-    (int, [int_validator]),
+    (int, [IfConfig(strict_int_validator, 'strict_int'), int_validator]),
     (float, [float_validator]),
     (Path, [path_validator]),
     (datetime, [parse_datetime]),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Add a global option `strict_int` to treat all `int` fields as strict

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable

* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
