### PR TITLE
Add lookahead for ip check in AnyUrl

### DIFF
--- a/changes/2512-sbv-csis.md
+++ b/changes/2512-sbv-csis.md
@@ -1,0 +1,2 @@
+Add lookahead to ip regexes for `AnyUrl` hosts. This allows urls with DNS labels
+looking like IPs to validate as they are perfectly valid host names.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -69,8 +69,8 @@ def url_regex() -> Pattern[str]:
             r'(?:(?P<scheme>[a-z][a-z0-9+\-.]+)://)?'  # scheme https://tools.ietf.org/html/rfc3986#appendix-A
             r'(?:(?P<user>[^\s:/]*)(?::(?P<password>[^\s/]*))?@)?'  # user info
             r'(?:'
-            r'(?P<ipv4>(?:\d{1,3}\.){3}\d{1,3})|'  # ipv4
-            r'(?P<ipv6>\[[A-F0-9]*:[A-F0-9:]+\])|'  # ipv6
+            r'(?P<ipv4>(?:\d{1,3}\.){3}\d{1,3})(?=$|[/:#?])|'  # ipv4
+            r'(?P<ipv6>\[[A-F0-9]*:[A-F0-9:]+\])(?=$|[/:#?])|'  # ipv6
             r'(?P<domain>[^\s/:?#]+)'  # domain, validation occurs later
             r')?'
             r'(?::(?P<port>\d+))?'  # port

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -51,6 +51,8 @@ except ImportError:
         AnyUrl('https://example.com', scheme='https', host='example.com'),
         'https://exam_ple.com/',
         'http://twitter.com/@handle/',
+        'http://11.11.11.11.example.com/action',
+        'http://abc.11.11.11.11.example.com/action',
     ],
 )
 def test_any_url_success(value):
@@ -155,6 +157,16 @@ def test_ipv4_port():
     assert url.host == '123.45.67.8'
     assert url.host_type == 'ipv4'
     assert url.port == '8329'
+    assert url.user is None
+    assert url.password is None
+
+
+def test_ipv4_no_port():
+    url = validate_url('ftp://123.45.67.8')
+    assert url.scheme == 'ftp'
+    assert url.host == '123.45.67.8'
+    assert url.host_type == 'ipv4'
+    assert url.port is None
     assert url.user is None
     assert url.password is None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Added lookahead for the ip regex'es to allow for urls with 4 numbers preceeding the rest of the host

## Related issue number

fix #1651 


## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
