### PR TITLE
Documentation on reducing package size and custom CFLAGS

### DIFF
--- a/changes/2517-peterroelants.md
+++ b/changes/2517-peterroelants.md
@@ -1,0 +1,1 @@
+Documentation update how to custom compile pydantic when using pip install, small change in `setup.py` to allow for custom CFLAGS when compiling.

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,10 +16,13 @@ channel:
 conda install pydantic -c conda-forge
 ```
 
-*pydantic* can optionally be compiled with [cython](https://cython.org/) which should give a 30-50% performance
-improvement. 
+## Compiled with Cython
 
-Binaries are available from [PyPI](https://pypi.org/project/pydantic/#files) for Linux, MacOS and 64bit Windows.
+*pydantic* can optionally be compiled with [cython](https://cython.org/) which should give a 30-50% performance improvement. 
+
+By default `pip install` provides optimized binaries via [PyPI](https://pypi.org/project/pydantic/#files) for Linux, MacOS and 64bit Windows.
+
+
 If you're installing manually, install `cython` before installing *pydantic* and compilation should happen automatically.
 
 To test if *pydantic* is compiled run:
@@ -28,6 +31,27 @@ To test if *pydantic* is compiled run:
 import pydantic
 print('compiled:', pydantic.compiled)
 ```
+
+### Performance vs package size trade-off
+
+Compiled binaries can increase the size of your Python environment. If for some reason you want to reduce the size of your *pydantic* installation you can avoid installing any binaries using the [`pip --no-binary`](https://pip.pypa.io/en/stable/cli/pip_install/#install-no-binary) option. Make sure `Cython` is not in your environment, or that you have the `SKIP_CYTHON` environment variable set to avoid re-compiling *pydantic* libraries:
+
+```bash
+SKIP_CYTHON=1 pip install --no-binary pydantic pydantic
+```
+!!! note
+    `pydantic` is repeated here intentionally, `--no-binary pydantic` tells `pip` you want no binaries for pydantic,
+    the next `pydantic` tells `pip` which package to install.
+
+Alternatively, you can re-compile *pydantic* with custom [build options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html), this would require having the [`Cython`](https://pypi.org/project/Cython/) package installed before re-compiling *pydantic* with:
+```bash
+CFLAGS="-Os -g0 -s" pip install \
+  --no-binary pydantic \
+  --global-option=build_ext \
+  pydantic
+```
+
+## Optional dependencies
 
 *pydantic* has two optional dependencies:
 
@@ -45,6 +69,9 @@ pip install pydantic[email,dotenv]
 ```
 
 Of course, you can also install these requirements manually with `pip install email-validator` and/or `pip install`.
+
+
+## Install from repository
 
 And if you prefer to install *pydantic* directly from the repository:
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,9 @@ if not any(arg in sys.argv for arg in ['clean', 'check']) and 'SKIP_CYTHON' not 
         compiler_directives = {}
         if 'CYTHON_TRACE' in sys.argv:
             compiler_directives['linetrace'] = True
-        os.environ['CFLAGS'] = '-O3'
+        # Set CFLAG to all optimizations (-O3)
+        # Any additional CFLAGS will be appended. Only the last optimization flag will have effect
+        os.environ['CFLAGS'] = '-O3 ' + os.environ.get('CFLAGS', '')
         ext_modules = cythonize(
             'pydantic/*.py',
             exclude=['pydantic/generics.py'],


### PR DESCRIPTION
## Change Summary

- Documentation update on how to custom compile *pydantic* when using pip install.
- Small change in `setup.py` to allow for custom CFLAGS when compiling.

### Setup.py CFLAGS
pydantic's [`setup.py` overwrites all custom CFLAGS](https://github.com/samuelcolvin/pydantic/blob/619ff261c9bdc2a612ef2fcfa17a005dfefbcf21/setup.py#L85) that a user might pass in when rebuilding pydantic. 
This change appends custom CFLAGS to the current CFLAGS used when building. There should not be any change in the current default behaviour.

By appending custom CFLAGS to the end it is possible to overwrite the default optimization flags currently used in pydantic. From the [gcc docs](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#:~:text=If%20you%20use%20multiple%20-O%20options):
> _If you use multiple -O options, with or without level numbers, the last such option is the one that is effective._

#### Performance impact of setting different CFLAGS

|      | size| benchmark avg time |
| --- | --- | --- |
| default `pip install` (from PyPI) | 45M | 70.7μs |
| `pip install --no-binary` (from PyPI) | 796K | 101.4μs |
| `pip install --no-binary` (from PyPI) with cython | 6.4M | 67.8μs |
| `pip install --no-binary` with cython CFLAG "-O3" (This branch) | 6.4M | 68.1μs |
| `pip install --no-binary` with cython CFLAG "-Os" (This branch) | 5.2M | 74.6μs |

## Related issue number

Issue https://github.com/samuelcolvin/pydantic/issues/2276 will be resolved by documenting how to reduce *pydantic* installation size. Additionally, users can pass in custom CFLAGs  to trade-off speed vs size.

## Checklist

* [x] Unit tests for the changes exist (Already existent)
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
