### PR TITLE
Allow collections.abc.Callable to be used as type in python 3.9

### DIFF
--- a/changes/2519-daviskirk.md
+++ b/changes/2519-daviskirk.md
@@ -1,0 +1,1 @@
+Allow `collections.abc.Callable` to be used as type in python 3.9.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -30,7 +30,6 @@ from .error_wrappers import ErrorWrapper
 from .errors import ConfigError, NoneIsNotAllowedError
 from .types import Json, JsonWrapper
 from .typing import (
-    NONE_TYPES,
     Callable,
     ForwardRef,
     NoArgAnyCallable,
@@ -40,6 +39,7 @@ from .typing import (
     get_origin,
     is_literal_type,
     is_new_type,
+    is_none_type,
     is_typeddict,
     new_type_supertype,
 )
@@ -737,7 +737,7 @@ class ModelField(Representation):
                 return v, errors
 
         if v is None:
-            if self.type_ in NONE_TYPES:
+            if is_none_type(self.type_):
                 # keep validating
                 pass
             elif self.allow_none:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -63,7 +63,6 @@ from .types import (
     constr,
 )
 from .typing import (
-    NONE_TYPES,
     ForwardRef,
     all_literal_values,
     get_args,
@@ -71,6 +70,7 @@ from .typing import (
     is_callable_type,
     is_literal_type,
     is_namedtuple,
+    is_none_type,
 )
 from .utils import ROOT_KEY, get_model, lenient_issubclass, sequence_like
 
@@ -787,7 +787,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         )
     if field_type is Any or field_type.__class__ == TypeVar:
         return {}, definitions, nested_models  # no restrictions
-    if field_type in NONE_TYPES:
+    if is_none_type(field_type):
         return {'type': 'null'}, definitions, nested_models
     if is_callable_type(field_type):
         raise SkipField(f'Callable {field.name} was excluded from schema since JSON schema has no equivalent type.')

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -248,6 +248,11 @@ NONE_TYPES: Tuple[Any, Any, Any] = (None, NoneType, Literal[None])
 
 
 if sys.version_info < (3, 8):  # noqa: C901 (ignore complexity)
+    # Even though this implementation is slower, we need it for python 3.6/3.7:
+    # In python 3.6/3.7 "Literal" is not a builtin type and uses a different
+    # mechanism.
+    # for this reason `Literal[None] is Literal[None]` evaluates to `False`,
+    # breaking the faster implementation used for the other python versions.
 
     def is_none_type(type_: Any) -> bool:
         return type_ in NONE_TYPES

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -245,14 +245,14 @@ __all__ = (
 NoneType = None.__class__
 
 
-NONE_TYPES: Tuple[Any, ...] = (None, NoneType, Literal[None])
+NONE_TYPES: Set[Any] = {None, NoneType, Literal[None]}
 
 
 def is_none_type(type_: Any) -> bool:
-    for none_type in NONE_TYPES:
-        if type_ is none_type:
-            return True
-    return False
+    try:
+        return type_ in NONE_TYPES
+    except TypeError:
+        return False
 
 
 def display_as_type(v: Type[Any]) -> str:

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -211,6 +211,7 @@ __all__ = (
     'NoArgAnyCallable',
     'NoneType',
     'NONE_TYPES',
+    'is_none_type',
     'display_as_type',
     'resolve_annotations',
     'is_callable_type',
@@ -242,7 +243,16 @@ __all__ = (
 
 
 NoneType = None.__class__
-NONE_TYPES: Set[Any] = {None, NoneType, Literal[None]}
+
+
+NONE_TYPES: Tuple[Any, ...] = (None, NoneType, Literal[None])
+
+
+def is_none_type(type_: Any) -> bool:
+    for none_type in NONE_TYPES:
+        if type_ is none_type:
+            return True
+    return False
 
 
 def display_as_type(v: Type[Any]) -> str:

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -250,10 +250,7 @@ NONE_TYPES: Tuple[Any, Any, Any] = (None, NoneType, Literal[None])
 if sys.version_info < (3, 8):  # noqa: C901 (ignore complexity)
 
     def is_none_type(type_: Any) -> bool:
-        try:
-            return type_ in NONE_TYPES
-        except TypeError:
-            return False
+        return type_ in NONE_TYPES
 
 
 else:

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -210,7 +210,6 @@ __all__ = (
     'AnyCallable',
     'NoArgAnyCallable',
     'NoneType',
-    'NONE_TYPES',
     'is_none_type',
     'display_as_type',
     'resolve_annotations',
@@ -245,13 +244,24 @@ __all__ = (
 NoneType = None.__class__
 
 
-NONE_TYPES: Set[Any] = {None, NoneType, Literal[None]}
+NONE_TYPES: Tuple[Any, Any, Any] = (None, NoneType, Literal[None])
 
 
-def is_none_type(type_: Any) -> bool:
-    try:
-        return type_ in NONE_TYPES
-    except TypeError:
+if sys.version_info < (3, 8):  # noqa: C901 (ignore complexity)
+
+    def is_none_type(type_: Any) -> bool:
+        try:
+            return type_ in NONE_TYPES
+        except TypeError:
+            return False
+
+
+else:
+
+    def is_none_type(type_: Any) -> bool:
+        for none_type in NONE_TYPES:
+            if type_ is none_type:
+                return True
         return False
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -656,9 +656,12 @@ def find_validators(  # noqa: C901 (ignore complexity)
     type_type = type_.__class__
     if type_type == ForwardRef or type_type == TypeVar:
         return
-    if type_ in NONE_TYPES:
-        yield none_validator
-        return
+    try:
+        if type_ in NONE_TYPES:
+            yield none_validator
+            return
+    except TypeError:
+        pass  # in case unhashable types are in the type
     if type_ is Pattern:
         yield pattern_validator
         return

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -30,7 +30,6 @@ from typing_extensions import Literal
 from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
 from .typing import (
-    NONE_TYPES,
     AnyCallable,
     ForwardRef,
     all_literal_values,
@@ -39,6 +38,7 @@ from .typing import (
     is_callable_type,
     is_literal_type,
     is_namedtuple,
+    is_none_type,
     is_typeddict,
 )
 from .utils import almost_equal_floats, lenient_issubclass, sequence_like
@@ -656,12 +656,10 @@ def find_validators(  # noqa: C901 (ignore complexity)
     type_type = type_.__class__
     if type_type == ForwardRef or type_type == TypeVar:
         return
-    try:
-        if type_ in NONE_TYPES:
-            yield none_validator
-            return
-    except TypeError:
-        pass  # in case unhashable types are in the type
+
+    if is_none_type(type_):
+        yield none_validator
+        return
     if type_ is Pattern:
         yield pattern_validator
         return

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -1,11 +1,18 @@
+import sys
 from typing import Callable
 
 import pytest
 
 from pydantic import BaseModel, ValidationError
 
+collection_callable_types = [Callable, Callable[[int], int]]
+if sys.version_info >= (3, 9):
+    from collections.abc import Callable as CollectionsCallable
 
-@pytest.mark.parametrize('annotation', [Callable, Callable[[int], int]])
+    collection_callable_types += [CollectionsCallable, CollectionsCallable[[int], int]]
+
+
+@pytest.mark.parametrize('annotation', collection_callable_types)
 def test_callable(annotation):
     class Model(BaseModel):
         callback: annotation
@@ -14,7 +21,7 @@ def test_callable(annotation):
     assert callable(m.callback)
 
 
-@pytest.mark.parametrize('annotation', [Callable, Callable[[int], int]])
+@pytest.mark.parametrize('annotation', collection_callable_types)
 def test_non_callable(annotation):
     class Model(BaseModel):
         callback: annotation

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1865,9 +1865,9 @@ def test_repr_field():
 
     m = Model(a=1, b=2, c=3)
     assert repr(m) == 'Model(a=1, b=2)'
-    assert repr(m.__fields__['a'].field_info) == 'FieldInfo(default=Ellipsis, extra={})'
-    assert repr(m.__fields__['b'].field_info) == 'FieldInfo(default=Ellipsis, extra={})'
-    assert repr(m.__fields__['c'].field_info) == 'FieldInfo(default=Ellipsis, repr=False, extra={})'
+    assert repr(m.__fields__['a'].field_info) == 'FieldInfo(default=PydanticUndefined, extra={})'
+    assert repr(m.__fields__['b'].field_info) == 'FieldInfo(default=PydanticUndefined, extra={})'
+    assert repr(m.__fields__['c'].field_info) == 'FieldInfo(default=PydanticUndefined, repr=False, extra={})'
 
 
 def test_inherited_model_field_copy():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -62,7 +62,7 @@ def test_is_none_type():
     assert is_none_type(type(None)) is True
     assert is_none_type(6) is False
     assert is_none_type({}) is False
-    # WARNING: It's important to test typing.Callable not
-    # collections.abc.Callable (event with python >= 3.9) as they behave
+    # WARNING: It's important to test `typing.Callable` not
+    # `collections.abc.Callable` (even with python >= 3.9) as they behave
     # differently
     assert is_none_type(TypingCallable) is False

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,9 +1,9 @@
 from collections import namedtuple
-from typing import NamedTuple
+from typing import Callable as TypingCallable, NamedTuple
 
 import pytest
 
-from pydantic.typing import is_namedtuple, is_typeddict
+from pydantic.typing import Literal, is_namedtuple, is_none_type, is_typeddict
 
 try:
     from typing import TypedDict as typing_TypedDict
@@ -54,3 +54,15 @@ def test_is_typeddict_typing(TypedDict):
         id: int
 
     assert is_typeddict(Other) is False
+
+
+def test_is_none_type():
+    assert is_none_type(Literal[None]) is True
+    assert is_none_type(None) is True
+    assert is_none_type(type(None)) is True
+    assert is_none_type(6) is False
+    assert is_none_type({}) is False
+    # WARNING: It's important to test typing.Callable not
+    # collections.abc.Callable (event with python >= 3.9) as they behave
+    # differently
+    assert is_none_type(TypingCallable) is False


### PR DESCRIPTION
## Change Summary

Allows using python 3.9 generic alias version of `Callable` (`collections.abc.Callable`)

Fixes #2465

## Related issue number

Address #2465

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
