### PR TITLE
Allow for generation of a constrained decimal with decimal_places argument for hypothesis plugin

### DIFF
--- a/changes/2524-cwe5590.md
+++ b/changes/2524-cwe5590.md
@@ -1,1 +1,1 @@
-Add functionality to properly create a constrained decimal strategy when the decimal_place argument is provided.
+Enable the Hypothesis plugin to generate a constrained decimal when the `decimal_place` argument is specified.

--- a/changes/2524-cwe5590.md
+++ b/changes/2524-cwe5590.md
@@ -1,1 +1,1 @@
-Enable the Hypothesis plugin to generate a constrained decimal when the `decimal_place` argument is specified.
+Enable the Hypothesis plugin to generate a constrained decimal when the `decimal_places` argument is specified.

--- a/changes/2524-cwe5590.md
+++ b/changes/2524-cwe5590.md
@@ -1,0 +1,1 @@
+Add functionality to properly create a constrained decimal strategy when the decimal_place argument is provided.

--- a/pydantic/_hypothesis_plugin.py
+++ b/pydantic/_hypothesis_plugin.py
@@ -262,7 +262,7 @@ def resolve_condecimal(cls):  # type: ignore[no-untyped-def]
     if cls.lt is not None:
         assert max_value is None, 'Set `lt` or `le`, but not both'
         max_value = cls.lt
-    s = st.decimals(min_value, max_value, allow_nan=False)
+    s = st.decimals(min_value, max_value, allow_nan=False, places=cls.decimal_places)
     if cls.lt is not None:
         s = s.filter(lambda d: d < cls.lt)
     if cls.gt is not None:

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -75,9 +75,10 @@ def gen_models():
         confloatt: pydantic.confloat(gt=10, lt=100)
         confloate: pydantic.confloat(ge=10, le=100)
         confloatemul: pydantic.confloat(ge=10, le=100, multiple_of=4.2)
-        confloattmul: pydantic.confloat(gt=10, lt=100, multiple_of=10)
         condecimalt: pydantic.condecimal(gt=10, lt=100)
         condecimale: pydantic.condecimal(ge=10, le=100)
+        condecimaltplc: pydantic.condecimal(gt=10, lt=100, decimal_places=5)
+        condecimaleplc: pydantic.condecimal(ge=10, le=100, decimal_places=2)
 
     yield from (
         MiscModel,

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -75,6 +75,7 @@ def gen_models():
         confloatt: pydantic.confloat(gt=10, lt=100)
         confloate: pydantic.confloat(ge=10, le=100)
         confloatemul: pydantic.confloat(ge=10, le=100, multiple_of=4.2)
+        confloattmul: pydantic.confloat(gt=10, lt=100, multiple_of=10)
         condecimalt: pydantic.condecimal(gt=10, lt=100)
         condecimale: pydantic.condecimal(ge=10, le=100)
         condecimaltplc: pydantic.condecimal(gt=10, lt=100, decimal_places=5)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Enable the Hypothesis plugin to generate a constrained decimal when the `decimal_place` argument is specified.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

fix https://github.com/samuelcolvin/pydantic/discussions/2520

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
