### PR TITLE
build(dev-deps): bump lint and doc deps

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 ansi2html==1.6.0
-flake8==3.8.4
+flake8==3.9.0
 flake8-quotes==3.2.0
 hypothesis==6.3.4
 markdown-include==0.6.0
 mdx-truly-sane-lists==1.2
 mkdocs==1.1.2
 mkdocs-exclude==1.0.2
-mkdocs-material==7.0.3
+mkdocs-material==7.0.6
 sqlalchemy
 orjson
 ujson

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -1,9 +1,9 @@
 black==20.8b1
-flake8==3.8.4
+flake8==3.9.0
 flake8-quotes==3.2.0
 hypothesis==6.3.4
 isort==5.7.0
 mypy==0.812
-pycodestyle==2.6.0
-pyflakes==2.2.0
+pycodestyle==2.7.0
+pyflakes==2.3.0
 twine==3.3.0


### PR DESCRIPTION
build(deps): bump flake8 from 3.8.4 to 3.9.0 #2528
build(deps): bump pycodestyle from 2.6.0 to 2.7.0 #2527 
build(deps): bump pyflakes from 2.2.0 to 2.3.0 #2526 
build(deps): bump mkdocs-material from 7.0.3 to 7.0.6 #2525 