### PR TITLE
fix(schema): JSON schema generation with a `Literal` of an enum member

### DIFF
--- a/changes/2536-PrettyWood.md
+++ b/changes/2536-PrettyWood.md
@@ -1,0 +1,1 @@
+fix JSON schema generation with a `Literal` of an enum member

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -788,6 +788,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
     f_schema: Dict[str, Any] = {}
     if field.field_info is not None and field.field_info.const:
         f_schema['const'] = field.default
+
     field_type = field.type_
     if is_literal_type(field_type):
         values = all_literal_values(field_type)
@@ -805,8 +806,8 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         # All values have the same type
         field_type = values[0].__class__
         f_schema['enum'] = list(values)
-
-    if lenient_issubclass(field_type, Enum):
+        add_field_type_to_schema(field_type, f_schema)
+    elif lenient_issubclass(field_type, Enum):
         enum_name = model_name_map[field_type]
         f_schema, schema_overrides = get_field_info_schema(field)
         f_schema.update(get_schema_ref(enum_name, ref_prefix, ref_template, schema_overrides))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1780,6 +1780,22 @@ def test_literal_schema():
     }
 
 
+def test_literal_enum():
+    class MyEnum(str, Enum):
+        FOO = 'foo'
+        BAR = 'bar'
+
+    class Model(BaseModel):
+        kind: Literal[MyEnum.FOO]
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'kind': {'title': 'Kind', 'enum': ['foo'], 'type': 'string'}},
+        'required': ['kind'],
+    }
+
+
 def test_color_type():
     class Model(BaseModel):
         color: Color


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Support JSON schema generation with a `Literal` of an enum member

<!-- Please give a short summary of the changes. -->

## Related issue number
closes #2534
closes #2535

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
