### PR TITLE
fix: doc indent

### DIFF
--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -76,21 +76,21 @@ It has the following arguments:
 * `regex`: for string values, this adds a Regular Expression validation generated from the passed string and an
   annotation of `pattern` to the JSON Schema
 
-    !!! note
-        *pydantic* validates strings using `re.match`,
-        which treats regular expressions as implicitly anchored at the beginning.
-        On the contrary,
-        JSON Schema validators treat the `pattern` keyword as implicitly unanchored,
-        more like what `re.search` does.
+!!! note
+    *pydantic* validates strings using `re.match`,
+    which treats regular expressions as implicitly anchored at the beginning.
+    On the contrary,
+    JSON Schema validators treat the `pattern` keyword as implicitly unanchored,
+    more like what `re.search` does.
 
-        For interoperability, depending on your desired behavior,
-        either explicitly anchor your regular expressions with `^`
-        (e.g. `^foo` to match any string starting with `foo`),
-        or explicitly allow an arbitrary prefix with `.*?`
-        (e.g. `.*?foo` to match any string containing the substring `foo`).
+    For interoperability, depending on your desired behavior,
+    either explicitly anchor your regular expressions with `^`
+    (e.g. `^foo` to match any string starting with `foo`),
+    or explicitly allow an arbitrary prefix with `.*?`
+    (e.g. `.*?foo` to match any string containing the substring `foo`).
 
-        See [#1631](https://github.com/samuelcolvin/pydantic/issues/1631)
-        for a discussion of possible changes to *pydantic* behavior in **v2**.
+    See [#1631](https://github.com/samuelcolvin/pydantic/issues/1631)
+    for a discussion of possible changes to *pydantic* behavior in **v2**.
 
 * `**` any other keyword arguments (e.g. `examples`) will be added verbatim to the field's schema
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

### BEFORE
<img width="683" alt="Screen Shot 2021-03-17 at 11 41 49 PM" src="https://user-images.githubusercontent.com/18406791/111548056-6bd7d980-877a-11eb-9068-b58f0f742a25.png">

### AFTER
<img width="826" alt="Screen Shot 2021-03-17 at 11 42 14 PM" src="https://user-images.githubusercontent.com/18406791/111548088-74c8ab00-877a-11eb-802c-dc6893c7ab77.png">

<!-- Please give a short summary of the changes. -->

## Related issue number
closes #2540
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
