### PR TITLE
feat: add `Constraints` and `Strict` to annotate fields

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -2,6 +2,7 @@
 from . import dataclasses
 from .annotated_types import create_model_from_namedtuple, create_model_from_typeddict
 from .class_validators import root_validator, validator
+from .constraints import Constraints, Strict
 from .decorator import validate_arguments
 from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
@@ -20,6 +21,9 @@ __all__ = [
     # annotated types utils
     'create_model_from_namedtuple',
     'create_model_from_typeddict',
+    # constraints
+    'Constraints',
+    'Strict',
     # dataclasses
     'dataclasses',
     # class_validators

--- a/pydantic/constraints.py
+++ b/pydantic/constraints.py
@@ -1,0 +1,93 @@
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Pattern, Tuple, TypeVar, Union
+
+from typing_extensions import Annotated
+
+from pydantic.types import StrictBool, conbytes, condecimal, confloat, conint, conlist, conset, constr
+from pydantic.typing import get_args, get_origin
+from pydantic.utils import Representation
+
+__all__ = 'Constraints', 'Strict', 'convert_type_to_constrained_if_needed'
+
+
+def conbool(*, strict: bool = False) -> type:
+    return StrictBool if strict else bool
+
+
+CONSTRAINED_TYPES_MAPPING: Dict[type, Any] = {
+    bool: conbool,
+    int: conint,
+    float: confloat,
+    Decimal: condecimal,
+    bytes: conbytes,
+    str: constr,
+    list: conlist,
+    set: conset,
+}
+
+
+@dataclass(repr=False)
+class Constraints(Representation):
+    strict: Optional[bool] = None
+
+    # int, float, decimal
+    gt: Union[int, float, Decimal, None] = None
+    ge: Union[int, float, Decimal, None] = None
+    lt: Union[int, float, Decimal, None] = None
+    le: Union[int, float, Decimal, None] = None
+    multiple_of: Union[int, float, Decimal, None] = None
+
+    # extra for decimal
+    max_digits: Optional[int] = None
+    decimal_places: Optional[int] = None
+
+    # str, bytes
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
+    regex: Optional[Pattern[str]] = None
+    curtail_length: Optional[int] = None
+    strip_whitespace: Optional[bool] = None
+    to_lower: Optional[bool] = None
+
+    # other collections (list, tuple, set, ...)
+    min_items: Optional[int] = None
+    max_items: Optional[int] = None
+
+    def todict(self) -> Dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    def __repr_args__(self) -> List[Tuple[str, Any]]:
+        return list(self.todict().items())
+
+
+T = TypeVar('T')
+Strict = Annotated[T, Constraints(strict=True)]
+
+
+def convert_type_to_constrained_if_needed(tp: Any) -> Any:
+    """
+    From a type like `Strict[Annotated[int, Constraints(ge=2)]]`,
+    return `conint(strict=True, ge=2)`
+    """
+    if get_origin(tp) is not Annotated:
+        return tp
+
+    type_, *metadata = get_args(tp)
+
+    constraints_kwargs: Dict[str, Any] = {}
+    type_origin = get_origin(type_)
+    if type_origin in {list, set}:
+        # type_ can be `list[int]` for example
+        item_type = get_args(type_)[0]
+        # item_type can itself have constraints
+        constraints_kwargs['item_type'] = convert_type_to_constrained_if_needed(item_type)
+        type_ = type_origin
+
+    all_constraints = [x for x in metadata if isinstance(x, Constraints)]
+    if type_ in CONSTRAINED_TYPES_MAPPING:
+        for constraint in all_constraints:
+            constraints_kwargs.update(constraint.todict())
+        return CONSTRAINED_TYPES_MAPPING[type_](**constraints_kwargs)
+    else:
+        return type_

--- a/pydantic/constraints.py
+++ b/pydantic/constraints.py
@@ -27,7 +27,7 @@ CONSTRAINED_TYPES_MAPPING: Dict[type, Any] = {
 }
 
 
-@dataclass(repr=False)
+@dataclass(frozen=True, repr=False)
 class Constraints(Representation):
     strict: Optional[bool] = None
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -521,7 +521,9 @@ class ModelField(Representation):
                 self.allow_none = True
             return
         if origin is Annotated:
-            self.type_ = get_args(self.type_)[0]
+            from .constraints import convert_type_to_constrained_if_needed
+
+            self.type_ = convert_type_to_constrained_if_needed(self.type_)
             self._type_analysis()
             return
         if origin is Callable:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Hi!
ℹ️ **This is only a proposal at the moment** to improve the dev experience with `mypy` and IDE.
If we decide to go further I'll write the tests and the doc!
We can go way further (I actually started working on the strict mode but it feels like we first need to clean our room for the constraints and also decide if we put the strictness everywhere (a set cannot be coerced into a list, ...))

Content of this PR: `Constraints` and `Strict` alias to avoid using `conint`, `confloat`, ...
`Strict` is just an alias for `Annotated[T, Constraints(strict=True)]`.
But since `Annotated` can use nested and `Constraints` too, the alias feels really good IMO.
Behind the scene we still call them to avoid any issues

### Example of usage now
```py
from typing_extensions import Annotated

from pydantic import BaseModel, Constraints, Strict

class Model(BaseModel):
    a: Strict[Annotated[int, Constraints(ge=2)]]
    b: Strict[Annotated[str, Constraints(min_length=2)]]
    c: Strict[bool]
    d: Annotated[list[Strict[int]], Constraints(min_items=2)]
```
```console
▶ mypy pika.py
Success: no issues found in 1 source file
```

### What we need to write at the moment
```py
from pydantic import BaseModel, StrictBool, conint, conlist, constr

class Model(BaseModel):
    a: conint(ge=2, strict=True)
    b: constr(min_length=2, strict=True)
    c: StrictBool
    d: conlist(int, min_items=2)
```
```console
▶ mypy pika.py
pika.py:18: error: Invalid type comment or annotation  [valid-type]
pika.py:18: note: Suggestion: use conint[...] instead of conint(...)
pika.py:19: error: Invalid type comment or annotation  [valid-type]
pika.py:19: note: Suggestion: use constr[...] instead of constr(...)
pika.py:21: error: Invalid type comment or annotation  [valid-type]
pika.py:21: note: Suggestion: use conlist[...] instead of conlist(...)
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
