### PR TITLE
fix: remove side effect of `default_factory` to always run it only once

### DIFF
--- a/changes/2515-PrettyWood.md
+++ b/changes/2515-PrettyWood.md
@@ -1,0 +1,1 @@
+remove side effect of `default_factory` to run it only once even if `Config.validate_all` is set

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -540,8 +540,6 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
 
 !!! warning
     The `default_factory` expects the field type to be set.
-    Moreover if you want to validate default values with `validate_all`,
-    *pydantic* will need to call the `default_factory`, which could lead to side effects!
 
 ## Automatically excluded attributes
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -458,17 +458,13 @@ class ModelField(Representation):
     def _set_default_and_type(self) -> None:
         """
         Set the default value, infer the type if needed and check if `None` value is valid.
-
-        Note: to prevent side effects by calling the `default_factory` for nothing, we only call it
-        when we want to validate the default value i.e. when `validate_all` is set to True.
         """
         if self.default_factory is not None:
             if self.type_ is Undefined:
                 raise errors_.ConfigError(
                     f'you need to set the type of field {self.name!r} when using `default_factory`'
                 )
-            if not self.model_config.validate_all:
-                return
+            return
 
         default_value = self.get_default()
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1695,12 +1695,12 @@ def test_hashable_optional(default):
     Model()
 
 
-def test_default_factory_side_effect():
-    """It may call `default_factory` more than once when `validate_all` is set"""
+def test_default_factory_called_once():
+    """It should never call `default_factory` more than once even when `validate_all` is set"""
 
     v = 0
 
-    def factory():
+    def factory() -> int:
         nonlocal v
         v += 1
         return v
@@ -1712,7 +1712,20 @@ def test_default_factory_side_effect():
             validate_all = True
 
     m1 = MyModel()
-    assert m1.id == 2  # instead of 1
+    assert m1.id == 1
+
+    class MyBadModel(BaseModel):
+        id: List[str] = Field(default_factory=factory)
+
+        class Config:
+            validate_all = True
+
+    with pytest.raises(ValidationError) as exc_info:
+        MyBadModel()
+    assert v == 2  # `factory` has been called to run validation
+    assert exc_info.value.errors() == [
+        {'loc': ('id',), 'msg': 'value is not a valid list', 'type': 'type_error.list'},
+    ]
 
 
 def test_default_factory_validator_child():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
I don't know why I did this now that I come back on it 😅 
Validation is still properly triggered as showcased in the test

## Related issue number
closes #2515
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
