### PR TITLE
fix: provide __version__ attribute

### DIFF
--- a/changes/2572-paxcodes.md
+++ b/changes/2572-paxcodes.md
@@ -1,0 +1,1 @@
+Add `__version__` attribute to pydantic module.

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -14,6 +14,8 @@ from .tools import *
 from .types import *
 from .version import VERSION
 
+__version__ = VERSION
+
 # WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
 # please use "from pydantic.errors import ..." instead
 __all__ = [

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,9 @@
+import pydantic
+
+
+def test_version_attribute_is_present():
+    assert hasattr(pydantic, '__version__')
+
+
+def test_version_attribute_is_a_string():
+    assert isinstance(pydantic.__version__, str)


### PR DESCRIPTION
## Change Summary

Provide `__version__` attribute.

Pyinstaller is giving an error packaging a script that uses pydantic, `AttributeError: Module 'pydantic' has no attribute '__version__'`

## Related issue number

fix #2572

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [n/a] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
