### PR TITLE
Fix indent level of "Validating the first value"

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -221,7 +221,7 @@ _(This script is complete, it should run "as is")_
     pydantic can't validate the values automatically for you because it would require
     consuming the infinite generator.
 
-## Validating the first value
+#### Validating the first value
 
 You can create a [validator](validators.md) to validate the first value in an infinite generator and still not consume it entirely.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
A minor fix of the indent level of "Validating the first value" in `types.md`.
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
