### PR TITLE
docs preview and coverage using smokeshow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,19 +68,20 @@ jobs:
         ls -alh
         ls -alh pydantic/
 
+    - run: mkdir coverage
+
     - name: test compiled and deps
       run: make test
-
-    - run: mkdir coverage
-    - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dY
+      env:
+        COVERAGE_FILE: coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dY
 
     - name: uninstall deps
       run: pip uninstall -y cython email-validator devtools python-dotenv
 
     - name: test compiled without deps
       run: make test
-
-    - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dN
+      env:
+        COVERAGE_FILE: coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dN
 
     - name: remove compiled binaries
       run: |
@@ -90,8 +91,8 @@ jobs:
 
     - name: test uncompiled without deps
       run: make test
-
-    - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cN-dN
+      env:
+        COVERAGE_FILE: coverage/.coverage.linux-py${{ matrix.python-version }}-cN-dN
 
     - name: store coverage files
       uses: actions/upload-artifact@v2
@@ -124,11 +125,12 @@ jobs:
     - name: install
       run: make install-testing
 
+    - run: mkdir coverage
+
     - name: test
       run: make test
-
-    - run: mkdir coverage
-    - run: mv .coverage coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
+      env:
+        COVERAGE_FILE: coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
 
     - name: store coverage files
       uses: actions/upload-artifact@v2
@@ -136,7 +138,7 @@ jobs:
         name: coverage
         path: coverage
 
-  coverage-check:
+  coverage-upload:
     name: coverage check
     needs: [test-linux, test-windows-mac]
     runs-on: ubuntu-latest
@@ -152,17 +154,14 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: coverage
-          path: .
+          path: coverage
 
       - run: pip install coverage smokeshow
 
       - run: ls -la
-      - run: coverage combine
-      - run: coverage report -i
-      - run: coverage debug config
-      - run: coverage debug data
-      - run: coverage debug sys
-      - run: coverage html -i --show-contexts
+      - run: coverage combine coverage
+      - run: coverage report
+      - run: coverage html
 
       - run: smokeshow upload htmlcov
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,14 @@ jobs:
     - name: test compiled and deps
       run: make test
 
-    - run: coverage xml
-    - uses: codecov/codecov-action@v1.2.1
+    - run: mkdir coverage
+    - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dY
+
+    - name: store coverage files
+      uses: actions/upload-artifact@v2
       with:
-        file: ./coverage.xml
-        env_vars: COMPILED,DEPS,PYTHON,OS
-      env:
-        COMPILED: yes
-        DEPS: yes
+        name: coverage
+        path: coverage
 
     - name: uninstall deps
       run: pip uninstall -y cython email-validator devtools python-dotenv
@@ -86,14 +86,7 @@ jobs:
     - name: test compiled without deps
       run: make test
 
-    - run: coverage xml
-    - uses: codecov/codecov-action@v1.2.1
-      with:
-        file: ./coverage.xml
-        env_vars: COMPILED,DEPS,PYTHON,OS
-      env:
-        COMPILED: yes
-        DEPS: no
+    - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dN
 
     - name: remove compiled binaries
       run: |
@@ -104,14 +97,13 @@ jobs:
     - name: test uncompiled without deps
       run: make test
 
-    - run: coverage xml
-    - uses: codecov/codecov-action@v1.2.1
+    - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cN-dN
+
+    - name: store coverage files
+      uses: actions/upload-artifact@v2
       with:
-        file: ./coverage.xml
-        env_vars: COMPILED,DEPS,PYTHON,OS
-      env:
-        COMPILED: no
-        DEPS: no
+        name: coverage
+        path: coverage
 
   test-windows-mac:
     name: test py${{ matrix.python-version }} on ${{ matrix.os }}
@@ -126,7 +118,7 @@ jobs:
       COMPILED: no
       DEPS: yes
 
-    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2
 
@@ -143,10 +135,43 @@ jobs:
 
     - run: coverage xml
 
-    - uses: codecov/codecov-action@v1.2.1
+    - run: mv .coverage coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
+
+    - name: store coverage files
+      uses: actions/upload-artifact@v2
       with:
-        file: ./coverage.xml
-        env_vars: COMPILED,DEPS,PYTHON,OS
+        name: coverage
+        path: coverage
+
+  coverage-check:
+    name: coverage check
+    needs: [test-linux, test-windows-mac]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+
+      - name: get coverage files
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
+          path: .
+
+      - run: pip install coverage smokeshow
+
+      - run: coverage combine
+      - run: coverage html -i
+
+      - run: smokeshow upload htmlcov
+        env:
+          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: CLI Coverage {coverage-percentage}
+          SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 100
+          SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   test-fastapi:
     name: test fastAPI
@@ -203,7 +228,7 @@ jobs:
         - os: windows
           ls: dir
 
-    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,6 @@ jobs:
     - name: test
       run: make test
 
-    - run: coverage xml
-
     - run: mkdir coverage
     - run: mv .coverage coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
 
@@ -164,7 +162,7 @@ jobs:
 
       - run: smokeshow upload htmlcov
         env:
-          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: CLI Coverage {coverage-percentage}
+          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Coverage {coverage-percentage}
           SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 100
           SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,6 @@ jobs:
     - run: mkdir coverage
     - run: mv .coverage coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dY
 
-    - name: store coverage files
-      uses: actions/upload-artifact@v2
-      with:
-        name: coverage
-        path: coverage
-
     - name: uninstall deps
       run: pip uninstall -y cython email-validator devtools python-dotenv
 
@@ -118,7 +112,7 @@ jobs:
       COMPILED: no
       DEPS: yes
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
     - uses: actions/checkout@v2
 
@@ -164,6 +158,7 @@ jobs:
 
       - run: pip install coverage smokeshow
 
+      - run: ls -la
       - run: coverage combine
       - run: coverage html -i
 
@@ -229,7 +224,7 @@ jobs:
         - os: windows
           ls: dir
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
-    needs: [lint, test-linux, test-windows-mac, test-fastapi]
+    needs: [lint, test-linux, test-windows-mac, test-fastapi, benchmark]
     if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
         env:
           SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Coverage {coverage-percentage}
           SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 100
+          SMOKESHOW_GITHUB_CONTEXT: coverage
           SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
 
     - run: coverage xml
 
+    - run: mkdir coverage
     - run: mv .coverage coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
 
     - name: store coverage files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       run: make test
       env:
         COVERAGE_FILE: coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dY
+        CONTEXT: linux-py${{ matrix.python-version }}-compiled-yes-deps-yes
 
     - name: uninstall deps
       run: pip uninstall -y cython email-validator devtools python-dotenv
@@ -82,6 +83,7 @@ jobs:
       run: make test
       env:
         COVERAGE_FILE: coverage/.coverage.linux-py${{ matrix.python-version }}-cY-dN
+        CONTEXT: linux-py${{ matrix.python-version }}-compiled-yes-deps-no
 
     - name: remove compiled binaries
       run: |
@@ -93,6 +95,7 @@ jobs:
       run: make test
       env:
         COVERAGE_FILE: coverage/.coverage.linux-py${{ matrix.python-version }}-cN-dN
+        CONTEXT: linux-py${{ matrix.python-version }}-compiled-no-deps-no
 
     - name: store coverage files
       uses: actions/upload-artifact@v2
@@ -131,6 +134,7 @@ jobs:
       run: make test
       env:
         COVERAGE_FILE: coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
+        CONTEXT: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     - name: store coverage files
       uses: actions/upload-artifact@v2
@@ -161,7 +165,7 @@ jobs:
       - run: ls -la
       - run: coverage combine coverage
       - run: coverage report
-      - run: coverage html
+      - run: coverage html --show-contexts
 
       - run: smokeshow upload htmlcov
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,11 @@ jobs:
 
       - run: ls -la
       - run: coverage combine
-      - run: coverage html -i
+      - run: coverage report -i
+      - run: coverage debug config
+      - run: coverage debug data
+      - run: coverage debug sys
+      - run: coverage html -i --show-contexts
 
       - run: smokeshow upload htmlcov
         env:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,5 +24,6 @@ jobs:
     - run: smokeshow upload site
       env:
         SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Docs Preview
+        SMOKESHOW_GITHUB_CONTEXT: docs
         SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -16,19 +16,13 @@ jobs:
     - name: install
       run: make install-docs
 
-    - name: build site
-      run: |
-        make docs
-        zip -r site.zip site
-        ls -lh
+    - run: pip install smokeshow
 
-    - name: upload
-      run: >
-        wget
-        https://site-deploy-opivr5adlq-ue.a.run.app/upload/?run_id=$GITHUB_RUN_ID
-        -O-
-        -q
-        --content-on-error
-        --post-file=site.zip
+    - name: build site
+      run: make docs
+
+    - run: smokeshow upload site
       env:
-        GITHUB_RUN_ID: ${{ github.run_id }}
+        SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Docs Preview
+        SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pydantic
 
 [![CI](https://github.com/samuelcolvin/pydantic/workflows/CI/badge.svg?event=push)](https://github.com/samuelcolvin/pydantic/actions?query=event%3Apush+branch%3Amaster+workflow%3ACI)
-[![Coverage](https://codecov.io/gh/samuelcolvin/pydantic/branch/master/graph/badge.svg)](https://codecov.io/gh/samuelcolvin/pydantic)
+[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/samuelcolvin/pydantic.svg)](https://github.com/samuelcolvin/pydantic/actions?query=event%3Apush+branch%3Amaster+workflow%3ACI)
 [![pypi](https://img.shields.io/pypi/v/pydantic.svg)](https://pypi.python.org/pypi/pydantic)
 [![CondaForge](https://img.shields.io/conda/v/conda-forge/pydantic.svg)](https://anaconda.org/conda-forge/pydantic)
 [![downloads](https://img.shields.io/pypi/dm/pydantic.svg)](https://pypistats.org/packages/pydantic)

--- a/changes/2580-samuelcolvin.md
+++ b/changes/2580-samuelcolvin.md
@@ -1,0 +1,1 @@
+Switch docs preview and coverage display to use [smokeshow](https://smokeshow.helpmanual.io/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/samuelcolvin/pydantic/workflows/CI/badge.svg?event=push)](https://github.com/samuelcolvin/pydantic/actions?query=event%3Apush+branch%3Amaster+workflow%3ACI)
-[![Coverage](https://codecov.io/gh/samuelcolvin/pydantic/branch/master/graph/badge.svg)](https://codecov.io/gh/samuelcolvin/pydantic)
+[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/samuelcolvin/pydantic.svg)](https://github.com/samuelcolvin/pydantic/actions?query=event%3Apush+branch%3Amaster+workflow%3ACI)
 [![pypi](https://img.shields.io/pypi/v/pydantic.svg)](https://pypi.python.org/pypi/pydantic)
 [![CondaForge](https://img.shields.io/conda/v/conda-forge/pydantic.svg)](https://anaconda.org/conda-forge/pydantic)
 [![downloads](https://img.shields.io/pypi/dm/pydantic.svg)](https://pypistats.org/packages/pydantic)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,12 @@ exclude_lines =
     if TYPE_CHECKING:
     @overload
 
+[coverage:paths]
+source =
+    pydantic/
+    /Users/runner/work/pydantic/pydantic/pydantic/
+    D:\a\pydantic\pydantic\pydantic
+
 [isort]
 line_length=120
 known_first_party=pydantic

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ per-file-ignores =
 [coverage:run]
 source = pydantic
 branch = True
+context = ${CONTEXT}
 
 [coverage:report]
 precision = 2


### PR DESCRIPTION
## Change Summary

Switch from my bodged solution for docs preview to use [smokeshow](https://smokeshow.helpmanual.io/)

I also want to use smokeshow instead of codecov, because:
* codecovs bugs and outages are beginning to annoy me
* pydantic has 100%, so any missing coverage on a PR is the fault of that PR - codecov's clever feature for showing coverage changes are not needed

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
