### PR TITLE
Try to evaluate forward refs after model created

### DIFF
--- a/changes/2588-uriyyo.md
+++ b/changes/2588-uriyyo.md
@@ -1,0 +1,1 @@
+Try to evaluate forward refs after model created.

--- a/changes/2588-uriyyo.md
+++ b/changes/2588-uriyyo.md
@@ -1,1 +1,1 @@
-Try to evaluate forward refs after model created.
+Try to evaluate forward refs automatically at model creation.

--- a/docs/examples/postponed_annotations_self_referencing_annotations.py
+++ b/docs/examples/postponed_annotations_self_referencing_annotations.py
@@ -8,7 +8,5 @@ class Foo(BaseModel):
     sibling: Foo = None
 
 
-Foo.update_forward_refs()
-
 print(Foo())
 print(Foo(sibling={'a': '321'}))

--- a/docs/examples/postponed_annotations_self_referencing_string.py
+++ b/docs/examples/postponed_annotations_self_referencing_string.py
@@ -7,7 +7,5 @@ class Foo(BaseModel):
     sibling: 'Foo' = None
 
 
-Foo.update_forward_refs()
-
 print(Foo())
 print(Foo(sibling={'a': '321'}))

--- a/docs/usage/postponed_annotations.md
+++ b/docs/usage/postponed_annotations.md
@@ -45,9 +45,8 @@ Resolving this is beyond the call for *pydantic*: either remove the future impor
 
 ## Self-referencing Models
 
-Data structures with self-referencing models are also supported, provided the function
-`update_forward_refs()` is called once the model is created (you will be reminded
-with a friendly error message if you forget).
+Data structures with self-referencing models are also supported. Self-referencing fields will be automatically
+resolved after was created.
 
 Within the model, you can refer to the not-yet-constructed model using a string:
 

--- a/docs/usage/postponed_annotations.md
+++ b/docs/usage/postponed_annotations.md
@@ -46,7 +46,7 @@ Resolving this is beyond the call for *pydantic*: either remove the future impor
 ## Self-referencing Models
 
 Data structures with self-referencing models are also supported. Self-referencing fields will be automatically
-resolved after was created.
+resolved after model creation.
 
 Within the model, you can refer to the not-yet-constructed model using a string:
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,5 +1,3 @@
-import sys
-import json
 import warnings
 from abc import ABCMeta
 from copy import deepcopy

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -6,6 +6,7 @@ from typing import (  # type: ignore
     ClassVar,
     Dict,
     Generator,
+    Iterable,
     List,
     Mapping,
     NewType,
@@ -222,6 +223,7 @@ __all__ = (
     'new_type_supertype',
     'is_classvar',
     'update_field_forward_refs',
+    'update_model_forward_refs',
     'TupleGenerator',
     'DictStrAny',
     'DictAny',
@@ -384,6 +386,29 @@ def update_field_forward_refs(field: 'ModelField', globalns: Any, localns: Any) 
     if field.sub_fields:
         for sub_f in field.sub_fields:
             update_field_forward_refs(sub_f, globalns=globalns, localns=localns)
+
+
+def update_model_forward_refs(
+    model: Type[Any],
+    fields: Iterable['ModelField'],
+    localns: 'DictStrAny',
+    exc_to_suppress: Tuple[Type[BaseException], ...] = (),
+) -> None:
+    """
+    Try to update model fields ForwardRefs based on model and localns.
+    """
+    if model.__module__ in sys.modules:
+        globalns = sys.modules[model.__module__].__dict__.copy()
+    else:
+        globalns = {}
+
+    globalns.setdefault(model.__name__, model)
+
+    for f in fields:
+        try:
+            update_field_forward_refs(f, globalns=globalns, localns=localns)
+        except exc_to_suppress:
+            pass
 
 
 def get_class(type_: Type[Any]) -> Union[None, bool, Type[Any]]:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -41,6 +41,57 @@ class Model(BaseModel):
     assert module.Model().dict() == {'a': None}
 
 
+@skip_pre_37
+def test_postponed_annotations_auto_update_forward_refs(create_module):
+    module = create_module(
+        # language=Python
+        """
+from __future__ import annotations
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    a: Model
+"""
+    )
+
+    assert module.Model.__fields__['a'].type_ is module.Model
+
+
+def test_forward_ref_auto_update_no_model(create_module):
+    module = create_module(
+        # language=Python
+        """
+from pydantic import BaseModel
+
+class Foo(BaseModel):
+    a: 'Bar'
+
+class Bar(BaseModel):
+    b: 'Foo'
+"""
+    )
+
+    from pydantic.typing import ForwardRef
+
+    assert module.Foo.__fields__['a'].type_ == ForwardRef('Bar')
+    assert module.Bar.__fields__['b'].type_ is module.Foo
+
+
+def test_forward_ref_one_of_fields_not_defined(create_module):
+    @create_module
+    def module():
+        from pydantic import BaseModel
+
+        class Foo(BaseModel):
+            foo: 'Foo'
+            bar: 'Bar'  # noqa: F821
+
+    from pydantic.typing import ForwardRef
+
+    assert module.Foo.__fields__['bar'].type_ == ForwardRef('Bar')
+    assert module.Foo.__fields__['foo'].type_ is module.Foo
+
+
 def test_basic_forward_ref(create_module):
     @create_module
     def module():
@@ -509,13 +560,5 @@ def test_nested_forward_ref():
     class NestedTuple(BaseModel):
         x: Tuple[int, Optional['NestedTuple']]  # noqa: F821
 
-    with pytest.raises(ConfigError) as exc_info:
-        NestedTuple.parse_obj({'x': ('1', {'x': ('2', {'x': ('3', None)})})})
-    assert str(exc_info.value) == (
-        'field "x_1" not yet prepared so type is still a ForwardRef, '
-        'you might need to call NestedTuple.update_forward_refs().'
-    )
-
-    NestedTuple.update_forward_refs()
     obj = NestedTuple.parse_obj({'x': ('1', {'x': ('2', {'x': ('3', None)})})})
     assert obj.dict() == {'x': (1, {'x': (2, {'x': (3, None)})})}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Try to evaluate forward refs after model created.
<!-- Please give a short summary of the changes. -->

So it will not be required to use `update_forward_refs` in the case of self-referencing model:
```python
from __future__ import annotations

from pydantic import BaseModel
from typing import Optional


class Foo(BaseModel):
    foo: Optional[Foo]


assert Foo.__fields__['foo'].type_ is Foo
```

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
