### PR TITLE
feat: support generic types and | operator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         CONTEXT: linux-py${{ matrix.python-version }}-compiled-yes-deps-yes
 
     - name: uninstall deps
-      run: pip uninstall -y cython email-validator devtools python-dotenv
+      run: pip uninstall -y cython email-validator devtools python-dotenv future-typing
 
     - name: test compiled without deps
       run: make test

--- a/changes/2609-PrettyWood.md
+++ b/changes/2609-PrettyWood.md
@@ -1,0 +1,1 @@
+make _pydantic_ [compatible with new annotation syntax](https://pydantic-docs.helpmanual.io/usage/postponed_annotations/#using-new-annotation-syntax-in-your-model)

--- a/docs/examples/postponed_annotations_new_syntax.py
+++ b/docs/examples/postponed_annotations_new_syntax.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Foo(BaseModel):
+    values: list[int | str]
+    optional: str | None = None
+
+Foo(values=[1, "qwe"])

--- a/docs/examples/postponed_annotations_new_syntax.py
+++ b/docs/examples/postponed_annotations_new_syntax.py
@@ -7,4 +7,5 @@ class Foo(BaseModel):
     values: list[int | str]
     optional: str | None = None
 
-Foo(values=[1, "qwe"])
+
+Foo(values=[1, 'qwe'])

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,19 +29,23 @@ import pydantic
 print('compiled:', pydantic.compiled)
 ```
 
-*pydantic* has two optional dependencies:
+*pydantic* has three optional dependencies:
 
 * If you require email validation you can add [email-validator](https://github.com/JoshData/python-email-validator)
 * [dotenv file support](usage/settings.md#dotenv-env-support) with `Settings` requires
   [python-dotenv](https://pypi.org/project/python-dotenv)
+* If you want to use new annotation syntax from `__future__.annotations` in your models,
+  you can add [future-typing](https://pypi.org/project/future-typing)
 
 To install these along with *pydantic*:
 ```bash
 pip install pydantic[email]
 # or
 pip install pydantic[dotenv]
+# or
+pip install pydantic[future-annotations]
 # or just
-pip install pydantic[email,dotenv]
+pip install pydantic[email,dotenv,future-annotations]
 ```
 
 Of course, you can also install these requirements manually with `pip install email-validator` and/or `pip install`.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ mkdocs-material==7.1.4
 sqlalchemy
 orjson
 ujson
+future-typing==0.4.1

--- a/docs/usage/postponed_annotations.md
+++ b/docs/usage/postponed_annotations.md
@@ -64,3 +64,19 @@ and *pydantic* versions).
 {!.tmp_examples/postponed_annotations_self_referencing_annotations.py!}
 ```
 _(This script is complete, it should run "as is")_
+
+## Using new annotation syntax in your model
+
+New annotation syntax like `list[int | str]` may be valid prior to python 3.10 for static type checkers
+but _pydantic_ needs to actually `eval`uate them, which is by default impossible!
+Nevertheless, if you still want to use them, you can install `future-typing`, which will be used by
+_pydantic_ to modify the annotations before evaluating them
+
+```py
+{!.tmp_examples/postponed_annotations_new_syntax.py!}
+```
+_(This script is complete, it should run "as is")_
+
+!!! warning
+    **`future-typing` is still in beta!** If you find a bug, please open an issue
+    [in the dedicated repository](https://github.com/PrettyWood/future-typing/issues).

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -288,7 +288,7 @@ def resolve_annotations(raw_annotations: Dict[str, Type[Any]], module_name: Opti
         except NameError:
             # this is ok, it can be fixed with update_forward_refs
             pass
-        except TypeError:
+        except TypeError as te:
             if value.__class__ is not ForwardRef:
                 raise
 
@@ -304,7 +304,7 @@ def resolve_annotations(raw_annotations: Dict[str, Type[Any]], module_name: Opti
                     'you need to install `future-typing`',
                     UserWarning,
                 )
-                raise
+                raise te
             else:
                 import typing
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -289,7 +289,7 @@ def resolve_annotations(raw_annotations: Dict[str, Type[Any]], module_name: Opti
             # this is ok, it can be fixed with update_forward_refs
             pass
         except TypeError as te:
-            if value.__class__ is not ForwardRef:
+            if value.__class__ is not ForwardRef:  # pragma: no cover
                 raise
 
             # In case of `ForwardRef`, we give it another shot if we want to leverage "new" annotations

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -301,7 +301,7 @@ def resolve_annotations(raw_annotations: Dict[str, Type[Any]], module_name: Opti
 
                 warnings.warn(
                     'If you try to use generic builtins or new `|` Union operator, '
-                    'you need to install `future-typing`',
+                    'you need to install `pydantic[future-annotations]` or directly `future-typing`.',
                     UserWarning,
                 )
                 raise te

--- a/pydantic/typing_merge.py
+++ b/pydantic/typing_merge.py
@@ -1,3 +1,4 @@
+# type: ignore
 # flake8: noqa
 from typing import *
 

--- a/pydantic/typing_merge.py
+++ b/pydantic/typing_merge.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+from typing import *
+
+from typing_extensions import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 Cython==0.29.23;sys_platform!='win32'
 devtools==0.6.1
 email-validator==1.1.2
-future-typing==0.4.0
+future-typing==0.4.1
 dataclasses==0.6; python_version < '3.7'
 typing-extensions==3.7.4.3
 python-dotenv==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 Cython==0.29.23;sys_platform!='win32'
 devtools==0.6.1
 email-validator==1.1.2
+future-typing==0.4.0
 dataclasses==0.6; python_version < '3.7'
 typing-extensions==3.7.4.3
 python-dotenv==0.17.1

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     extras_require={
         'email': ['email-validator>=1.0.3'],
         'dotenv': ['python-dotenv>=0.10.4'],
-        'future': ['future-typing>=0.4.0'],
+        'future-typing': ['future-typing>=0.4.1'],
     },
     ext_modules=ext_modules,
     entry_points={'hypothesis': ['_ = pydantic._hypothesis_plugin']},

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
     extras_require={
         'email': ['email-validator>=1.0.3'],
         'dotenv': ['python-dotenv>=0.10.4'],
+        'future': ['future-typing>=0.4.0'],
     },
     ext_modules=ext_modules,
     entry_points={'hypothesis': ['_ = pydantic._hypothesis_plugin']},

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     extras_require={
         'email': ['email-validator>=1.0.3'],
         'dotenv': ['python-dotenv>=0.10.4'],
-        'future-typing': ['future-typing>=0.4.1'],
+        'future-annotations': ['future-typing>=0.4.1'],
     },
     ext_modules=ext_modules,
     entry_points={'hypothesis': ['_ = pydantic._hypothesis_plugin']},

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -7,3 +7,4 @@ mypy==0.812
 pycodestyle==2.7.0
 pyflakes==2.3.1
 twine==3.4.1
+future-typing==0.4.1

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -534,6 +534,8 @@ def test_forward_ref_future_typing(create_module):
         """
 from __future__ import annotations
 
+from typing_extensions import Literal
+
 from pydantic import BaseModel, Field
 
 class User(BaseModel, validate_assignment=True):
@@ -541,8 +543,9 @@ class User(BaseModel, validate_assignment=True):
     last_name: str | None = None
     friends: list[User] = Field(default_factory=list)
     metadata: dict[str, int] | None = None
+    number: Literal[42] = 42
 
-user = User(first_name='pika', last_name=666)
+user = User(first_name='pika', last_name=666, number=42)
 """
     )
     assert m.user.last_name == '666'
@@ -551,6 +554,8 @@ user = User(first_name='pika', last_name=666)
     assert m.user.metadata == {'1': 1}
     with pytest.raises(ValidationError):
         m.user.last_name = ['chu']
+    with pytest.raises(ValidationError):
+        m.user.number = 43
 
 
 @pytest.mark.skipif(future_typing is not None, reason='`future_typing` is installed')

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -562,7 +562,7 @@ user = User(first_name='pika', last_name=666, number=42)
 @skip_pre_37
 def test_forward_ref_no_future_typing(create_module):
     with pytest.raises(TypeError, match="unsupported operand type(s) for |: 'type' and 'type'"):
-        with pytest.warns(UserWarning, match='you need to install `future-typing`'):
+        with pytest.warns(UserWarning, match='you need to install `pydantic[future-annotations]`'):
             create_module(
                 # language=Python
                 """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Now this is possible with python 3.7+
```py
from __future__ import annotations

from pydantic import BaseModel, Field

class User(BaseModel, validate_assignment=True):
    first_name: int | str
    last_name: str | None = None
    friends: list[User] = Field(default_factory=list)
    metadata: dict[str, int] | None = None

user = User(first_name='pika', last_name=666)

assert user.last_name == '666'
assert user.friends == []
user.metadata = {b'1': b'1'}
assert m.user.metadata == {'1': 1}
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
