### PR TITLE
Documentation: Put examples for config to the start of the section

### DIFF
--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -1,5 +1,22 @@
 Behaviour of _pydantic_ can be controlled via the `Config` class on a model or a _pydantic_ dataclass.
 
+```py
+{!.tmp_examples/model_config_main.py!}
+```
+_(This script is complete, it should run "as is")_
+
+Also, you can specify config options as model class kwargs:
+```py
+{!.tmp_examples/model_config_class_kwargs.py!}
+```
+_(This script is complete, it should run "as is")_
+
+Similarly, if using the `@dataclass` decorator:
+```py
+{!.tmp_examples/model_config_dataclass.py!}
+```
+_(This script is complete, it should run "as is")_
+
 Options:
 
 **`title`**
@@ -91,24 +108,6 @@ not be included in the model schemas. **Note**: this means that attributes on th
 
 **`json_encoders`**
 : a `dict` used to customise the way types are encoded to JSON; see [JSON Serialisation](exporting_models.md#modeljson)
-
-```py
-{!.tmp_examples/model_config_main.py!}
-```
-_(This script is complete, it should run "as is")_
-
-Also, you can specify config options as model class kwargs:
-```py
-{!.tmp_examples/model_config_class_kwargs.py!}
-```
-_(This script is complete, it should run "as is")_
-
-Similarly, if using the `@dataclass` decorator:
-```py
-{!.tmp_examples/model_config_dataclass.py!}
-```
-_(This script is complete, it should run "as is")_
-
 
 **`underscore_attrs_are_private`**
 : whether to treat any underscore non-class var attrs as private, or leave them as is; See [Private model attributes](models.md#private-model-attributes)

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -91,7 +91,7 @@ _(This script is complete, it should run "as is")_
   for use with `orm_mode`
 
 **`alias_generator`**
-: a callable that takes a field name and returns an alias for it
+: a callable that takes a field name and returns an alias for it (see [the dedicated section](#alias-generator))
 
 **`keep_untouched`**
 : a tuple of types (e.g. descriptors) for a model's default values that should not be changed during model creation and will

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -17,7 +17,7 @@ Similarly, if using the `@dataclass` decorator:
 ```
 _(This script is complete, it should run "as is")_
 
-Options:
+## Options
 
 **`title`**
 : the title for the generated JSON Schema


### PR DESCRIPTION
I think this is where they belong, they were in the middle of the list of config options somewhere near the end.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
