### PR TITLE
Revert "trying to fix fastapi tests (#2584)"

### DIFF
--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -8,10 +8,6 @@ git fetch --tags
 latest_tag_commit=$(git rev-list --tags --max-count=1)
 latest_tag=$(git describe --tags "${latest_tag_commit}")
 git checkout "${latest_tag}"
-
-# FIXME this is a temporary workaround while fastapi tests are broken with newer sqlalchemy
-pip install SQLAlchemy==1.3.23
-
 pip install -U flit
 flit install
 


### PR DESCRIPTION
This reverts commit 7b7e70557bb80ef5f033e3e9caca68484aae78c5.

The issue has been fixed upstream https://github.com/encode/databases/releases/tag/0.4.3

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
