### PR TITLE
fix: stop calling parent class `root_validator` if overridden

### DIFF
--- a/changes/1895-PrettyWood.md
+++ b/changes/1895-PrettyWood.md
@@ -1,0 +1,1 @@
+stop calling parent class `root_validator` if overridden

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -362,11 +362,11 @@ class ModelMetaclass(ABCMeta):
             '__validators__': vg.validators,
             '__pre_root_validators__': unique_list(
                 pre_root_validators + pre_rv_new,
-                get_name=lambda v: v.__name__,
+                name_factory=lambda v: v.__name__,
             ),
             '__post_root_validators__': unique_list(
                 post_root_validators + post_rv_new,
-                get_name=lambda skip_on_failure_and_v: skip_on_failure_and_v[1].__name__,
+                name_factory=lambda skip_on_failure_and_v: skip_on_failure_and_v[1].__name__,
             ),
             '__schema_cache__': {},
             '__json_encoder__': staticmethod(json_encoder),

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -346,8 +346,14 @@ class ModelMetaclass(ABCMeta):
             '__config__': config,
             '__fields__': fields,
             '__validators__': vg.validators,
-            '__pre_root_validators__': unique_list(pre_root_validators + pre_rv_new),
-            '__post_root_validators__': unique_list(post_root_validators + post_rv_new),
+            '__pre_root_validators__': unique_list(
+                pre_root_validators + pre_rv_new,
+                get_name=lambda v: v.__name__,
+            ),
+            '__post_root_validators__': unique_list(
+                post_root_validators + post_rv_new,
+                get_name=lambda skip_on_failure_and_v: skip_on_failure_and_v[1].__name__,
+            ),
             '__schema_cache__': {},
             '__json_encoder__': staticmethod(json_encoder),
             '__custom_root_type__': _custom_root_type,

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -279,7 +279,7 @@ T = TypeVar('T')
 def unique_list(
     input_list: Union[List[T], Tuple[T, ...]],
     *,
-    get_name: Callable[..., str] = lambda x: str(x),
+    name_factory: Callable[[T], str] = str,
 ) -> List[T]:
     """
     Make a list unique while maintaining order.
@@ -289,7 +289,7 @@ def unique_list(
     result: List[T] = []
     result_names: List[str] = []
     for v in input_list:
-        v_name = get_name(v)
+        v_name = name_factory(v)
         if v_name not in result_names:
             result_names.append(v_name)
             result.append(v)

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -277,16 +277,25 @@ def to_camel(string: str) -> str:
 T = TypeVar('T')
 
 
-def unique_list(input_list: Union[List[T], Tuple[T, ...]]) -> List[T]:
+def unique_list(
+    input_list: Union[List[T], Tuple[T, ...]],
+    *,
+    get_name: Callable[..., str] = lambda x: str(x),
+) -> List[T]:
     """
     Make a list unique while maintaining order.
+    We update the list if another one with the same name is set
+    (e.g. root validator overridden in subclass)
     """
-    result = []
-    unique_set = set()
+    result: List[T] = []
+    result_names: List[str] = []
     for v in input_list:
-        if v not in unique_set:
-            unique_set.add(v)
+        v_name = get_name(v)
+        if v_name not in result_names:
+            result_names.append(v_name)
             result.append(v)
+        else:
+            result[result_names.index(v_name)] = v
 
     return result
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1256,3 +1256,39 @@ def test_exceptions_in_field_validators_restore_original_field_value():
     with pytest.raises(RuntimeError, match='test error'):
         model.foo = 'raise_exception'
     assert model.foo == 'foo'
+
+
+def test_overridden_root_validators(mocker):
+    validate_stub = mocker.stub(name='validate')
+
+    class A(BaseModel):
+        x: str
+
+        @root_validator(pre=True)
+        def pre_root(cls, values):
+            validate_stub('A', 'pre')
+            return values
+
+        @root_validator(pre=False)
+        def post_root(cls, values):
+            validate_stub('A', 'post')
+            return values
+
+    class B(A):
+        @root_validator(pre=True)
+        def pre_root(cls, values):
+            validate_stub('B', 'pre')
+            return values
+
+        @root_validator(pre=False)
+        def post_root(cls, values):
+            validate_stub('B', 'post')
+            return values
+
+    A(x='pika')
+    assert validate_stub.call_args_list == [mocker.call('A', 'pre'), mocker.call('A', 'post')]
+
+    validate_stub.reset_mock()
+
+    B(x='pika')
+    assert validate_stub.call_args_list == [mocker.call('B', 'pre'), mocker.call('B', 'post')]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
We would keep all the root validators even those that were supposed to be overridden.
Now they actually are

<!-- Please give a short summary of the changes. -->

## Related issue number
fix #1895
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
