### PR TITLE
fix(schema): namedtuple field with default value

### DIFF
--- a/changes/2707-PrettyWood.md
+++ b/changes/2707-PrettyWood.md
@@ -1,0 +1,1 @@
+fix JSON schema generation when a field is of type `NamedTuple` and has a default value

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -889,7 +889,8 @@ def encode_default(dft: Any) -> Any:
         return dft
     elif sequence_like(dft):
         t = dft.__class__
-        return t(encode_default(v) for v in dft)
+        seq_args = (encode_default(v) for v in dft)
+        return t(*seq_args) if is_namedtuple(t) else t(seq_args)
     elif isinstance(dft, dict):
         return {encode_default(k): encode_default(v) for k, v in dft.items()}
     elif dft is None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -15,6 +15,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    NamedTuple,
     NewType,
     Optional,
     Set,
@@ -2271,4 +2272,26 @@ def test_schema_for_generic_field():
             'data1': {'title': 'Data1', 'anyOf': [{'type': 'string'}, {'type': 'array', 'items': {'type': 'string'}}]},
         },
         'required': ['data', 'data1'],
+    }
+
+
+def test_namedtuple_default():
+    class Coordinates(NamedTuple):
+        x: float
+        y: float
+
+    class LocationBase(BaseModel):
+        coords: Coordinates = Coordinates(0, 0)
+
+    assert LocationBase.schema() == {
+        'title': 'LocationBase',
+        'type': 'object',
+        'properties': {
+            'coords': {
+                'title': 'Coords',
+                'default': Coordinates(x=0, y=0),
+                'type': 'array',
+                'items': [{'title': 'X', 'type': 'number'}, {'title': 'Y', 'type': 'number'}],
+            }
+        },
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
fix JSON schema generation when a field is of type `NamedTuple` and has a default value

## Related issue number
closes #2707 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
