### PR TITLE
Fix recursive ORM parsing error

### DIFF
--- a/changes/2718-nuno-andre.md
+++ b/changes/2718-nuno-andre.md
@@ -1,0 +1,1 @@
+Change `orm_mode` checking to allow recursive ORM mode parsing with dicts.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -725,10 +725,11 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             return value.copy() if cls.__config__.copy_on_model_validation else value
 
         value = cls._enforce_dict_if_root(value)
-        if isinstance(value, dict):
-            return cls(**value)
-        elif cls.__config__.orm_mode:
+
+        if cls.__config__.orm_mode:
             return cls.from_orm(value)
+        elif isinstance(value, dict):
+            return cls(**value)
         else:
             try:
                 value_as_dict = dict(value)


### PR DESCRIPTION
The _ORM mode_ doesn't parse dictionaries if it's not explicitly called.

## Change Summary

Prepend the `orm_mode` checking to the `dict`'s.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)

## Example

```python
from pydantic import BaseModel
from pydantic.utils import GetterDict

class Getter(GetterDict):
    # not relevant, just to show the behavior
    def get(self, key, default):
        key = key + key
        try:
            return self._obj[key]
        except TypeError:
            return getattr(self._obj, key, default)
        except KeyError:
            return default

class Model(BaseModel):
    class Config:
        orm_mode = True
        getter_dict = Getter

class ModelA(Model):
    a: int

class ModelB(Model):
    b: ModelA
```

```python
from types import SimpleNamespace

x = dict(bb=SimpleNamespace(aa=1))
ModelB.from_orm(x)
#> b=ModelA(a=1)

y = dict(bb=dict(aa=1))
ModelB.from_orm(y)
#> ...
#> b -> a
#>   field required (type=value_error.missing)
```