### PR TITLE
fix: add missing BaseConfig type annotations and handle `max_length = 0`

### DIFF
--- a/changes/2719-PrettyWood.md
+++ b/changes/2719-PrettyWood.md
@@ -1,0 +1,1 @@
+add missing type annotations in `BaseConfig` and handle `max_length = 0`

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -32,7 +32,7 @@ _(This script is complete, it should run "as is")_
 : the min length for str & byte types (default: `0`)
 
 **`max_anystr_length`**
-: the max length for str & byte types (default: `2 ** 16`)
+: the max length for str & byte types (default: `None`)
 
 **`validate_all`**
 : whether to validate field defaults (default: `False`)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -112,21 +112,21 @@ class Extra(str, Enum):
 
 
 class BaseConfig:
-    title = None
-    anystr_lower = False
-    anystr_strip_whitespace = False
-    min_anystr_length = None
-    max_anystr_length = None
-    validate_all = False
-    extra = Extra.ignore
-    allow_mutation = True
-    frozen = False
-    allow_population_by_field_name = False
-    use_enum_values = False
+    title: Optional[str] = None
+    anystr_lower: bool = False
+    anystr_strip_whitespace: bool = False
+    min_anystr_length: int = 0
+    max_anystr_length: Optional[int] = None
+    validate_all: bool = False
+    extra: Extra = Extra.ignore
+    allow_mutation: bool = True
+    frozen: bool = False
+    allow_population_by_field_name: bool = False
+    use_enum_values: bool = False
     fields: Dict[str, Union[str, Dict[str, str]]] = {}
-    validate_assignment = False
+    validate_assignment: bool = False
     error_msg_templates: Dict[str, str] = {}
-    arbitrary_types_allowed = False
+    arbitrary_types_allowed: bool = False
     orm_mode: bool = False
     getter_dict: Type[GetterDict] = GetterDict
     alias_generator: Optional[Callable[[str], str]] = None

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -192,7 +192,7 @@ def anystr_length_validator(v: 'StrBytes', config: 'BaseConfig') -> 'StrBytes':
     v_len = len(v)
 
     min_length = config.min_anystr_length
-    if min_length is not None and v_len < min_length:
+    if v_len < min_length:
         raise errors.AnyStrMinLengthError(limit_value=min_length)
 
     max_length = config.max_anystr_length
@@ -469,11 +469,11 @@ def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
 def constr_length_validator(v: 'StrBytes', field: 'ModelField', config: 'BaseConfig') -> 'StrBytes':
     v_len = len(v)
 
-    min_length = field.type_.min_length or config.min_anystr_length
-    if min_length is not None and v_len < min_length:
+    min_length = field.type_.min_length if field.type_.min_length is not None else config.min_anystr_length
+    if v_len < min_length:
         raise errors.AnyStrMinLengthError(limit_value=min_length)
 
-    max_length = field.type_.max_length or config.max_anystr_length
+    max_length = field.type_.max_length if field.type_.max_length is not None else config.max_anystr_length
     if max_length is not None and v_len > max_length:
         raise errors.AnyStrMaxLengthError(limit_value=max_length)
 

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -12,8 +12,10 @@ from uuid import UUID
 
 from pydantic import (
     UUID1,
+    BaseConfig,
     BaseModel,
     DirectoryPath,
+    Extra,
     FilePath,
     Json,
     NegativeFloat,
@@ -234,3 +236,9 @@ validated.my_file_path.absolute()
 validated.my_file_path_str.absolute()
 validated.my_dir_path.absolute()
 validated.my_dir_path_str.absolute()
+
+
+class Config(BaseConfig):
+    title = 'Record'
+    extra = Extra.ignore
+    max_anystr_length = 1234

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -531,6 +531,24 @@ def test_constrained_str_lower_disabled():
     assert m.v == 'ABCD'
 
 
+def test_constrained_str_max_length_0():
+    class Model(BaseModel):
+        v: constr(max_length=0)
+
+    m = Model(v='')
+    assert m.v == ''
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v='qwe')
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('v',),
+            'msg': 'ensure this value has at most 0 characters',
+            'type': 'value_error.any_str.max_length',
+            'ctx': {'limit_value': 0},
+        }
+    ]
+
+
 def test_module_import():
     class PyObjectModel(BaseModel):
         module: PyObject = 'os.path'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
closes #2719
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
