### PR TITLE
Eliminate redundant variable with direct returns in the if statement

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -920,14 +920,13 @@ class PaymentCardNumber(str):
     @staticmethod
     def _get_brand(card_number: str) -> PaymentCardBrand:
         if card_number[0] == '4':
-            brand = PaymentCardBrand.visa
+            return PaymentCardBrand.visa
         elif 51 <= int(card_number[:2]) <= 55:
-            brand = PaymentCardBrand.mastercard
+            return PaymentCardBrand.mastercard
         elif card_number[:2] in {'34', '37'}:
-            brand = PaymentCardBrand.amex
+            return PaymentCardBrand.amex
         else:
-            brand = PaymentCardBrand.other
-        return brand
+            return PaymentCardBrand.other
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BYTE SIZE TYPE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As we have else clause to handle the last case, it is easy to return inside the `if/elif` pairs rather than to assign the value to the `brand` variable.