### PR TITLE
Renamed schema variable name to schema_ as there is a schema function defined

### DIFF
--- a/changes/2724-shahriyarr.md
+++ b/changes/2724-shahriyarr.md
@@ -1,0 +1,2 @@
+Spotted an anti-pattern which can lead to shadowing in the outer scope, as there is a function named schema.
+Renamed all schema variables to schema_

--- a/changes/2724-shahriyarr.md
+++ b/changes/2724-shahriyarr.md
@@ -1,2 +1,1 @@
-Spotted an anti-pattern which can lead to shadowing in the outer scope, as there is a function named schema.
-Renamed all schema variables to schema_
+Renamed variable `schema` to `schema_` to avoid shadowing of global variable name.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -182,15 +182,15 @@ def get_field_info_schema(field: ModelField) -> Tuple[Dict[str, Any], bool]:
     # If no title is explicitly set, we don't set title in the schema for enums.
     # The behaviour is the same as `BaseModel` reference, where the default title
     # is in the definitions part of the schema.
-    schema: Dict[str, Any] = {}
+    schema_: Dict[str, Any] = {}
     if field.field_info.title or not lenient_issubclass(field.type_, Enum):
-        schema['title'] = field.field_info.title or field.alias.title().replace('_', ' ')
+        schema_['title'] = field.field_info.title or field.alias.title().replace('_', ' ')
 
     if field.field_info.title:
         schema_overrides = True
 
     if field.field_info.description:
-        schema['description'] = field.field_info.description
+        schema_['description'] = field.field_info.description
         schema_overrides = True
 
     if (
@@ -199,10 +199,10 @@ def get_field_info_schema(field: ModelField) -> Tuple[Dict[str, Any], bool]:
         and field.default is not None
         and not is_callable_type(field.outer_type_)
     ):
-        schema['default'] = encode_default(field.default)
+        schema_['default'] = encode_default(field.default)
         schema_overrides = True
 
-    return schema, schema_overrides
+    return schema_, schema_overrides
 
 
 def field_schema(

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -737,7 +737,7 @@ field_class_to_schema: Tuple[Tuple[Any, Dict[str, Any]], ...] = (
 json_scheme = {'type': 'string', 'format': 'json-string'}
 
 
-def add_field_type_to_schema(field_type: Any, schema: Dict[str, Any]) -> None:
+def add_field_type_to_schema(field_type: Any, schema_: Dict[str, Any]) -> None:
     """
     Update the given `schema` with the type-specific metadata for the given `field_type`.
 
@@ -747,7 +747,7 @@ def add_field_type_to_schema(field_type: Any, schema: Dict[str, Any]) -> None:
     for type_, t_schema in field_class_to_schema:
         # Fallback for `typing.Pattern` as it is not a valid class
         if lenient_issubclass(field_type, type_) or field_type is type_ is Pattern:
-            schema.update(t_schema)
+            schema_.update(t_schema)
             break
 
 
@@ -998,8 +998,8 @@ def get_annotation_with_constraints(annotation: Any, field_info: FieldInfo) -> T
             if issubclass(type_, (SecretStr, SecretBytes)):
                 attrs = ('max_length', 'min_length')
 
-                def constraint_func(**kwargs: Any) -> Type[Any]:
-                    return type(type_.__name__, (type_,), kwargs)
+                def constraint_func(**kw: Any) -> Type[Any]:
+                    return type(type_.__name__, (type_,), kw)
 
             elif issubclass(type_, str) and not issubclass(type_, (EmailStr, AnyUrl, ConstrainedStr)):
                 attrs = ('max_length', 'min_length', 'regex')

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -627,7 +627,7 @@ def enum_process_schema(enum: Type[Enum]) -> Dict[str, Any]:
     """
     from inspect import getdoc
 
-    schema: Dict[str, Any] = {
+    schema_: Dict[str, Any] = {
         'title': enum.__name__,
         # Python assigns all enums a default docstring value of 'An enumeration', so
         # all enums will have a description field even if not explicitly provided.
@@ -636,13 +636,13 @@ def enum_process_schema(enum: Type[Enum]) -> Dict[str, Any]:
         'enum': [item.value for item in cast(Iterable[Enum], enum)],
     }
 
-    add_field_type_to_schema(enum, schema)
+    add_field_type_to_schema(enum, schema_)
 
     modify_schema = getattr(enum, '__modify_schema__', None)
     if modify_schema:
-        modify_schema(schema)
+        modify_schema(schema_)
 
-    return schema
+    return schema_
 
 
 def field_singleton_sub_fields_schema(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Spotted an anti-pattern which can lead to shadowing in the outer scope, as there is a function named `schema`.
Renamed all `schema`  variables to  `schema_`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
