### PR TITLE
Changed the order of exceptions to first catch more specific

### DIFF
--- a/changes/2726-shahriyarr.md
+++ b/changes/2726-shahriyarr.md
@@ -1,0 +1,1 @@
+Changed the order of exceptions UnicodeDecodeError to be the first one.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -590,7 +590,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 allow_pickle=allow_pickle,
                 json_loads=cls.__config__.json_loads,
             )
-        except (ValueError, TypeError, UnicodeDecodeError) as e:
+        except (UnicodeDecodeError, ValueError, TypeError) as e:
             raise ValidationError([ErrorWrapper(e, loc=ROOT_KEY)], cls)
         return cls.parse_obj(obj)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
As `UnicodeDecodeError` is a type of `UnicodeError` and it is a type of `ValueError`, I think it will never be reached because the broad `ValueError` will be handled first. Changed the order of exceptions `UnicodeDecodeError` to be the first one.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
