### PR TITLE
Eliminated duplicated code portion inside the for loop

### DIFF
--- a/changes/2727-shahriyarr.md
+++ b/changes/2727-shahriyarr.md
@@ -1,0 +1,1 @@
+Changed superclass_fields.append(field) to be called outside of the if/else pair but inside the for loop, it will ensure that it is not duplicated

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -286,11 +286,10 @@ class PydanticModelTransformer:
                 if name not in known_fields:
                     field = PydanticModelField.deserialize(info, data)
                     known_fields.add(name)
-                    superclass_fields.append(field)
                 else:
                     (field,) = [a for a in all_fields if a.name == name]
                     all_fields.remove(field)
-                    superclass_fields.append(field)
+                superclass_fields.append(field)
             all_fields = superclass_fields + all_fields
         return all_fields
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Changed  `superclass_fields.append(field)` to be called outside of the if/else pair but inside the for loop, it will ensure that it is not duplicated.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
