### PR TITLE
Fix(docs): remove colon to separate unrelated clauses

### DIFF
--- a/changes/2733-krisaoe.md
+++ b/changes/2733-krisaoe.md
@@ -1,0 +1,2 @@
+The colon at the end of the line "The fields which were supplied when user was initialised:" suggests that the code following it is related.
+Changed it to a period.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -46,7 +46,7 @@ assert user.name == 'Jane Doe'
 ```py
 assert user.__fields_set__ == {'id'}
 ```
-The fields which were supplied when user was initialised:
+The fields which were supplied when user was initialised.
 ```py
 assert user.dict() == dict(user) == {'id': 123, 'name': 'Jane Doe'}
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

The colon at the end of the line "The fields which were supplied when user was initialised:" suggests that the code following it is related.
Changed it to a period.

## Related issue number

No.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
