### PR TITLE
add label-and-assign github action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,3 +17,4 @@
 * [ ] Documentation reflects the changes where applicable
 * [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
   (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
+* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

--- a/.github/workflows/label-assign.yml
+++ b/.github/workflows/label-assign.yml
@@ -3,8 +3,8 @@ name: Label & Assign
 on:
   issue_comment:
     types: [created, edited]
-  pull_request_review:
-    types: [submitted, edited]
+#  pull_request_review:
+#    types: [submitted, edited]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/label-assign.yml
+++ b/.github/workflows/label-assign.yml
@@ -1,0 +1,23 @@
+name: Label & Assign
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-and-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cat "$GITHUB_EVENT_PATH"
+
+      - uses: docker://samuelcolvin/label-and-assign:v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          reviewers: samuelcolvin,PrettyWood
+          awaiting_update_label: 'awaiting author revision'
+          awaiting_review_label: 'ready for review'


### PR DESCRIPTION
This should making reviewing easier by allowing PR authors to assign reviews (currently me and @PrettyWood) and simplifying the process of us re-assigning the authors after reviews.

@PrettyWood I hope you don't mind me adding you here? It shouldn't make any difference to the number of notifications you get.

## Usage

PR authors can assign reviewers by adding a comment to their PR with the magic string **"please review"**, this will:
* unassign them (if they're assigned) and assign the reviewers
* add the `ready for review` label and remove the `awaiting author revision` label if required

Reviewers can add the magic string **"please update"** which will:
* unassign reviewers and assign the PR author
* add the `awaiting author revision` label and add the `ready for review` label if required
