### PR TITLE
Fix mypy  plugin issue with self field

### DIFF
--- a/changes/2743-uriyyo.md
+++ b/changes/2743-uriyyo.md
@@ -1,0 +1,1 @@
+Fix mypy plugin issue with self field declaration.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -619,7 +619,7 @@ def add_method(
     #     first = []
     else:
         self_type = self_type or fill_typevars(info)
-        first = [Argument(Var('self'), self_type, None, ARG_POS)]
+        first = [Argument(Var('__pydantic_self__'), self_type, None, ARG_POS)]
     args = first + args
     arg_types, arg_names, arg_kinds = [], [], []
     for arg in args:

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -158,3 +158,7 @@ class NotFrozenModel(FrozenModel):
 
 NotFrozenModel(x=1).x = 2
 NotFrozenModel.from_orm(model)
+
+
+class ModelWithSelfField(BaseModel):
+    self: str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Fix mypy plugin issue with `self` field.

Currently mypy plugin will fail at this code:
```py
from pydantic import BaseModel


class Model(BaseModel):
    self: str
```
```
error: Name 'self' already defined (possibly by an import)  [no-redef]
```

<!-- Please give a short summary of the changes. -->

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
