### PR TITLE
Add ability to have custom encoder for builtin types

### DIFF
--- a/changes/2531-uriyyo.md
+++ b/changes/2531-uriyyo.md
@@ -1,0 +1,1 @@
+Add ability to have custom encoder for builtin types.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -29,7 +29,7 @@ from .class_validators import ValidatorGroup, extract_root_validators, extract_v
 from .error_wrappers import ErrorWrapper, ValidationError
 from .errors import ConfigError, DictError, ExtraError, MissingError
 from .fields import MAPPING_LIKE_SHAPES, ModelField, ModelPrivateAttr, PrivateAttr, Undefined
-from .json import custom_pydantic_encoder, pydantic_encoder
+from .json import custom_pydantic_encoder, pydantic_encoder, wrap_builtin_types
 from .parse import Protocol, load_file, load_str_bytes
 from .schema import default_ref_template, model_schema
 from .types import PyObject, StrBytes
@@ -222,6 +222,18 @@ UNTOUCHED_TYPES: Tuple[Any, ...] = (FunctionType,) + ANNOTATED_FIELD_UNTOUCHED_T
 # the `BaseModel` class, since that's defined immediately after the metaclass.
 _is_base_model_class_defined = False
 
+BUILTIN_TYPES: AbstractSet[Type[Any]] = frozenset(
+    (
+        dict,
+        list,
+        tuple,
+        float,
+        bool,
+        int,
+        str,
+    )
+)
+
 
 class ModelMetaclass(ABCMeta):
     @no_type_check  # noqa C901
@@ -334,8 +346,11 @@ class ModelMetaclass(ABCMeta):
         vg.check_for_unused()
         if config.json_encoders:
             json_encoder = partial(custom_pydantic_encoder, config.json_encoders)
+            json_built_in_types = frozenset(t for t in config.json_encoders if t in BUILTIN_TYPES)
         else:
             json_encoder = pydantic_encoder
+            json_built_in_types = frozenset()
+
         pre_rv_new, post_rv_new = extract_root_validators(namespace)
 
         if hash_func is None:
@@ -358,6 +373,7 @@ class ModelMetaclass(ABCMeta):
             '__post_root_validators__': unique_list(post_root_validators + post_rv_new),
             '__schema_cache__': {},
             '__json_encoder__': staticmethod(json_encoder),
+            '__json_builtin_encode_types__': json_built_in_types,
             '__custom_root_type__': _custom_root_type,
             '__private_attributes__': private_attributes,
             '__slots__': slots | private_attributes.keys(),
@@ -387,6 +403,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         __config__: Type[BaseConfig] = BaseConfig
         __root__: Any = None
         __json_encoder__: Callable[[Any], Any] = lambda x: x
+        __json_builtin_encode_types__: AbstractSet[Type[Any]]
         __schema_cache__: 'DictAny' = {}
         __custom_root_type__: bool = False
         __signature__: 'Signature'
@@ -558,6 +575,10 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         )
         if self.__custom_root_type__:
             data = data[ROOT_KEY]
+
+        if encoder is self.__json_encoder__ and self.__json_builtin_encode_types__:
+            data = wrap_builtin_types(data, self.__json_builtin_encode_types__)
+
         return self.__config__.json_dumps(data, default=encoder, **dumps_kwargs)
 
     @classmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Add ability to have custom encoder for builtin types

<!-- Please give a short summary of the changes. -->

## Related issue number
Closes #2531 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
