### PR TITLE
mypy: Add create_model overload

### DIFF
--- a/changes/2748-uriyyo.md
+++ b/changes/2748-uriyyo.md
@@ -1,0 +1,1 @@
+Add function overloading for a `pydantic.create_model` function.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -21,6 +21,7 @@ from typing import (
     Union,
     cast,
     no_type_check,
+    overload,
 )
 
 from .class_validators import ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
@@ -844,33 +845,33 @@ _is_base_model_class_defined = True
 def create_model(
     __model_name: str,
     *,
-    __config__: Type[BaseConfig] = None,
+    __config__: Optional[Type[BaseConfig]] = None,
     __base__: None = None,
     __module__: str = __name__,
     __validators__: Dict[str, classmethod] = None,
     **field_definitions: Any,
 ) -> Type['BaseModel']:
-    pass
+    ...
 
 
 @overload
 def create_model(
     __model_name: str,
     *,
-    __config__: Type[BaseConfig] = None,
-    __base__: Type['Model'] = None,
+    __config__: Optional[Type[BaseConfig]] = None,
+    __base__: Type['Model'],
     __module__: str = __name__,
     __validators__: Dict[str, classmethod] = None,
     **field_definitions: Any,
 ) -> Type['Model']:
-    pass
+    ...
 
 
 def create_model(
     __model_name: str,
     *,
-    __config__: Type[BaseConfig] = None,
-    __base__: Type['Model'] = None,
+    __config__: Optional[Type[BaseConfig]] = None,
+    __base__: Optional[Type['Model']] = None,
     __module__: str = __name__,
     __validators__: Dict[str, classmethod] = None,
     **field_definitions: Any,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -938,6 +938,32 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 _is_base_model_class_defined = True
 
 
+@overload
+def create_model(
+    __model_name: str,
+    *,
+    __config__: Type[BaseConfig] = None,
+    __base__: None = None,
+    __module__: str = __name__,
+    __validators__: Dict[str, classmethod] = None,
+    **field_definitions: Any,
+) -> Type['BaseModel']:
+    pass
+
+
+@overload
+def create_model(
+    __model_name: str,
+    *,
+    __config__: Type[BaseConfig] = None,
+    __base__: Type['Model'] = None,
+    __module__: str = __name__,
+    __validators__: Dict[str, classmethod] = None,
+    **field_definitions: Any,
+) -> Type['Model']:
+    pass
+
+
 def create_model(
     __model_name: str,
     *,

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -31,6 +31,7 @@ from pydantic import (
     StrictFloat,
     StrictInt,
     StrictStr,
+    create_model,
     root_validator,
     validate_arguments,
     validator,
@@ -234,3 +235,5 @@ validated.my_file_path.absolute()
 validated.my_file_path_str.absolute()
 validated.my_dir_path.absolute()
 validated.my_dir_path_str.absolute()
+
+DynamicModel = create_model('DynamicModel')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Add create_model overload

Currently `mypy` will fail on this code:
```python
from pydantic import create_model

Foo = create_model("Foo")
```
```
error: Need type annotation for 'Foo'  [var-annotated]
```

With this PR `mypy` will correctly resolve return value type of `create_model`:
```python
from pydantic import create_model

Foo = create_model("Foo")
reveal_type(Foo)
```
```
note: Revealed type is 'Type[pydantic.main.BaseModel]'
```

And it will still work for a cases when `__base__` is specified:
```python
from pydantic import create_model, BaseModel


class Bar(BaseModel):
    a: int


Foo = create_model("Foo", __base__=Bar)
reveal_type(Foo)
```
```
note: Revealed type is 'Type[temp.Bar*]'
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
