### PR TITLE
Resolve postponed NamedTuple annotations (#2760)

### DIFF
--- a/changes/2760-jameysharp.md
+++ b/changes/2760-jameysharp.md
@@ -1,0 +1,1 @@
+Fix postponed annotation resolution for `NamedTuple` and `TypedDict` when they're used directly as the type of fields within Pydantic models

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -558,7 +558,10 @@ NamedTupleT = TypeVar('NamedTupleT', bound=NamedTuple)
 def make_namedtuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
     from .annotated_types import create_model_from_namedtuple
 
-    NamedTupleModel = create_model_from_namedtuple(namedtuple_cls)
+    NamedTupleModel = create_model_from_namedtuple(
+        namedtuple_cls,
+        __module__=namedtuple_cls.__module__,
+    )
     namedtuple_cls.__pydantic_model__ = NamedTupleModel  # type: ignore[attr-defined]
 
     def namedtuple_validator(values: Tuple[Any, ...]) -> NamedTupleT:
@@ -579,7 +582,11 @@ def make_typeddict_validator(
 ) -> Callable[[Any], Dict[str, Any]]:
     from .annotated_types import create_model_from_typeddict
 
-    TypedDictModel = create_model_from_typeddict(typeddict_cls, __config__=config)
+    TypedDictModel = create_model_from_typeddict(
+        typeddict_cls,
+        __config__=config,
+        __module__=typeddict_cls.__module__,
+    )
     typeddict_cls.__pydantic_model__ = TypedDictModel  # type: ignore[attr-defined]
 
     def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -11,7 +11,7 @@ from typing import List, NamedTuple, Tuple
 import pytest
 from typing_extensions import TypedDict
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, PositiveInt, ValidationError
 
 if sys.version_info < (3, 9):
     try:
@@ -121,6 +121,23 @@ def test_namedtuple_right_length():
             'ctx': {'limit_value': 2},
         }
     ]
+
+
+def test_namedtuple_postponed_annotation():
+    """
+    https://github.com/samuelcolvin/pydantic/issues/2760
+    """
+
+    class Tup(NamedTuple):
+        v: 'PositiveInt'
+
+    class Model(BaseModel):
+        t: Tup
+
+    # The effect of issue #2760 is that this call raises a `ConfigError` even though the type declared on `Tup.v`
+    # references a binding in this module's global scope.
+    with pytest.raises(ValidationError):
+        Model.parse_obj({'t': [-1]})
 
 
 def test_typeddict():
@@ -253,3 +270,14 @@ def test_typeddict_schema():
             },
         },
     }
+
+
+def test_typeddict_postponed_annotation():
+    class DataTD(TypedDict):
+        v: 'PositiveInt'
+
+    class Model(BaseModel):
+        t: DataTD
+
+    with pytest.raises(ValidationError):
+        Model.parse_obj({'t': {'v': -1}})


### PR DESCRIPTION
Thanks to @PrettyWood for pointing me to the right place to fix this!

Since I was told that both NamedTuple and TypedDict use the same
__pydantic_model__ machinery that dataclasses do, I checked and found
that TypedDict had the same bug, and fixed that too.

Tests for both issues are included, which fail without the associated
fixes being applied.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Follow the example of dataclasses' call to `create_model` to set up `__module__` correctly when implicitly calling `create_model_from_(namedtuple|typeddict)`.

## Related issue number

fix #2760 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
