### PR TITLE
Fix bug when mypy plugin fail on construct method call

### DIFF
--- a/changes/2753-uriyyo.md
+++ b/changes/2753-uriyyo.md
@@ -1,1 +1,1 @@
-Fix bug when `mypy` plugin fail on `construct` method call for `BaseSettings` derived classes.
+Fix bug when `mypy` plugin fails on `construct` method call for `BaseSettings` derived classes.

--- a/changes/2753-uriyyo.md
+++ b/changes/2753-uriyyo.md
@@ -1,0 +1,1 @@
+Fix bug when `mypy` plugin fail on `construct` method call for `BaseSettings` derived classes.

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from pathlib import Path
-from typing import AbstractSet, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple, Union
+from typing import AbstractSet, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 from .config import BaseConfig, Extra
 from .fields import ModelField
@@ -114,7 +114,7 @@ class BaseSettings(BaseModel):
         ) -> Tuple[SettingsSourceCallable, ...]:
             return init_settings, env_settings, file_secret_settings
 
-    __config__: ClassVar[Config]  # type: ignore
+    __config__: ClassVar[Type[Config]]  # type: ignore
 
 
 class InitSettingsSource:

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from pathlib import Path
-from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
+from typing import AbstractSet, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple, Union
 
 from .fields import ModelField
 from .main import BaseConfig, BaseModel, Extra
@@ -113,7 +113,7 @@ class BaseSettings(BaseModel):
         ) -> Tuple[SettingsSourceCallable, ...]:
             return init_settings, env_settings, file_secret_settings
 
-    __config__: Config  # type: ignore
+    __config__: ClassVar[Config]  # type: ignore
 
 
 class InitSettingsSource:

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -170,7 +170,7 @@ class EnvSettingsSource:
 
             if field.is_complex():
                 try:
-                    env_val = settings.__config__.json_loads(env_val)  # type: ignore
+                    env_val = settings.__config__.json_loads(env_val)
                 except ValueError as e:
                     raise SettingsError(f'error parsing JSON for "{env_name}"') from e
             elif (
@@ -179,7 +179,7 @@ class EnvSettingsSource:
                 and any(f.is_complex() for f in field.sub_fields)
             ):
                 try:
-                    env_val = settings.__config__.json_loads(env_val)  # type: ignore
+                    env_val = settings.__config__.json_loads(env_val)
                 except ValueError:
                     pass
             d[field.alias] = env_val

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,6 +1,6 @@
 from typing import ClassVar, Optional, Union
 
-from pydantic import BaseModel, Field, create_model, BaseSettings
+from pydantic import BaseModel, BaseSettings, Field, create_model
 from pydantic.dataclasses import dataclass
 
 

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,6 +1,6 @@
 from typing import ClassVar, Optional, Union
 
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, Field, create_model, BaseSettings
 from pydantic.dataclasses import dataclass
 
 
@@ -158,3 +158,10 @@ class NotFrozenModel(FrozenModel):
 
 NotFrozenModel(x=1).x = 2
 NotFrozenModel.from_orm(model)
+
+
+class SettingsModel(BaseSettings):
+    pass
+
+
+settings = SettingsModel.construct()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Fix `mypy` plugin bug
Fix bug when `mypy` plugin fails on `construct` method call for `BaseSettings` derived classes.

<!-- Please give a short summary of the changes. -->

## Related issue number
Closes #2753

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
