### PR TITLE
Fix repr tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1865,9 +1865,9 @@ def test_repr_field():
 
     m = Model(a=1, b=2, c=3)
     assert repr(m) == 'Model(a=1, b=2)'
-    assert repr(m.__fields__['a'].field_info) == 'FieldInfo(default=Ellipsis, extra={})'
-    assert repr(m.__fields__['b'].field_info) == 'FieldInfo(default=Ellipsis, extra={})'
-    assert repr(m.__fields__['c'].field_info) == 'FieldInfo(default=Ellipsis, repr=False, extra={})'
+    assert repr(m.__fields__['a'].field_info) == 'FieldInfo(default=PydanticUndefined, extra={})'
+    assert repr(m.__fields__['b'].field_info) == 'FieldInfo(default=PydanticUndefined, extra={})'
+    assert repr(m.__fields__['c'].field_info) == 'FieldInfo(default=PydanticUndefined, repr=False, extra={})'
 
 
 def test_inherited_model_field_copy():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Fix repr tests

Tests on the master branch are failing after #2593.

Basically, #2502 has changed the repr behavior of the `FieldInfo` class:
```py
class Model(BaseModel):
    a: int = Field()

field_info = Model.__fileds__['a'].field_info

# before #2502
assert repr(field_info) == 'FieldInfo(default=Ellipsis, extra={})'

# after  #2502
assert repr(field_info) == 'FieldInfo(default=PydanticUndefined, extra={})'
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
