### PR TITLE
allow empty fragments in AnyUrl

### DIFF
--- a/changes/2778-jeremyschlatter.md
+++ b/changes/2778-jeremyschlatter.md
@@ -1,0 +1,1 @@
+Allow empty fragments in `AnyUrl`.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -76,7 +76,7 @@ def url_regex() -> Pattern[str]:
             r'(?::(?P<port>\d+))?'  # port
             r'(?P<path>/[^\s?#]*)?'  # path
             r'(?:\?(?P<query>[^\s#]+))?'  # query
-            r'(?:#(?P<fragment>\S+))?',  # fragment
+            r'(?:#(?P<fragment>\S*))?',  # fragment
             re.IGNORECASE,
         )
     return _url_regex_cache

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -53,6 +53,7 @@ except ImportError:
         'http://twitter.com/@handle/',
         'http://11.11.11.11.example.com/action',
         'http://abc.11.11.11.11.example.com/action',
+        'http://example.com#',
     ],
 )
 def test_any_url_success(value):


### PR DESCRIPTION
On my understanding of the spec, empty fragments are valid:

https://datatracker.ietf.org/doc/html/rfc3986#section-3.5

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Allows empty fragments in AnyUrl.

## Related issue number

n/a

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
