### PR TITLE
Fix deprecation warning regarding Enum member access in Python 3.10.

### DIFF
--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -231,7 +231,7 @@ def generate_model_signature(
                 param_name, Parameter.KEYWORD_ONLY, annotation=field.outer_type_, **kwargs
             )
 
-    if config.extra is config.extra.allow:
+    if config.extra.value == "allow":
         use_var_kw = True
 
     if var_kw and use_var_kw:


### PR DESCRIPTION
## Change Summary

Fix deprecation warning regarding Enum member access in Python 3.10. Trying to import `Extra` from `.main` causes cyclic import error.

## Related issue number

Fixes #2786 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
