### PR TITLE
fix: support properly path type

### DIFF
--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -5,7 +5,7 @@ from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tu
 
 from .fields import ModelField
 from .main import BaseConfig, BaseModel, Extra
-from .typing import display_as_type
+from .typing import StrPath, display_as_type
 from .utils import deep_update, path_type, sequence_like
 
 env_file_sentinel = str(object())
@@ -27,9 +27,9 @@ class BaseSettings(BaseModel):
 
     def __init__(
         __pydantic_self__,
-        _env_file: Union[Path, str, None] = env_file_sentinel,
+        _env_file: Optional[StrPath] = env_file_sentinel,
         _env_file_encoding: Optional[str] = None,
-        _secrets_dir: Union[Path, str, None] = None,
+        _secrets_dir: Optional[StrPath] = None,
         **values: Any,
     ) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
@@ -42,9 +42,9 @@ class BaseSettings(BaseModel):
     def _build_values(
         self,
         init_kwargs: Dict[str, Any],
-        _env_file: Union[Path, str, None] = None,
+        _env_file: Optional[StrPath] = None,
         _env_file_encoding: Optional[str] = None,
-        _secrets_dir: Union[Path, str, None] = None,
+        _secrets_dir: Optional[StrPath] = None,
     ) -> Dict[str, Any]:
         # Configure built-in sources
         init_settings = InitSettingsSource(init_kwargs=init_kwargs)
@@ -132,8 +132,8 @@ class InitSettingsSource:
 class EnvSettingsSource:
     __slots__ = ('env_file', 'env_file_encoding')
 
-    def __init__(self, env_file: Union[Path, str, None], env_file_encoding: Optional[str]):
-        self.env_file: Union[Path, str, None] = env_file
+    def __init__(self, env_file: Optional[StrPath], env_file_encoding: Optional[str]):
+        self.env_file: Optional[StrPath] = env_file
         self.env_file_encoding: Optional[str] = env_file_encoding
 
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
@@ -182,8 +182,8 @@ class EnvSettingsSource:
 class SecretsSettingsSource:
     __slots__ = ('secrets_dir',)
 
-    def __init__(self, secrets_dir: Union[Path, str, None]):
-        self.secrets_dir: Union[Path, str, None] = secrets_dir
+    def __init__(self, secrets_dir: Optional[StrPath]):
+        self.secrets_dir: Optional[StrPath] = secrets_dir
 
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
         """
@@ -220,7 +220,9 @@ class SecretsSettingsSource:
         return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
 
 
-def read_env_file(file_path: Path, *, encoding: str = None, case_sensitive: bool = False) -> Dict[str, Optional[str]]:
+def read_env_file(
+    file_path: StrPath, *, encoding: str = None, case_sensitive: bool = False
+) -> Dict[str, Optional[str]]:
     try:
         from dotenv import dotenv_values
     except ImportError as e:

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -3,8 +3,9 @@ import warnings
 from pathlib import Path
 from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
+from .config import BaseConfig, Extra
 from .fields import ModelField
-from .main import BaseConfig, BaseModel, Extra
+from .main import BaseModel
 from .typing import StrPath, display_as_type
 from .utils import deep_update, path_type, sequence_like
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -207,15 +207,11 @@ else:
     WithArgsTypes = (typing._GenericAlias, types.GenericAlias, types.UnionType)
 
 
-if TYPE_CHECKING:
-    StrPath = Union[str, PathLike[str]]
+if sys.version_info < (3, 9):
+    StrPath = Union[str, PathLike]
 else:
-    if sys.version_info < (3, 9):
-        # Python >= 3.6, < 3.9
-        StrPath = Union[str, PathLike]
-    else:
-        # os.PathLike only becomes subscriptable from Python 3.9 onwards
-        StrPath = Union[str, PathLike[str]]
+    # os.PathLike only becomes subscriptable from Python 3.9 onwards
+    StrPath = Union[str, PathLike[str]]
 
 
 if TYPE_CHECKING:

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -1,4 +1,5 @@
 import sys
+from os import PathLike
 from typing import (  # type: ignore
     TYPE_CHECKING,
     AbstractSet,
@@ -190,6 +191,17 @@ else:
 
 
 if TYPE_CHECKING:
+    StrPath = Union[str, PathLike[str]]
+else:
+    if sys.version_info < (3, 9):
+        # Python >= 3.6, < 3.9
+        StrPath = Union[str, PathLike]
+    else:
+        # os.PathLike only becomes subscriptable from Python 3.9 onwards
+        StrPath = Union[str, PathLike[str]]
+
+
+if TYPE_CHECKING:
     from .fields import ModelField
 
     TupleGenerator = Generator[Tuple[str, Any], None, None]
@@ -238,6 +250,7 @@ __all__ = (
     'get_origin',
     'typing_base',
     'get_all_type_hints',
+    'StrPath',
 )
 
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -210,8 +210,12 @@ else:
 if sys.version_info < (3, 9):
     StrPath = Union[str, PathLike]
 else:
-    # os.PathLike only becomes subscriptable from Python 3.9 onwards
-    StrPath = Union[str, PathLike[str]]
+    StrPath = Union[str, PathLike]
+    # TODO: Once we switch to Cython 3 to handle generics properly
+    #  (https://github.com/cython/cython/issues/2753), use following lines instead
+    #  of the one above
+    # # os.PathLike only becomes subscriptable from Python 3.9 onwards
+    # StrPath = Union[str, PathLike[str]]
 
 
 if TYPE_CHECKING:

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -4,9 +4,10 @@ Test pydantic's compliance with mypy.
 Do a little skipping about with types to demonstrate its usage.
 """
 import json
+import os
 import sys
 from datetime import date, datetime, timedelta
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 from uuid import UUID
 
@@ -14,6 +15,7 @@ from pydantic import (
     UUID1,
     BaseConfig,
     BaseModel,
+    BaseSettings,
     DirectoryPath,
     Extra,
     FilePath,
@@ -250,3 +252,20 @@ class Config(BaseConfig):
     title = 'Record'
     extra = Extra.ignore
     max_anystr_length = 1234
+
+
+class Settings(BaseSettings):
+    ...
+
+
+class CustomPath(PurePath):
+    def __init__(self, *args: str):
+        self.path = os.path.join(*args)
+
+    def __fspath__(self) -> str:
+        return f'a/custom/{self.path}'
+
+
+def dont_check_path_existence() -> None:
+    Settings(_env_file='a/path', _secrets_dir='a/path')
+    Settings(_env_file=CustomPath('a/path'), _secrets_dir=CustomPath('a/path'))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Support properly path type

Example: 
```python
import os
from pathlib import PurePath

from pydantic import BaseSettings


class Settings(BaseSettings):
    ...


class CustomPath:
    def __init__(self, *args: str):
        self.path = os.path.join(*args)

    def __fspath__(self) -> str:
        return self.path
```

Before:
```python
Settings(_env_file=CustomPath("/var", ".env"))
# mypy error: Argument "_env_file" to "Settings" has incompatible type "CustomPath"; expected "Union[Path, str, None]"

Settings(_env_file=PurePath("/var/.env"))
# mypy error: Argument "_env_file" to "Settings" has incompatible type "PurePath"; expected "Union[Path, str, None]"
```

After:
```python
Settings(_env_file=CustomPath("/var", ".env"))  # OK
Settings(_env_file=PurePath("/var/.env"))  # OK

```

## Related issue number

N/A

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
