### PR TITLE
fix(schema): fix schema generation for `Deque` field

### DIFF
--- a/changes/2810-sergejkozin.md
+++ b/changes/2810-sergejkozin.md
@@ -1,0 +1,1 @@
+Fix schema generation for `Deque` fields

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -31,6 +31,7 @@ from typing_extensions import Annotated, Literal
 
 from .fields import (
     MAPPING_LIKE_SHAPES,
+    SHAPE_DEQUE,
     SHAPE_FROZENSET,
     SHAPE_GENERIC,
     SHAPE_ITERABLE,
@@ -437,7 +438,15 @@ def field_type_schema(
     definitions = {}
     nested_models: Set[str] = set()
     f_schema: Dict[str, Any]
-    if field.shape in {SHAPE_LIST, SHAPE_TUPLE_ELLIPSIS, SHAPE_SEQUENCE, SHAPE_SET, SHAPE_FROZENSET, SHAPE_ITERABLE}:
+    if field.shape in {
+        SHAPE_LIST,
+        SHAPE_TUPLE_ELLIPSIS,
+        SHAPE_SEQUENCE,
+        SHAPE_SET,
+        SHAPE_FROZENSET,
+        SHAPE_ITERABLE,
+        SHAPE_DEQUE,
+    }:
         items_schema, f_definitions, f_nested_models = field_singleton_schema(
             field,
             by_alias=by_alias,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
+    Deque,
     Dict,
     FrozenSet,
     Generic,
@@ -554,6 +555,18 @@ def test_tuple(field_type, expected_schema):
     base_schema['properties']['a']['items'] = expected_schema
 
     assert Model.schema() == base_schema
+
+
+def test_deque():
+    class Model(BaseModel):
+        a: Deque[str]
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'string'}}},
+        'required': ['a'],
+    }
 
 
 def test_bool():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

The `AssertionError` exception occurred on schema generation when a `Deque` field in the Pydantic model.

```python
from typing import Deque
from pydantic import BaseModel

class Model(BaseModel):
    a: Deque[str]

Model.schema()

"""
Traceback (most recent call last):
  File "/home/sergej/Projects/pydantic/test_deque.py", line 10, in <module>
    Model.schema()
  File "/home/sergej/Projects/pydantic/pydantic/main.py", line 720, in schema
    s = model_schema(cls, by_alias=by_alias, ref_template=ref_template)
  File "/home/sergej/Projects/pydantic/pydantic/schema.py", line 168, in model_schema
    m_schema, m_definitions, nested_models = model_process_schema(
  File "/home/sergej/Projects/pydantic/pydantic/schema.py", line 557, in model_process_schema
    m_schema, m_definitions, nested_models = model_type_schema(
  File "/home/sergej/Projects/pydantic/pydantic/schema.py", line 598, in model_type_schema
    f_schema, f_definitions, f_nested_models = field_schema(
  File "/home/sergej/Projects/pydantic/pydantic/schema.py", line 242, in field_schema
    f_schema, f_definitions, f_nested_models = field_type_schema(
  File "/home/sergej/Projects/pydantic/pydantic/schema.py", line 503, in field_type_schema
    assert field.shape in {SHAPE_SINGLETON, SHAPE_GENERIC}, field.shape
AssertionError: 11
"""
```

It happened because the `SHAPE_DEQUE` was missed in the set of array-like shapes.
(https://github.com/samuelcolvin/pydantic/blob/master/pydantic/schema.py#L439)

I updated this set and added the `test_deque()` case to the `test_shema.py`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2810 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
