### PR TITLE
Fix missing enum extra

### DIFF
--- a/changes/2697-sammchardy.md
+++ b/changes/2697-sammchardy.md
@@ -1,2 +1,1 @@
-Update get_field_info_schema to prevent it resetting schema_overrides which stopped **extras on Enum type Fields
-from being saved to the json schema output
+`Enum` fields now properly support extra kwargs in schema generation

--- a/changes/2697-sammchardy.md
+++ b/changes/2697-sammchardy.md
@@ -1,0 +1,2 @@
+Update get_field_info_schema to prevent it resetting schema_overrides which stopped **extras on Enum type Fields
+from being saved to the json schema output

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -176,8 +176,7 @@ def model_schema(
     return m_schema
 
 
-def get_field_info_schema(field: ModelField) -> Tuple[Dict[str, Any], bool]:
-    schema_overrides = False
+def get_field_info_schema(field: ModelField, schema_overrides: bool = False) -> Tuple[Dict[str, Any], bool]:
 
     # If no title is explicitly set, we don't set title in the schema for enums.
     # The behaviour is the same as `BaseModel` reference, where the default title
@@ -814,7 +813,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         add_field_type_to_schema(field_type, f_schema)
     elif lenient_issubclass(field_type, Enum):
         enum_name = model_name_map[field_type]
-        f_schema, schema_overrides = get_field_info_schema(field)
+        f_schema, schema_overrides = get_field_info_schema(field, schema_overrides)
         f_schema.update(get_schema_ref(enum_name, ref_prefix, ref_template, schema_overrides))
         definitions[enum_name] = enum_process_schema(field_type)
     elif is_namedtuple(field_type):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -397,6 +397,35 @@ def test_enum_and_model_have_same_behaviour():
     }
 
 
+def test_enum_includes_extra_without_other_params():
+    class Names(str, Enum):
+        rick = 'Rick'
+        morty = 'Morty'
+        summer = 'Summer'
+
+    class Foo(BaseModel):
+        enum: Names
+        extra_enum: Names = Field(..., extra='Extra field')
+
+    assert Foo.schema() == {
+        'definitions': {
+            'Names': {
+                'description': 'An enumeration.',
+                'enum': ['Rick', 'Morty', 'Summer'],
+                'title': 'Names',
+                'type': 'string',
+            },
+        },
+        'properties': {
+            'enum': {'$ref': '#/definitions/Names'},
+            'extra_enum': {'allOf': [{'$ref': '#/definitions/Names'}], 'extra': 'Extra field'},
+        },
+        'required': ['enum', 'extra_enum'],
+        'title': 'Foo',
+        'type': 'object',
+    }
+
+
 def test_list_enum_schema_extras():
     class FoodChoice(str, Enum):
         spam = 'spam'


### PR DESCRIPTION
## Change Summary

Models with an enum and Field definiton that just has **extra params now includes these in the output

```   
   class Names(str, Enum):
        rick = 'Rick'
        morty = 'Morty'
        summer = 'Summer'

    class Foo(BaseModel):
        enum: Names
        extra_enum: Names = Field(..., extra='Extra field')

   Foo.schema()
```

Before
```
{
        'definitions': {
            'Names': {
                'description': 'An enumeration.',
                'enum': ['Rick', 'Morty', 'Summer'],
                'title': 'Names',
                'type': 'string',
            },
        },
        'properties': {
            'enum': {'$ref': '#/definitions/Names'},
            'extra_enum': {'$ref': '#/definitions/Names'},
        },
        'required': ['enum', 'extra_enum'],
        'title': 'Foo',
        'type': 'object',
}
```

After
```
{
        'definitions': {
            'Names': {
                'description': 'An enumeration.',
                'enum': ['Rick', 'Morty', 'Summer'],
                'title': 'Names',
                'type': 'string',
            },
        },
        'properties': {
            'enum': {'$ref': '#/definitions/Names'},
            'extra_enum': {'allOf': [{'$ref': '#/definitions/Names'}], 'extra': 'Extra field'},
        },
        'required': ['enum', 'extra_enum'],
        'title': 'Foo',
        'type': 'object',
}
```

## Related issue number

This resolves https://github.com/samuelcolvin/pydantic/issues/2697

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review
