### PR TITLE
Add exclude_unset_none arg

### DIFF
--- a/changes/2838-goodoldneon.md
+++ b/changes/2838-goodoldneon.md
@@ -1,0 +1,1 @@
+Add `exclude_unset_none` arg to `BaseModel.dict` and `BaseModel.json`. This argument excludes all fields that were unset and whose value is `None`.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -505,6 +505,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_unset_none: bool = False,
     ) -> 'DictStrAny':
         """
         Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.
@@ -526,6 +527,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
                 exclude_none=exclude_none,
+                exclude_unset_none=exclude_unset_none,
             )
         )
 
@@ -539,6 +541,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_unset_none: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
         **dumps_kwargs: Any,
     ) -> str:
@@ -561,6 +564,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
+            exclude_unset_none=exclude_unset_none,
         )
         if self.__custom_root_type__:
             data = data[ROOT_KEY]
@@ -856,6 +860,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_unset_none: bool = False,
     ) -> 'TupleGenerator':
 
         # Merge field set excludes with explicit exclude parameter with explicit overriding field set options.
@@ -884,6 +889,11 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             if exclude_defaults:
                 model_field = self.__fields__.get(field_key)
                 if not getattr(model_field, 'required', True) and getattr(model_field, 'default', _missing) == v:
+                    continue
+
+            if exclude_unset_none:
+                model_field = self.__fields__.get(field_key)
+                if v is None and field_key not in self.__fields_set__.copy():
                     continue
 
             if by_alias and field_key in self.__fields__:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -389,6 +389,30 @@ def test_include_exclude_unset():
     assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, exclude_unset=True) == {'b': 2}
 
 
+def test_include_exclude_unset_none():
+    class Model(BaseModel):
+        a: int
+        b: int = 2
+        c: Optional[int] = 3
+        d: Optional[int] = 4
+        e: Optional[int] = None
+        f: Optional[int] = None
+
+    m = Model(a=1, b=2, c=None, e=None)
+    assert m.dict() == {'a': 1, 'b': 2, 'c': None, 'd': 4, 'e': None, 'f': None}
+    assert m.__fields_set__ == {'a', 'b', 'c', 'e'}
+    assert m.dict(exclude_unset_none=True) == {'a': 1, 'b': 2, 'c': None, 'd': 4, 'e': None}
+
+    assert m.dict(include={'a'}, exclude_unset_none=True) == {'a': 1}
+    assert m.dict(include={'f'}, exclude_unset_none=True) == {}
+
+    assert m.dict(exclude={'a'}, exclude_unset_none=True) == {'b': 2, 'c': None, 'd': 4, 'e': None}
+    assert m.dict(exclude={'c'}, exclude_unset_none=True) == {'a': 1, 'b': 2, 'd': 4, 'e': None}
+
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'b'}, exclude_unset_none=True) == {'a': 1, 'c': None}
+    assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, exclude_unset_none=True) == {'b': 2}
+
+
 def test_include_exclude_defaults():
     class Model(BaseModel):
         a: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Add `exclude_unset_none` arg to `BaseModel.dict` and `BaseModel.json`. This argument excludes all fields that were unset and whose value is `None`.

## Related issue number

No issue, but resolves this feature request:

https://github.com/samuelcolvin/pydantic/discussions/2837

## Checklist

* [X] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
