### PR TITLE
Adding warning about Union order

### DIFF
--- a/changes/2839-djpugh.md
+++ b/changes/2839-djpugh.md
@@ -1,0 +1,1 @@
+Add warning on `typing.Union` order and third party imports.

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -104,7 +104,7 @@ with custom properties and validation.
 : see [Typing Iterables](#typing-iterables) below for more detail on parsing and validation
 
 `subclass of typing.TypedDict`
-: Same as `dict` but _pydantic_ will validate the dictionary since keys are annotated.  
+: Same as `dict` but _pydantic_ will validate the dictionary since keys are annotated.
   See [Annotated Types](#annotated-types) below for more detail on parsing and validation
 
 `typing.Set`
@@ -258,7 +258,7 @@ _(This script is complete, it should run "as is")_
 !!! warning
     `typing.Unions` also ignore order when they are [defined](https://docs.python.org/3/library/typing.html#typing.Union),
     so `Union[int, float] == Union[float, int]` which can lead to unexpected behaviour when combined with matching the first type.
-    Please note that this can also be affected by third party libraries and their internal type definitions.
+    Please note that this can also be affected by third party libraries and their internal type definitions and the import orders.
 
 !!! tip
     The type `Optional[x]` is a shorthand for `Union[x, None]`.
@@ -834,16 +834,16 @@ The following arguments are available when using the `conbytes` type function
 
 ## Strict Types
 
-You can use the `StrictStr`, `StrictBytes`, `StrictInt`, `StrictFloat`, and `StrictBool` types 
+You can use the `StrictStr`, `StrictBytes`, `StrictInt`, `StrictFloat`, and `StrictBool` types
 to prevent coercion from compatible types.
 These types will only pass validation when the validated value is of the respective type or is a subtype of that type.
-This behavior is also exposed via the `strict` field of the `ConstrainedStr`, `ConstrainedBytes`, 
+This behavior is also exposed via the `strict` field of the `ConstrainedStr`, `ConstrainedBytes`,
 `ConstrainedFloat` and `ConstrainedInt` classes and can be combined with a multitude of complex validation rules.
 
 The following caveats apply:
 
 - `StrictBytes` (and the `strict` option of `ConstrainedBytes`) will accept both `bytes`,
-   and `bytearray` types. 
+   and `bytearray` types.
 - `StrictInt` (and the `strict` option of `ConstrainedInt`) will not accept `bool` types,
     even though `bool` is a subclass of `int` in Python. Other subclasses will work.
 - `StrictFloat` (and the `strict` option of `ConstrainedFloat`) will not accept `int`.

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -255,6 +255,11 @@ classes to preclude the unexpected representation as such:
 ```
 _(This script is complete, it should run "as is")_
 
+!!! warning
+    `typing.Unions` also ignore order when they are [defined](https://docs.python.org/3/library/typing.html#typing.Union),
+    so `Union[int, float] == Union[float, int]` which can lead to unexpected behaviour when combined with matching the first type.
+    Please note that this can also be affected by third party libraries and their internal type definitions.
+
 !!! tip
     The type `Optional[x]` is a shorthand for `Union[x, None]`.
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Adding warning about union order and initial definition (e.g. in third party libraries.)

## Related issue number
#2835 
#2092 should resolve this

## Checklist

* [x] Unit tests for the changes exist - n/a, just docs
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
