### PR TITLE
clarify docs on validation and strict type checking

### DIFF
--- a/changes/2855-paxcodes.md
+++ b/changes/2855-paxcodes.md
@@ -1,1 +1,1 @@
-Clarify documentation about `pydantic`'s support for custom validation and strict type checking, despite `pydantic` being primarily a parsing library.
+Clarify documentation about _pydantic_'s support for custom validation and strict type checking, despite _pydantic_ being primarily a parsing library.

--- a/changes/2855-paxcodes.md
+++ b/changes/2855-paxcodes.md
@@ -1,0 +1,1 @@
+Clarify documentation about `pydantic`'s support for custom validation and strict type checking, despite `pydantic` being primarily a parsing library.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -16,6 +16,8 @@ of the resultant model instance will conform to the field types defined on the m
     This might sound like an esoteric distinction, but it is not. If you're unsure what this means or
     how it might affect your usage you should read the section about [Data Conversion](#data-conversion) below.
 
+    Although validation is not the main purpose of *pydantic*, you **can** use this library for custom [validation](validators.md).
+
 ## Basic model usage
 
 ```py
@@ -612,6 +614,8 @@ _(This script is complete, it should run "as is")_
 
 This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See 
 [here](https://github.com/samuelcolvin/pydantic/issues/578) for a longer discussion on the subject.
+
+Nevertheless, [strict type checking](types.md#strict-types) is supported.
 
 ## Model signature
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -615,7 +615,7 @@ _(This script is complete, it should run "as is")_
 This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See 
 [here](https://github.com/samuelcolvin/pydantic/issues/578) for a longer discussion on the subject.
 
-Nevertheless, [strict type checking](types.md#strict-types) is supported.
+Nevertheless, [strict type checking](types.md#strict-types) is partially supported.
 
 ## Model signature
 


### PR DESCRIPTION
## Change Summary

Clarify docs about Pydantic's support for custom validation and strict type checking, despite that pydantic is primarily a parsing library.

Content is based on comments by @cknoll [[link](https://github.com/samuelcolvin/pydantic/issues/578#issuecomment-711144799)] and @PyAntony [[link](https://github.com/samuelcolvin/pydantic/issues/578#issuecomment-706621721)) <sup>[1](#myfootnote1)</sup>

## Related issue number

#578

## Checklist

* [n/a] Unit tests for the changes exist
* [n/a] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

---

<sub><a name="myfootnote1">1</a>: I'd need your email / GitHub-provided no-reply email if you'd like GitHub to recognize you as co-authors of the commit.</span></sub>