### PR TITLE
mention 3.8 requirement in contrib docs

### DIFF
--- a/changes/2856-paxcodes.md
+++ b/changes/2856-paxcodes.md
@@ -1,0 +1,1 @@
+Update contrib docs re: python version to use for building docs.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,8 +43,8 @@ cd pydantic
 # 2. Set up a virtualenv for running tests
 virtualenv -p `which python3.8` env
 source env/bin/activate
-# Building docs require 3.8. Otherwise, feel free to setup a python environment
-# however you prefer; 3.6 will work too.
+# Building docs requires 3.8. If you don't need to build docs you can use
+# whichever version; 3.6 will work too.
 
 # 3. Install pydantic, dependencies, test dependencies and doc dependencies
 make install

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,9 +41,10 @@ git clone git@github.com:<your username>/pydantic.git
 cd pydantic
 
 # 2. Set up a virtualenv for running tests
-virtualenv -p `which python3.7` env
+virtualenv -p `which python3.8` env
 source env/bin/activate
-# (or however you prefer to setup a python environment, 3.6 will work too)
+# Building docs require 3.8. Otherwise, feel free to setup a python environment
+# however you prefer; 3.6 will work too.
 
 # 3. Install pydantic, dependencies, test dependencies and doc dependencies
 make install


### PR DESCRIPTION
## Change Summary

Mention 3.8 requirement in contrib docs. Using python3.7 to build docs will fail:

```sh
-> % make docs      
flake8 --max-line-length=80 docs/examples/
docs/examples/validation_decorator_parameter_types.py:26:34: E999 SyntaxError: invalid syntax
make: *** [docs] Error 1
```

Where [`validation_decorator_parameter_types.py:26:34`](https://github.com/samuelcolvin/pydantic/blob/b718e8e62680c2d7a42f1cf946094e1c0fe28c1d/docs/examples/validation_decorator_parameter_types.py#L26) has `def pos_only(a: int, b: int = 2, /) -> str:  # python 3.8 only`

## Checklist

* [n/a; docs change] Unit tests for the changes exist
* [n/a; docs change] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
