### PR TITLE
fix: attrs + cattrs benchmark

### DIFF
--- a/benchmarks/test_cattrs.py
+++ b/benchmarks/test_cattrs.py
@@ -95,7 +95,5 @@ class TestCAttrs:
     def validate(self, data):
         try:
             return True, cattr.structure(data, self.model)
-        except ValueError as e:
-            return False, str(e)
-        except TypeError as e:
+        except (ValueError, TypeError, KeyError) as e:
             return False, str(e)


### PR DESCRIPTION
With https://github.com/Tinche/cattrs/commit/41c494599efe3cf49e11f2630dff5415b719fe43, `cattrs` uses `GenConverter` instead of `Converter` as global converter, which raises `KeyError` by default when a required value is missing
Let's just catch this `KeyError` in the benchmark!