### PR TITLE
🔥 Unpin SQLAlchemy version for FastAPI tests

### DIFF
--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -9,9 +9,6 @@ latest_tag_commit=$(git rev-list --tags --max-count=1)
 latest_tag=$(git describe --tags "${latest_tag_commit}")
 git checkout "${latest_tag}"
 
-# FIXME this is a temporary workaround while fastapi tests are broken with newer sqlalchemy
-pip install SQLAlchemy==1.3.23
-
 pip install -U flit
 flit install
 


### PR DESCRIPTION
🔥 Unpin SQLAlchemy version for FastAPI tests as it is now pinned in FastAPI, and soon I will upgrade its version.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Currently, the FastAPI tests here have SQLAlchemy pinned because I didn't have it pinned on FastAPI, and `encode/databases` didn't have it pinned, but a new version had breaking changes for them (SQLAlchemy doesn't follow SemVer), resulting in breaking tests in FastAPI, which resulted in breaking tests here (sorry for that :facepalm:).

I already pinned it on the FastAPI side, so it should be safe to unpin it here on pydantic.

I'm also planning on upgrading it, removing the tests for `encode/databases`, and instead, documenting and testing how to use SQLAlchemy `1.4`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

https://github.com/samuelcolvin/pydantic/pull/2584/files and https://github.com/samuelcolvin/pydantic/pull/2630/files

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
    - I didn't add a change for this as the other two related PRs didn't have one, and this doesn't really affect pydantic, only the CI setup
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
