### PR TITLE
build(deps-dev): bump dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 ansi2html==1.6.0
-flake8==3.9.1
+flake8==3.9.2
 flake8-quotes==3.2.0
-hypothesis==6.10.1
+hypothesis==6.13.10
 markdown-include==0.6.0
 mdx-truly-sane-lists==1.2
 mkdocs==1.1.2
 mkdocs-exclude==1.0.2
-mkdocs-material==7.1.4
+mkdocs-material==7.1.6
 sqlalchemy
 orjson
 ujson

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Cython==0.29.23;sys_platform!='win32'
 devtools==0.6.1
 email-validator==1.1.2
 dataclasses==0.6; python_version < '3.7'
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
 python-dotenv==0.17.1

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -1,7 +1,7 @@
-black==21.4b0
-flake8==3.9.1
+black==21.5b2
+flake8==3.9.2
 flake8-quotes==3.2.0
-hypothesis==6.10.1
+hypothesis==6.13.10
 isort==5.8.0
 mypy==0.812
 pycodestyle==2.7.0

--- a/tests/requirements-testing.txt
+++ b/tests/requirements-testing.txt
@@ -1,9 +1,9 @@
 coverage==5.5
-hypothesis==6.10.1
+hypothesis==6.13.10
 # pin importlib-metadata as upper versions need typing-extensions to work if on python < 3.8
 importlib-metadata==3.1.0;python_version<"3.8"
 mypy==0.812
-pytest==6.2.3
-pytest-cov==2.11.1
+pytest==6.2.4
+pytest-cov==2.12.0
 pytest-mock==3.6.1
 pytest-sugar==0.9.4


### PR DESCRIPTION
black:              21.4b0 ->  21.5b2
flake8:              3.9.1 ->   3.9.2
hypothesis:         6.10.1 -> 6.13.10
mkdocs-material:     7.1.4 ->   7.1.6
pytest:              6.2.3 ->   6.2.4
pytest-cov:         2.11.1 ->  2.12.0
typing-extensions: 3.7.4.3 ->  3.10.0.0

supersedes #2772, #2784, #2804, #2805, #2859