### PR TITLE
Added dark color scheme for docs

### DIFF
--- a/changes/2913-gbdlin.md
+++ b/changes/2913-gbdlin.md
@@ -1,0 +1,1 @@
+add a dark mode to _pydantic_ documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,14 +12,14 @@ theme:
     primary: pink
     accent: pink
     toggle:
-      icon: material/lightbulb
+      icon: material/lightbulb-outline
       name: "Switch to dark mode"
   - media: "(prefers-color-scheme: dark)"
     scheme: slate
     primary: pink
     accent: pink
     toggle:
-      icon: material/lightbulb-outline
+      icon: material/lightbulb
       name: "Switch to light mode"
 
   logo: 'logo-white.svg'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,8 +7,21 @@ theme:
   name: 'material'
   custom_dir: 'docs/theme'
   palette:
+  - media: "(prefers-color-scheme: light)"
+    scheme: default
     primary: pink
     accent: pink
+    toggle:
+      icon: material/lightbulb
+      name: "Switch to dark mode"
+  - media: "(prefers-color-scheme: dark)"
+    scheme: slate
+    primary: pink
+    accent: pink
+    toggle:
+      icon: material/lightbulb-outline
+      name: "Switch to light mode"
+
   logo: 'logo-white.svg'
   favicon: 'favicon.png'
 


### PR DESCRIPTION
## Change Summary

Added alternative, dark color scheme for docs, which should be automatically activated if user's browser presents the `prefers-color-scheme: dark` media query.

![Screen Shot 2021-09-04 at 8 13 31 PM](https://user-images.githubusercontent.com/18406791/132104323-50231a97-b242-4294-85ef-081bfa4ca74a.png)

## Related issue number

None

## Checklist

* [x]  ~~Unit tests for the changes exist~~
  documentation configuration change, not needed?
* [x] ~~Tests pass on CI and coverage remains at 100%~~ 
  documentation configuration change, not needed?
* [x] ~~Documentation reflects the changes where applicable~~ 
  documentation configuration change, not needed?
* [x] ~~`changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)~~ 
    documentation configuration change, not needed?
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
