### PR TITLE
Parse JSON for union type with complex subfields (#2936)

### DIFF
--- a/changes/2936-cbartz.md
+++ b/changes/2936-cbartz.md
@@ -1,0 +1,1 @@
+Parse environment variables as JSON, if they have a Union Type with a complex subfield.

--- a/changes/2936-cbartz.md
+++ b/changes/2936-cbartz.md
@@ -1,1 +1,1 @@
-Parse environment variables as JSON, if they have a Union Type with a complex subfield.
+Parse environment variables as JSON, if they have a `Union` type with a complex subfield.

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from pathlib import Path
-from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
+from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, get_origin
 
 from .fields import ModelField
 from .main import BaseConfig, BaseModel, Extra
@@ -172,6 +172,15 @@ class EnvSettingsSource:
                     env_val = settings.__config__.json_loads(env_val)  # type: ignore
                 except ValueError as e:
                     raise SettingsError(f'error parsing JSON for "{env_name}"') from e
+            elif (
+                get_origin(field.type_) == Union
+                and field.sub_fields
+                and any(map(lambda f: f.is_complex(), field.sub_fields))
+            ):
+                try:
+                    env_val = settings.__config__.json_loads(env_val)  # type: ignore
+                except ValueError:
+                    pass
             d[field.alias] = env_val
         return d
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -1,12 +1,12 @@
 import os
 import warnings
 from pathlib import Path
-from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, get_origin
+from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 from .config import BaseConfig, Extra
 from .fields import ModelField
 from .main import BaseModel
-from .typing import StrPath, display_as_type
+from .typing import StrPath, display_as_type, get_origin, is_union_origin
 from .utils import deep_update, path_type, sequence_like
 
 env_file_sentinel = str(object())
@@ -174,9 +174,9 @@ class EnvSettingsSource:
                 except ValueError as e:
                     raise SettingsError(f'error parsing JSON for "{env_name}"') from e
             elif (
-                get_origin(field.type_) == Union
+                is_union_origin(get_origin(field.type_))
                 and field.sub_fields
-                and any(map(lambda f: f.is_complex(), field.sub_fields))
+                and any(f.is_complex() for f in field.sub_fields)
             ):
                 try:
                     env_val = settings.__config__.json_loads(env_val)  # type: ignore


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Parse environment variables as JSON, if they have a Union Type with a complex subfield.

## Related issue number

Fixes [# 2936](https://github.com/samuelcolvin/pydantic/issues/2936)

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable - n/a
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

<!-- please review -->
