### PR TITLE
add defaultdict_validator to convert dict to defaultdict #2958

### DIFF
--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -1,5 +1,5 @@
 import re
-from collections import OrderedDict, deque
+from collections import OrderedDict, defaultdict, deque
 from collections.abc import Hashable
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal, DecimalException
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 
     ConstrainedNumber = Union[ConstrainedDecimal, ConstrainedFloat, ConstrainedInt]
     AnyOrderedDict = OrderedDict[Any, Any]
+    AnyDefaultdict = defaultdict[Any, Any]
     Number = Union[int, float, Decimal]
     StrBytes = Union[str, bytes]
 
@@ -208,6 +209,16 @@ def anystr_strip_whitespace(v: 'StrBytes') -> 'StrBytes':
 
 def anystr_lower(v: 'StrBytes') -> 'StrBytes':
     return v.lower()
+
+
+def defaultdict_validator(v: Any) -> 'AnyDefaultdict':
+    if isinstance(v, defaultdict):
+        return v
+
+    try:
+        return defaultdict(None, v)
+    except (TypeError, ValueError):
+        raise errors.DictError()
 
 
 def ordered_dict_validator(v: Any) -> 'AnyOrderedDict':
@@ -628,6 +639,7 @@ _VALIDATORS: List[Tuple[Type[Any], List[Any]]] = [
     (date, [parse_date]),
     (time, [parse_time]),
     (timedelta, [parse_duration]),
+    (defaultdict, [defaultdict_validator]),
     (OrderedDict, [ordered_dict_validator]),
     (dict, [dict_validator]),
     (list, [list_validator]),

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import defaultdict, deque
 from datetime import datetime
 from enum import Enum
 from itertools import product
@@ -69,6 +69,17 @@ def test_deque_validation():
     assert Model(a=deque({1, 2, 3})).a == deque([1, 2, 3])
     assert Model(a=[4, 5]).a == deque([4, 5])
     assert Model(a=(6,)).a == deque([6])
+
+
+def test_defaultdict_validation():
+    class Model(BaseModel):
+        a: defaultdict
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='snap')
+    assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
+    assert Model(a={1: 1, 2: 2, 3: 3}).a == defaultdict(None, {1: 1, 2: 2, 3: 3})
+    assert Model(a=defaultdict(list, {1: 1, 2: 2, 3: 3})).a == defaultdict(list, {1: 1, 2: 2, 3: 3})
 
 
 def test_validate_whole():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

add defaultdict_validator to convert dict to defaultdict 

## Related issue number

#2958

## Checklist

[☑️] Unit tests for the changes exist
[☑️] Tests pass on CI and coverage remains at 100%
[☑️] Documentation reflects the changes where applicable
[☑️] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
[☑️] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
