### PR TITLE
Fix mypy plugin without a config or with pyproject.toml

### DIFF
--- a/changes/2984-JacobHayes.md
+++ b/changes/2984-JacobHayes.md
@@ -1,0 +1,1 @@
+Fix pydantic.mypy plugin without a suitable config file

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -109,12 +109,14 @@ class PydanticPluginConfig:
 
     def __init__(self, options: Options) -> None:
         if options.config_file is None:  # pragma: no cover
-            return
-        plugin_config = ConfigParser()
-        plugin_config.read(options.config_file)
-        for key in self.__slots__:
-            setting = plugin_config.getboolean(CONFIGFILE_KEY, key, fallback=False)
-            setattr(self, key, setting)
+            for key in self.__slots__:
+                setattr(self, key, True)  # default to strict without a config
+        else:
+            plugin_config = ConfigParser()
+            plugin_config.read(options.config_file)
+            for key in self.__slots__:
+                setting = plugin_config.getboolean(CONFIGFILE_KEY, key, fallback=False)
+                setattr(self, key, setting)
 
 
 def from_orm_callback(ctx: MethodContext) -> Type:

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -108,7 +108,8 @@ class PydanticPluginConfig:
     warn_untyped_fields: bool
 
     def __init__(self, options: Options) -> None:
-        if options.config_file is None:  # pragma: no cover
+        # NOTE: pyproject.toml reading not supported
+        if options.config_file is None or options.config_file.endswith('.toml'):  # pragma: no cover
             for key in self.__slots__:
                 setattr(self, key, True)  # default to strict without a config
         else:


### PR DESCRIPTION
## Change Summary

The mypy plugin's `PydanticPluginConfig` relied on instance level booleans, but those were never set without a config
file. Separately, for users using mypy with a pyproject.toml, the `PydanticPluginConfig` would try to parse the config
with ConfigParser.

To solve both of those issues, I just default both cases to setting all of the flags to the strict mode.

The modified code is under `# pragma: no cover`, but I confirmed w/ a local run of things. Fair to mark "Unit tests for the changes exist" ✔️?

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
