### PR TITLE
Fix 2860

### DIFF
--- a/changes/2860-geekingfrog.md
+++ b/changes/2860-geekingfrog.md
@@ -1,0 +1,1 @@
+Correctly parse generic models with `Json[T]`.

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -205,8 +205,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
     # For JsonWrapperValue, need to handle its inner type to allow correct parsing
     # of generic Json arguments like Json[T]
     if not origin_type and lenient_issubclass(type_, JsonWrapper):
-        inner_resolved = replace_types(type_.inner_type, type_map)
-        type_.inner_type = inner_resolved
+        type_.inner_type = replace_types(type_.inner_type, type_map)
         return type_
 
     # If all else fails, we try to resolve the type directly and otherwise just

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -22,6 +22,7 @@ from typing_extensions import Annotated
 from .class_validators import gather_all_validators
 from .fields import DeferredType
 from .main import BaseModel, create_model
+from .types import JsonWrapper
 from .typing import display_as_type, get_all_type_hints, get_args, get_origin, typing_base
 from .utils import all_identical, lenient_issubclass
 
@@ -200,6 +201,13 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
         if all_identical(type_, resolved_list):
             return type_
         return resolved_list
+
+    # For JsonWrapperValue, need to handle its inner type to allow correct parsing
+    # of generic Json arguments like Json[T]
+    if not origin_type and lenient_issubclass(type_, JsonWrapper):
+        inner_resolved = replace_types(type_.inner_type, type_map)
+        type_.inner_type = inner_resolved
+        return type_
 
     # If all else fails, we try to resolve the type directly and otherwise just
     # return the input with no modifications.

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1173,3 +1173,12 @@ def test_parse_generic_json():
     raw = json.dumps({'payload_field': 'payload'})
     record = MessageWrapper[Payload](message=raw)
     assert isinstance(record.message, Payload)
+
+    schema = record.schema()
+    assert schema['properties'] == {'message': {'$ref': '#/definitions/Payload'}}
+    assert schema['definitions']['Payload'] == {
+        'title': 'Payload',
+        'type': 'object',
+        'properties': {'payload_field': {'title': 'Payload Field', 'type': 'string'}},
+        'required': ['payload_field'],
+    }


### PR DESCRIPTION
When dealing with JsonWrapper, replace the inner type when constructing
a a generic model.

## Change Summary

Fixes [bug 2860](https://github.com/samuelcolvin/pydantic/issues/2860)

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* N/A Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
