### PR TITLE
Fix error when using slots with multiple inheritance

### DIFF
--- a/changes/2989-hmvp.md
+++ b/changes/2989-hmvp.md
@@ -1,0 +1,1 @@
+Make mulitple inheritance work when using `PrivateAttr`

--- a/changes/2989-hmvp.md
+++ b/changes/2989-hmvp.md
@@ -1,1 +1,1 @@
-Make mulitple inheritance work when using `PrivateAttr`
+Make multiple inheritance work when using `PrivateAttr`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -296,7 +296,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         __schema_cache__: 'DictAny' = {}
         __custom_root_type__: bool = False
         __signature__: 'Signature'
-        __private_attributes__: Dict[str, Any]
+        __private_attributes__: Dict[str, ModelPrivateAttr]
         __class_vars__: SetStr
         __fields_set__: SetStr = set()
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -122,6 +122,7 @@ class ModelMetaclass(ABCMeta):
 
         pre_root_validators, post_root_validators = [], []
         private_attributes: Dict[str, ModelPrivateAttr] = {}
+        base_private_attributes: Dict[str, ModelPrivateAttr] = {}
         slots: SetStr = namespace.get('__slots__', ())
         slots = {slots} if isinstance(slots, str) else set(slots)
         class_vars: SetStr = set()
@@ -134,7 +135,7 @@ class ModelMetaclass(ABCMeta):
                 validators = inherit_validators(base.__validators__, validators)
                 pre_root_validators += base.__pre_root_validators__
                 post_root_validators += base.__post_root_validators__
-                private_attributes.update(base.__private_attributes__)
+                base_private_attributes.update(base.__private_attributes__)
                 class_vars.update(base.__class_vars__)
                 hash_func = base.__hash__
 
@@ -254,7 +255,7 @@ class ModelMetaclass(ABCMeta):
             '__schema_cache__': {},
             '__json_encoder__': staticmethod(json_encoder),
             '__custom_root_type__': _custom_root_type,
-            '__private_attributes__': private_attributes,
+            '__private_attributes__': {**base_private_attributes, **private_attributes},
             '__slots__': slots | private_attributes.keys(),
             '__hash__': hash_func,
             '__class_vars__': class_vars,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Using PrivateAttr with multiple inheritance does not work because of the use of `__slots__`. The current code sets all parent private attrs again on any child thus overwriting the parent slots. Functionally that is not really an issue but it breaks the algorithm which determines if base classes clash with multiple inheritance

## Related issue number

closes #2988

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
