### PR TITLE
chore(ci): remove warning filter for fastapi tests

### DIFF
--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -12,7 +12,4 @@ git checkout "${latest_tag}"
 pip install -U flit
 flit install
 
-# ignore cryptography warning https://github.com/mpdavis/python-jose/issues/208
-PYTHONPATH=./docs/src pytest \
-  -W 'ignore:int_from_bytes is deprecated, use int.from_bytes instead:cryptography.utils.CryptographyDeprecationWarning' \
-  -W ignore::pytest.PytestCollectionWarning
+PYTHONPATH=./docs/src pytest


### PR DESCRIPTION
Now that https://github.com/tiangolo/fastapi/pull/2790 has been merged
in master, we don't need to filter those warnings anymore