### PR TITLE
Issue #3011 - Testing and providing fix for bug with nested dataclass…

### DIFF
--- a/changes/3016-robons.md
+++ b/changes/3016-robons.md
@@ -1,0 +1,7 @@
+Testing and providing fix for bug with nested dataclass sub-types.
+
+    If an instance of pydantic.dataclasses.dataclass has an attribute a with an annotated type A which is a built in dataclasses.dataclass
+    When a value is assigned to a which is a subclass of type A - let's call this type B
+    Then validation should succeed provided that the the instance of type B is itself valid.
+
+This change ensures that the value is validated against a pydantic dataclass model which is based on the correct model targetting the appropriate subclass.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -46,7 +46,7 @@ def _dataclass_as_shallow_dict(data_class: Type['DataclassT']) -> dict:
     serialises the object to JSON. This causes problems when the type associated with the datatype is an abstract class
     since it cannot be instantiated.
     """
-    return dict([(f.name, getattr(data_class, f.name)) for f in dataclasses.fields(data_class)])
+    return dict([(f.name, getattr(data_class, f.name)) for f in dataclasses.fields(data_class) if f.init])
 
 
 def _validate_dataclass(cls: Type['DataclassT'], v: Any) -> 'DataclassT':

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -856,6 +856,32 @@ def test_wrapping_existing_data_classes_with_default_factory_fields():
     assert type(b_p.mro_override_test_prop) == bool
 
 
+def test_nested_dataclass_non_init_attributes():
+    """
+     When a dataclass instance is converted from a built-in type to the pydantic type, test that it correctly avoids
+     attempting to copy fields which have `init=False` set.
+    """
+    @dataclasses.dataclass
+    class A:
+        a_1: int
+        a_non_init: str = dataclasses.field(init=False)
+
+        def __post_init__(self):
+            self.a_non_init = "Hello, world."
+
+    @dataclasses.dataclass
+    class B:
+        a: A
+
+    B_Pydantic = pydantic.dataclasses.dataclass(B)
+
+    a = A(0)
+    a.a_non_init = "Goodbye, world."
+    b_p = B_Pydantic(a=a)
+    assert b_p.a.a_1 == 0
+    assert b_p.a.a_non_init == "Hello, world."
+
+
 def test_dataclass_arbitrary():
     class ArbitraryType:
         def __init__(self):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,5 +1,6 @@
 import dataclasses
 import pickle
+from abc import ABC, abstractmethod
 from collections.abc import Hashable
 from datetime import datetime
 from pathlib import Path
@@ -796,6 +797,41 @@ def test_inherit_builtin_dataclass_nested():
     assert z.za.b == 1
 
 
+def test_inherit_builtin_dataclass_nested_abstract():
+    """
+    Ensures the following exception is not raised:
+    `Can't instantiate abstract class A with abstract method do_something (type=type_error)`
+    """
+    @dataclasses.dataclass
+    class A(ABC):
+        a: int
+
+        @abstractmethod
+        def do_something(self) -> str:
+            pass
+
+    @dataclasses.dataclass
+    class B(A):
+        b: int
+
+        def do_something(self) -> str:
+            return "hi"
+
+    @dataclasses.dataclass
+    class X:
+        xa: A
+
+    @pydantic.dataclasses.dataclass
+    class Z:
+        zx: X
+
+    b = B(0, 1)
+    x = X(b)
+    z = Z(x)
+    assert z.zx.xa.a == 0
+    assert z.zx.xa.b == 1
+
+
 def test_dataclass_arbitrary():
     class ArbitraryType:
         def __init__(self):
@@ -871,20 +907,20 @@ def test_pydantic_callable_field():
     std_dc = StdlibDataclass(required_callable=foo, required_callable_2=bar)
 
     assert (
-        pyd_m.required_callable
-        is pyd_m.default_callable
-        is pyd_dc.required_callable
-        is pyd_dc.default_callable
-        is std_dc.required_callable
-        is std_dc.default_callable
+            pyd_m.required_callable
+            is pyd_m.default_callable
+            is pyd_dc.required_callable
+            is pyd_dc.default_callable
+            is std_dc.required_callable
+            is std_dc.default_callable
     )
     assert (
-        pyd_m.required_callable_2
-        is pyd_m.default_callable_2
-        is pyd_dc.required_callable_2
-        is pyd_dc.default_callable_2
-        is std_dc.required_callable_2
-        is std_dc.default_callable_2
+            pyd_m.required_callable_2
+            is pyd_m.default_callable_2
+            is pyd_dc.required_callable_2
+            is pyd_dc.default_callable_2
+            is std_dc.required_callable_2
+            is std_dc.default_callable_2
     )
 
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -777,6 +777,25 @@ def test_inherit_builtin_dataclass():
     assert pika.z == 3
 
 
+def test_inherit_builtin_dataclass_nested():
+    @dataclasses.dataclass
+    class A:
+        a: int
+
+    @dataclasses.dataclass
+    class B(A):
+        b: int
+
+    @pydantic.dataclasses.dataclass
+    class Z:
+        za: A
+
+    b = B(0, 1)
+    z = Z(b)
+    assert z.za.a == 0
+    assert z.za.b == 1
+
+
 def test_dataclass_arbitrary():
     class ArbitraryType:
         def __init__(self):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -832,6 +832,30 @@ def test_inherit_builtin_dataclass_nested_abstract():
     assert z.zx.xa.b == 1
 
 
+def test_idk():
+    """
+    Checking that the following exception is not raised:
+        > TypeError: non-default argument 'b_1' follows default argument
+        > in '3.9/lib/python3.9/dataclasses.py:504'
+    """
+    @dataclasses.dataclass
+    class A:
+        a_1: int
+        mro_override_test_prop: str
+
+    @dataclasses.dataclass
+    class B(A):
+        mro_override_test_prop: bool
+        b_2: Optional[str] = dataclasses.field(default=None)
+        b_1: List[str] = dataclasses.field(default_factory=list)
+
+    B_Pydantic = pydantic.dataclasses.dataclass(B)
+
+    b_p = B_Pydantic(a_1=0, mro_override_test_prop=False)
+    assert b_p.a_1 == 0
+    assert type(b_p.mro_override_test_prop) == bool
+
+
 def test_dataclass_arbitrary():
     class ArbitraryType:
         def __init__(self):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -802,6 +802,7 @@ def test_inherit_builtin_dataclass_nested_abstract():
     Ensures the following exception is not raised:
     `Can't instantiate abstract class A with abstract method do_something (type=type_error)`
     """
+
     @dataclasses.dataclass
     class A(ABC):
         a: int
@@ -838,6 +839,7 @@ def test_wrapping_existing_data_classes_with_default_factory_fields():
         > TypeError: non-default argument 'b_1' follows default argument
         > in '3.9/lib/python3.9/dataclasses.py:504'
     """
+
     @dataclasses.dataclass
     class A:
         a_1: int
@@ -858,9 +860,10 @@ def test_wrapping_existing_data_classes_with_default_factory_fields():
 
 def test_nested_dataclass_non_init_attributes():
     """
-     When a dataclass instance is converted from a built-in type to the pydantic type, test that it correctly avoids
-     attempting to copy fields which have `init=False` set.
+    When a dataclass instance is converted from a built-in type to the pydantic type, test that it correctly avoids
+    attempting to copy fields which have `init=False` set.
     """
+
     @dataclasses.dataclass
     class A:
         a_1: int
@@ -957,20 +960,20 @@ def test_pydantic_callable_field():
     std_dc = StdlibDataclass(required_callable=foo, required_callable_2=bar)
 
     assert (
-            pyd_m.required_callable
-            is pyd_m.default_callable
-            is pyd_dc.required_callable
-            is pyd_dc.default_callable
-            is std_dc.required_callable
-            is std_dc.default_callable
+        pyd_m.required_callable
+        is pyd_m.default_callable
+        is pyd_dc.required_callable
+        is pyd_dc.default_callable
+        is std_dc.required_callable
+        is std_dc.default_callable
     )
     assert (
-            pyd_m.required_callable_2
-            is pyd_m.default_callable_2
-            is pyd_dc.required_callable_2
-            is pyd_dc.default_callable_2
-            is std_dc.required_callable_2
-            is std_dc.default_callable_2
+        pyd_m.required_callable_2
+        is pyd_m.default_callable_2
+        is pyd_dc.required_callable_2
+        is pyd_dc.default_callable_2
+        is std_dc.required_callable_2
+        is std_dc.default_callable_2
     )
 
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -832,7 +832,7 @@ def test_inherit_builtin_dataclass_nested_abstract():
     assert z.zx.xa.b == 1
 
 
-def test_idk():
+def test_wrapping_existing_data_classes_with_default_factory_fields():
     """
     Checking that the following exception is not raised:
         > TypeError: non-default argument 'b_1' follows default argument


### PR DESCRIPTION
… sub-types.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Testing and providing fix for bug with nested dataclass sub-types.

- If an instance of `pydantic.dataclasses.dataclass` has an attribute `a` with an annotated type `A` which is a built in `dataclasses.dataclass`
- When a value is assigned to  `a` which is  a subclass of type `A` - let's call this type `B`
- Then validation should succeed provided that the the instance of type `B` is itself valid.

This change ensures that the value is validated against a pydantic dataclass model which is based on the correct model targetting the appropriate subclass. 

<!-- Please give a short summary of the changes. -->

## Related issue number

#3011 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
