### PR TITLE
Add a TypedDict class for error objects

### DIFF
--- a/changes/3038-matthewhughes934.md
+++ b/changes/3038-matthewhughes934.md
@@ -1,0 +1,1 @@
+Add a TypedDict class for error objects

--- a/changes/3038-matthewhughes934.md
+++ b/changes/3038-matthewhughes934.md
@@ -1,1 +1,1 @@
-Add a TypedDict class for error objects
+Add a `TypedDict` class for error objects

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -16,10 +16,13 @@ if TYPE_CHECKING:
 __all__ = 'ErrorWrapper', 'ValidationError'
 
 
-class ErrorDict(TypedDict, total=False):
+class _ErrorDictRequired(TypedDict):
     loc: 'Loc'
     msg: str
     type: str
+
+
+class ErrorDict(_ErrorDictRequired, total=False):
     ctx: Dict[str, Any]
 
 

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -11,13 +11,14 @@ if TYPE_CHECKING:
     from .types import ModelOrDc
     from .typing import ReprArgs
 
-    Loc = Tuple[Union[int, str], ...]
-
 __all__ = 'ErrorWrapper', 'ValidationError'
 
 
+Loc = Tuple[Union[int, str], ...]
+
+
 class _ErrorDictRequired(TypedDict):
-    loc: 'Loc'
+    loc: Loc
     msg: str
     type: str
 
@@ -29,11 +30,11 @@ class ErrorDict(_ErrorDictRequired, total=False):
 class ErrorWrapper(Representation):
     __slots__ = 'exc', '_loc'
 
-    def __init__(self, exc: Exception, loc: Union[str, 'Loc']) -> None:
+    def __init__(self, exc: Exception, loc: Union[str, Loc]) -> None:
         self.exc = exc
         self._loc = loc
 
-    def loc_tuple(self) -> 'Loc':
+    def loc_tuple(self) -> Loc:
         if isinstance(self._loc, tuple):
             return self._loc
         else:
@@ -98,7 +99,7 @@ def _display_error_type_and_ctx(error: ErrorDict) -> str:
 
 
 def flatten_errors(
-    errors: Sequence[Any], config: Type['BaseConfig'], loc: Optional['Loc'] = None
+    errors: Sequence[Any], config: Type['BaseConfig'], loc: Optional[Loc] = None
 ) -> Generator[ErrorDict, None, None]:
     for error in errors:
         if isinstance(error, ErrorWrapper):
@@ -118,7 +119,7 @@ def flatten_errors(
             raise RuntimeError(f'Unknown error object: {error}')
 
 
-def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> ErrorDict:
+def error_dict(exc: Exception, config: Type['BaseConfig'], loc: Loc) -> ErrorDict:
     type_ = get_exc_type(exc.__class__)
     msg_template = config.error_msg_templates.get(type_) or getattr(exc, 'msg_template', None)
     ctx = exc.__dict__

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -1,40 +1,38 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Sequence, Tuple, Type, Union
 
-from typing_extensions import TypedDict
-
 from .json import pydantic_encoder
 from .utils import Representation
 
 if TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
     from .config import BaseConfig
     from .types import ModelOrDc
     from .typing import ReprArgs
 
+    Loc = Tuple[Union[int, str], ...]
+
+    class _ErrorDictRequired(TypedDict):
+        loc: Loc
+        msg: str
+        type: str
+
+    class ErrorDict(_ErrorDictRequired, total=False):
+        ctx: Dict[str, Any]
+
+
 __all__ = 'ErrorWrapper', 'ValidationError'
-
-
-Loc = Tuple[Union[int, str], ...]
-
-
-class _ErrorDictRequired(TypedDict):
-    loc: Loc
-    msg: str
-    type: str
-
-
-class ErrorDict(_ErrorDictRequired, total=False):
-    ctx: Dict[str, Any]
 
 
 class ErrorWrapper(Representation):
     __slots__ = 'exc', '_loc'
 
-    def __init__(self, exc: Exception, loc: Union[str, Loc]) -> None:
+    def __init__(self, exc: Exception, loc: Union[str, 'Loc']) -> None:
         self.exc = exc
         self._loc = loc
 
-    def loc_tuple(self) -> Loc:
+    def loc_tuple(self) -> 'Loc':
         if isinstance(self._loc, tuple):
             return self._loc
         else:
@@ -55,9 +53,9 @@ class ValidationError(Representation, ValueError):
     def __init__(self, errors: Sequence[ErrorList], model: 'ModelOrDc') -> None:
         self.raw_errors = errors
         self.model = model
-        self._error_cache: Optional[List[ErrorDict]] = None
+        self._error_cache: Optional[List['ErrorDict']] = None
 
-    def errors(self) -> List[ErrorDict]:
+    def errors(self) -> List['ErrorDict']:
         if self._error_cache is None:
             try:
                 config = self.model.__config__  # type: ignore
@@ -81,15 +79,15 @@ class ValidationError(Representation, ValueError):
         return [('model', self.model.__name__), ('errors', self.errors())]
 
 
-def display_errors(errors: List[ErrorDict]) -> str:
+def display_errors(errors: List['ErrorDict']) -> str:
     return '\n'.join(f'{_display_error_loc(e)}\n  {e["msg"]} ({_display_error_type_and_ctx(e)})' for e in errors)
 
 
-def _display_error_loc(error: ErrorDict) -> str:
+def _display_error_loc(error: 'ErrorDict') -> str:
     return ' -> '.join(str(e) for e in error['loc'])
 
 
-def _display_error_type_and_ctx(error: ErrorDict) -> str:
+def _display_error_type_and_ctx(error: 'ErrorDict') -> str:
     t = 'type=' + error['type']
     ctx = error.get('ctx')
     if ctx:
@@ -99,8 +97,8 @@ def _display_error_type_and_ctx(error: ErrorDict) -> str:
 
 
 def flatten_errors(
-    errors: Sequence[Any], config: Type['BaseConfig'], loc: Optional[Loc] = None
-) -> Generator[ErrorDict, None, None]:
+    errors: Sequence[Any], config: Type['BaseConfig'], loc: Optional['Loc'] = None
+) -> Generator['ErrorDict', None, None]:
     for error in errors:
         if isinstance(error, ErrorWrapper):
 
@@ -119,7 +117,7 @@ def flatten_errors(
             raise RuntimeError(f'Unknown error object: {error}')
 
 
-def error_dict(exc: Exception, config: Type['BaseConfig'], loc: Loc) -> ErrorDict:
+def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> 'ErrorDict':
     type_ = get_exc_type(exc.__class__)
     msg_template = config.error_msg_templates.get(type_) or getattr(exc, 'msg_template', None)
     ctx = exc.__dict__
@@ -128,7 +126,7 @@ def error_dict(exc: Exception, config: Type['BaseConfig'], loc: Loc) -> ErrorDic
     else:
         msg = str(exc)
 
-    d = ErrorDict(loc=loc, msg=msg, type=type_)
+    d: 'ErrorDict' = {'loc': loc, 'msg': msg, 'type': type_}
 
     if ctx:
         d['ctx'] = ctx

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -1,6 +1,8 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Sequence, Tuple, Type, Union
 
+from typing_extensions import TypedDict
+
 from .json import pydantic_encoder
 from .utils import Representation
 
@@ -12,6 +14,13 @@ if TYPE_CHECKING:
     Loc = Tuple[Union[int, str], ...]
 
 __all__ = 'ErrorWrapper', 'ValidationError'
+
+
+class ErrorDict(TypedDict, total=False):
+    loc: 'Loc'
+    msg: str
+    type: str
+    ctx: Dict[str, Any]
 
 
 class ErrorWrapper(Representation):
@@ -42,9 +51,9 @@ class ValidationError(Representation, ValueError):
     def __init__(self, errors: Sequence[ErrorList], model: 'ModelOrDc') -> None:
         self.raw_errors = errors
         self.model = model
-        self._error_cache: Optional[List[Dict[str, Any]]] = None
+        self._error_cache: Optional[List[ErrorDict]] = None
 
-    def errors(self) -> List[Dict[str, Any]]:
+    def errors(self) -> List[ErrorDict]:
         if self._error_cache is None:
             try:
                 config = self.model.__config__  # type: ignore
@@ -68,15 +77,15 @@ class ValidationError(Representation, ValueError):
         return [('model', self.model.__name__), ('errors', self.errors())]
 
 
-def display_errors(errors: List[Dict[str, Any]]) -> str:
+def display_errors(errors: List[ErrorDict]) -> str:
     return '\n'.join(f'{_display_error_loc(e)}\n  {e["msg"]} ({_display_error_type_and_ctx(e)})' for e in errors)
 
 
-def _display_error_loc(error: Dict[str, Any]) -> str:
+def _display_error_loc(error: ErrorDict) -> str:
     return ' -> '.join(str(e) for e in error['loc'])
 
 
-def _display_error_type_and_ctx(error: Dict[str, Any]) -> str:
+def _display_error_type_and_ctx(error: ErrorDict) -> str:
     t = 'type=' + error['type']
     ctx = error.get('ctx')
     if ctx:
@@ -87,7 +96,7 @@ def _display_error_type_and_ctx(error: Dict[str, Any]) -> str:
 
 def flatten_errors(
     errors: Sequence[Any], config: Type['BaseConfig'], loc: Optional['Loc'] = None
-) -> Generator[Dict[str, Any], None, None]:
+) -> Generator[ErrorDict, None, None]:
     for error in errors:
         if isinstance(error, ErrorWrapper):
 
@@ -106,7 +115,7 @@ def flatten_errors(
             raise RuntimeError(f'Unknown error object: {error}')
 
 
-def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> Dict[str, Any]:
+def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> ErrorDict:
     type_ = get_exc_type(exc.__class__)
     msg_template = config.error_msg_templates.get(type_) or getattr(exc, 'msg_template', None)
     ctx = exc.__dict__
@@ -115,7 +124,7 @@ def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> Dict[s
     else:
         msg = str(exc)
 
-    d: Dict[str, Any] = {'loc': loc, 'msg': msg, 'type': type_}
+    d = ErrorDict(loc=loc, msg=msg, type=type_)
 
     if ctx:
         d['ctx'] = ctx


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This adds more specific typing for the dictionaries in
`ValidationError.errors()`. This shouldn't introduce any functional
change.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable (N/A)
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
