### PR TITLE
fix: make `create_model_from_typeddict` mypy compliant

### DIFF
--- a/changes/3008-PrettyWood.md
+++ b/changes/3008-PrettyWood.md
@@ -1,0 +1,1 @@
+make `create_model_from_typeddict` mypy compliant

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -4,15 +4,12 @@ from .fields import Required
 from .main import BaseModel, create_model
 
 if TYPE_CHECKING:
-
-    class TypedDict(Dict[str, Any]):
-        __annotations__: Dict[str, Type[Any]]
-        __total__: bool
-        __required_keys__: FrozenSet[str]
-        __optional_keys__: FrozenSet[str]
+    from typing_extensions import TypedDict
 
 
-def create_model_from_typeddict(typeddict_cls: Type['TypedDict'], **kwargs: Any) -> Type['BaseModel']:
+def create_model_from_typeddict(
+    typeddict_cls: Type['TypedDict'], **kwargs: Any  # type: ignore[valid-type]
+) -> Type['BaseModel']:
     """
     Create a `BaseModel` based on the fields of a `TypedDict`.
     Since `typing.TypedDict` in Python 3.8 does not store runtime information about optional keys,
@@ -27,8 +24,9 @@ def create_model_from_typeddict(typeddict_cls: Type['TypedDict'], **kwargs: Any)
             'Without it, there is no way to differentiate required and optional fields when subclassed.'
         )
 
+    required_keys: FrozenSet[str] = typeddict_cls.__required_keys__  # type: ignore[attr-defined]
     field_definitions = {
-        field_name: (field_type, Required if field_name in typeddict_cls.__required_keys__ else None)
+        field_name: (field_type, Required if field_name in required_keys else None)
         for field_name, field_type in typeddict_cls.__annotations__.items()
     }
 

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
 
 
 def create_model_from_typeddict(
-    typeddict_cls: Type['TypedDict'], **kwargs: Any  # type: ignore[valid-type]
+    # Mypy bug: `Type[TypedDict]` is resolved as `Any` https://github.com/python/mypy/issues/11030
+    typeddict_cls: Type['TypedDict'],  # type: ignore[valid-type]
+    **kwargs: Any,
 ) -> Type['BaseModel']:
     """
     Create a `BaseModel` based on the fields of a `TypedDict`.

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -26,8 +26,6 @@ from typing import (
 )
 from uuid import UUID
 
-from typing_extensions import Literal
-
 from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
 from .typing import (
@@ -45,7 +43,8 @@ from .typing import (
 from .utils import almost_equal_floats, lenient_issubclass, sequence_like
 
 if TYPE_CHECKING:
-    from .annotated_types import TypedDict
+    from typing_extensions import Literal, TypedDict
+
     from .config import BaseConfig
     from .fields import ModelField
     from .types import ConstrainedDecimal, ConstrainedFloat, ConstrainedInt
@@ -576,14 +575,14 @@ def make_namedtuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tu
 
 
 def make_typeddict_validator(
-    typeddict_cls: Type['TypedDict'], config: Type['BaseConfig']
+    typeddict_cls: Type['TypedDict'], config: Type['BaseConfig']  # type: ignore[valid-type]
 ) -> Callable[[Any], Dict[str, Any]]:
     from .annotated_types import create_model_from_typeddict
 
     TypedDictModel = create_model_from_typeddict(typeddict_cls, __config__=config)
     typeddict_cls.__pydantic_model__ = TypedDictModel  # type: ignore[attr-defined]
 
-    def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:
+    def typeddict_validator(values: 'TypedDict') -> Dict[str, Any]:  # type: ignore[valid-type]
         return TypedDictModel.parse_obj(values).dict(exclude_unset=True)
 
     return typeddict_validator

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 from uuid import UUID
 
+from typing_extensions import TypedDict
+
 from pydantic import (
     UUID1,
     BaseModel,
@@ -33,6 +35,7 @@ from pydantic import (
     StrictFloat,
     StrictInt,
     StrictStr,
+    create_model_from_typeddict,
     root_validator,
     validate_arguments,
     validator,
@@ -239,3 +242,16 @@ validated.my_file_path.absolute()
 validated.my_file_path_str.absolute()
 validated.my_dir_path.absolute()
 validated.my_dir_path_str.absolute()
+
+
+class SomeDict(TypedDict):
+    val: int
+    name: str
+
+
+obj: SomeDict = {
+    'val': 12,
+    'name': 'John',
+}
+
+create_model_from_typeddict(SomeDict)(**obj)


### PR DESCRIPTION
## Change Summary
make `create_model_from_typeddict` mypy compliant

## Related issue number
closes #3008

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
