### PR TITLE
feat: add support for `object` type

### DIFF
--- a/changes/3062-PrettyWood.md
+++ b/changes/3062-PrettyWood.md
@@ -1,0 +1,1 @@
+add support for `object` type

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -530,7 +530,7 @@ class ModelField(Representation):
         elif is_new_type(self.type_):
             self.type_ = new_type_supertype(self.type_)
 
-        if self.type_ is Any:
+        if self.type_ is Any or self.type_ is object:
             if self.required is Undefined:
                 self.required = False
             self.allow_none = True

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -786,7 +786,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
             ref_template=ref_template,
             known_models=known_models,
         )
-    if field_type is Any or field_type.__class__ == TypeVar:
+    if field_type is Any or field_type is object or field_type.__class__ == TypeVar:
         return {}, definitions, nested_models  # no restrictions
     if field_type in NONE_TYPES:
         return {'type': 'null'}, definitions, nested_models

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -652,7 +652,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
 ) -> Generator[AnyCallable, None, None]:
     from .dataclasses import is_builtin_dataclass, make_dataclass_validator
 
-    if type_ is Any:
+    if type_ is Any or type_ is object:
         return
     type_type = type_.__class__
     if type_type == ForwardRef or type_type == TypeVar:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -286,9 +286,15 @@ def test_set_attr_invalid():
 def test_any():
     class AnyModel(BaseModel):
         a: Any = 10
+        b: object = 20
 
-    assert AnyModel().a == 10
-    assert AnyModel(a='foobar').a == 'foobar'
+    m = AnyModel()
+    assert m.a == 10
+    assert m.b == 20
+
+    m = AnyModel(a='foobar', b='barfoo')
+    assert m.a == 'foobar'
+    assert m.b == 'barfoo'
 
 
 def test_alias():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -483,8 +483,16 @@ def test_optional():
 def test_any():
     class Model(BaseModel):
         a: Any
+        b: object
 
-    assert Model.schema() == {'title': 'Model', 'type': 'object', 'properties': {'a': {'title': 'A'}}}
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {
+            'a': {'title': 'A'},
+            'b': {'title': 'B'},
+        },
+    }
 
 
 def test_set():


### PR DESCRIPTION
## Change Summary
Allow to write something like
```py
class Model(BaseModel):
    metadata: dict[str, object]
```

## Related issue number
/

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
