### PR TITLE
Reproduce and Simplify logical expression for Some Functions

### DIFF
--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -90,17 +90,17 @@ class Color(Representation):
         return self._original
 
     def as_named(self, *, fallback: bool = False) -> str:
-        if self._rgba.alpha is None:
-            rgb = cast(Tuple[int, int, int], self.as_rgb_tuple())
-            try:
-                return COLORS_BY_VALUE[rgb]
-            except KeyError as e:
-                if fallback:
-                    return self.as_hex()
-                else:
-                    raise ValueError('no named color found, use fallback=True, as_hex() or as_rgb()') from e
-        else:
+        if self._rgba.alpha is not None:
             return self.as_hex()
+
+        rgb = cast(Tuple[int, int, int], self.as_rgb_tuple())
+        try:
+            return COLORS_BY_VALUE[rgb]
+        except KeyError as e:
+            if fallback:
+                return self.as_hex()
+            else:
+                raise ValueError('no named color found, use fallback=True, as_hex() or as_rgb()') from e
 
     def as_hex(self) -> str:
         """
@@ -139,16 +139,15 @@ class Color(Representation):
           False - always omit alpha,
         """
         r, g, b = [float_to_255(c) for c in self._rgba[:3]]
-        if alpha is None:
-            if self._rgba.alpha is None:
-                return r, g, b
-            else:
-                return r, g, b, self._alpha_float()
-        elif alpha:
-            return r, g, b, self._alpha_float()
-        else:
-            # alpha is False
+        if (
+            alpha is None
+            and self._rgba.alpha is None
+            or alpha is not None
+            and not alpha
+        ):
             return r, g, b
+        else:
+            return r, g, b, self._alpha_float()
 
     def as_hsl(self) -> str:
         """
@@ -244,10 +243,7 @@ def parse_str(value: str) -> RGBA:
     if m:
         *rgb, a = m.groups()
         r, g, b = [int(v, 16) for v in rgb]
-        if a:
-            alpha = int(a, 16) / 255
-        else:
-            alpha = None
+        alpha = int(a, 16) / 255 if a else None
         return ints_to_rgba(r, g, b, alpha)
 
     m = re.fullmatch(r_rgb, value_lower)
@@ -325,7 +321,7 @@ def parse_hsl(h: str, h_units: str, sat: str, light: str, alpha: Optional[float]
         h_value = h_value % rads / rads
     else:
         # turns
-        h_value = h_value % 1
+        h_value %= 1
 
     r, g, b = hls_to_rgb(h_value, l_value, s_value)
     return RGBA(r, g, b, alpha)

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -80,11 +80,7 @@ class ValidatedFunction:
         takes_kwargs = False
         fields: Dict[str, Tuple[Any, Any]] = {}
         for i, (name, p) in enumerate(parameters.items()):
-            if p.annotation is p.empty:
-                annotation = Any
-            else:
-                annotation = type_hints[name]
-
+            annotation = Any if p.annotation is p.empty else type_hints[name]
             default = ... if p.default is p.empty else p.default
             if p.kind == Parameter.POSITIONAL_ONLY:
                 self.arg_mapping[i] = name

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -91,11 +91,7 @@ def flatten_errors(
     for error in errors:
         if isinstance(error, ErrorWrapper):
 
-            if loc:
-                error_loc = loc + error.loc_tuple()
-            else:
-                error_loc = error.loc_tuple()
-
+            error_loc = loc + error.loc_tuple() if loc else error.loc_tuple()
             if isinstance(error.exc, ValidationError):
                 yield from flatten_errors(error.exc.raw_errors, config, error_loc)
             else:
@@ -110,11 +106,7 @@ def error_dict(exc: Exception, config: Type['BaseConfig'], loc: 'Loc') -> Dict[s
     type_ = get_exc_type(exc.__class__)
     msg_template = config.error_msg_templates.get(type_) or getattr(exc, 'msg_template', None)
     ctx = exc.__dict__
-    if msg_template:
-        msg = msg_template.format(**ctx)
-    else:
-        msg = str(exc)
-
+    msg = msg_template.format(**ctx) if msg_template else str(exc)
     d: Dict[str, Any] = {'loc': loc, 'msg': msg, 'type': type_}
 
     if ctx:

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -196,7 +196,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.
     if isinstance(type_, (List, list)):
-        resolved_list = list(replace_types(element, type_map) for element in type_)
+        resolved_list = [replace_types(element, type_map) for element in type_]
         if all_identical(type_, resolved_list):
             return type_
         return resolved_list

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -402,9 +402,8 @@ class ConstrainedStr(str):
         if cls.curtail_length and len(value) > cls.curtail_length:
             value = value[: cls.curtail_length]
 
-        if cls.regex:
-            if not cls.regex.match(value):
-                raise errors.StrRegexError(pattern=cls.regex.pattern)
+        if cls.regex and not cls.regex.match(value):
+            raise errors.StrRegexError(pattern=cls.regex.pattern)
 
         return value
 
@@ -935,14 +934,13 @@ class PaymentCardNumber(str):
     @staticmethod
     def _get_brand(card_number: str) -> PaymentCardBrand:
         if card_number[0] == '4':
-            brand = PaymentCardBrand.visa
+            return PaymentCardBrand.visa
         elif 51 <= int(card_number[:2]) <= 55:
-            brand = PaymentCardBrand.mastercard
+            return PaymentCardBrand.mastercard
         elif card_number[:2] in {'34', '37'}:
-            brand = PaymentCardBrand.amex
+            return PaymentCardBrand.amex
         else:
-            brand = PaymentCardBrand.other
-        return brand
+            return PaymentCardBrand.other
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BYTE SIZE TYPE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -652,7 +652,7 @@ def all_identical(left: Iterable[Any], right: Iterable[Any]) -> bool:
     >>> all_identical([a, b, [a]], [a, b, [a]])  # new list object, while "equal" is not "identical"
     False
     """
-    for left_item, right_item in zip_longest(left, right, fillvalue=_EMPTY):
-        if left_item is not right_item:
-            return False
-    return True
+    return all(
+        left_item is right_item
+        for left_item, right_item in zip_longest(left, right, fillvalue=_EMPTY)
+    )

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -655,7 +655,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if type_ is Any:
         return
     type_type = type_.__class__
-    if type_type == ForwardRef or type_type == TypeVar:
+    if type_type in [ForwardRef, TypeVar]:
         return
     if type_ in NONE_TYPES:
         yield none_validator

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -121,7 +121,7 @@ def bool_validator(v: Any) -> bool:
 
 
 def int_validator(v: Any) -> int:
-    if isinstance(v, int) and not (v is True or v is False):
+    if isinstance(v, int) and v is not True and v is not False:
         return v
 
     try:
@@ -131,7 +131,7 @@ def int_validator(v: Any) -> int:
 
 
 def strict_int_validator(v: Any) -> int:
-    if isinstance(v, int) and not (v is True or v is False):
+    if isinstance(v, int) and v is not True and v is not False:
         return v
     raise errors.IntegerError()
 
@@ -163,14 +163,14 @@ def number_multiple_validator(v: 'Number', field: 'ModelField') -> 'Number':
 
 def number_size_validator(v: 'Number', field: 'ModelField') -> 'Number':
     field_type: ConstrainedNumber = field.type_
-    if field_type.gt is not None and not v > field_type.gt:
+    if field_type.gt is not None and v <= field_type.gt:
         raise errors.NumberNotGtError(limit_value=field_type.gt)
-    elif field_type.ge is not None and not v >= field_type.ge:
+    elif field_type.ge is not None and v < field_type.ge:
         raise errors.NumberNotGeError(limit_value=field_type.ge)
 
-    if field_type.lt is not None and not v < field_type.lt:
+    if field_type.lt is not None and v >= field_type.lt:
         raise errors.NumberNotLtError(limit_value=field_type.lt)
-    if field_type.le is not None and not v <= field_type.le:
+    if field_type.le is not None and v > field_type.le:
         raise errors.NumberNotLeError(limit_value=field_type.le)
 
     return v

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,7 @@ if os.name == 'nt':
         """
         # Patch from: https://bugs.python.org/issue35893
         parts = ext.name.split('.')
-        if parts[-1] == '__init__':
-            suffix = parts[-2]
-        else:
-            suffix = parts[-1]
-
+        suffix = parts[-2] if parts[-1] == '__init__' else parts[-1]
         # from here on unchanged
         try:
             # Unicode module name support as defined in PEP-489
@@ -72,7 +68,10 @@ except FileNotFoundError:
 version = SourceFileLoader('version', 'pydantic/version.py').load_module()
 
 ext_modules = None
-if not any(arg in sys.argv for arg in ['clean', 'check']) and 'SKIP_CYTHON' not in os.environ:
+if (
+    all(arg not in sys.argv for arg in ['clean', 'check'])
+    and 'SKIP_CYTHON' not in os.environ
+):
     try:
         from Cython.Build import cythonize
     except ImportError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Function `Color.as_named` Reproduce with the following changes:

- Swap if/else branches
- Remove unnecessary else after guard condition

Function `Color.as_rgb_tuple` Reproduce with the following changes:

- Merge duplicate blocks `in` conditional

Function `parse_str` Reproduce with the following changes:

- Replace `if statement` with `if expression`

Function `parse_hsl` Reproduce with the following changes:

- Replace assignment with augmented assignment

Function FieldInfo.__repr_args__ Reproduce with the following changes:

- Replace `dict.get(x, None)` with `dict.get(x)`

Function `ModelField._get_mapping_value` Reproduce with the following changes:

- Replace multiple comparisons of same variable with `in` operator

Function `import_string.all_identical` Reproduce with the following changes:

- Use `any()` instead of for loop