### PR TITLE
Fix: _pydantic_post_init() reassigns __dict__ and removes properties

### DIFF
--- a/changes/3043-zulrang.md
+++ b/changes/3043-zulrang.md
@@ -1,0 +1,1 @@
+Updates pydantic dataclasses to keep _special properties on parent classes

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -98,7 +98,7 @@ def _generate_pydantic_post_init(
         d, _, validation_error = validate_model(self.__pydantic_model__, input_data, cls=self.__class__)
         if validation_error:
             raise validation_error
-        object.__setattr__(self, '__dict__', d)
+        object.__setattr__(self, '__dict__', {**getattr(self, '__dict__', {}), **d})
         object.__setattr__(self, '__initialised__', True)
         if post_init_post_parse is not None:
             post_init_post_parse(self, *initvars)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -920,3 +920,28 @@ def test_config_field_info_create_model():
     assert A2.__pydantic_model__.schema()['properties'] == {
         'a': {'title': 'A', 'description': 'descr', 'type': 'string'}
     }
+
+
+def test_keeps_custom_properties():
+    class StandardClass:
+        """Class which modifies instance creation."""
+
+        a: str
+
+        def __new__(cls, *args, **kwargs):
+            instance = super().__new__(cls)
+
+            instance._special_property = 1
+
+            return instance
+
+    StandardLibDataclass = dataclasses.dataclass(StandardClass)
+    PydanticDataclass = pydantic.dataclasses.dataclass(StandardClass)
+
+    clases_to_test = [StandardLibDataclass, PydanticDataclass]
+
+    test_string = 'string'
+    for cls in clases_to_test:
+        instance = cls(a=test_string)
+        assert instance._special_property == 1
+        assert instance.a == test_string


### PR DESCRIPTION
…added to the object, for example in __new__(), breaking integration with SQLAlchemy and other libraries #3043

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Fixes #3043 
Fixes #2924

## Related issue number

#3043

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
