### PR TITLE
Check for `collections.abc.Mapping` instead of dict when converting a…

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,3 +1,4 @@
+import collections
 import sys
 import warnings
 from abc import ABCMeta
@@ -678,7 +679,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         value_exclude = ValueItems(v, exclude) if exclude else None
         value_include = ValueItems(v, include) if include else None
 
-        if isinstance(v, dict):
+        if isinstance(v, collections.abc.Mapping):
             return {
                 k_: cls._get_value(
                     v_,


### PR DESCRIPTION
… pydantic field to a dict.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

We would like to be able use a custom immutable`frozendict` in fields as pydantic and have `dict()` continue to work as expected. So we should use a more generic type like `collections.abc.Mapping` instead of dict to make sure that we still convert it to a dict.

## Related issue number

N/A

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

please review
<!-- please review -->