### PR TITLE
fix int_validator not catching overflows

### DIFF
--- a/changes/3112-ojii.md
+++ b/changes/3112-ojii.md
@@ -1,0 +1,1 @@
+fix overflow errors in int_validator

--- a/changes/3112-ojii.md
+++ b/changes/3112-ojii.md
@@ -1,1 +1,1 @@
-fix overflow errors in int_validator
+Catch overflow errors in `int_validator`

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -125,7 +125,7 @@ def int_validator(v: Any) -> int:
 
     try:
         return int(v)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         raise errors.IntegerError()
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -43,6 +43,18 @@ def test_int_validation():
     assert Model(a=4.5).a == 4
 
 
+@pytest.mark.parametrize('value', [2.2250738585072011e308, float('nan'), float('inf')])
+def test_int_overflow_validation(value):
+    class Model(BaseModel):
+        a: int
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a=value)
+    assert exc_info.value.errors() == [
+        {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+    ]
+
+
 def test_frozenset_validation():
     class Model(BaseModel):
         a: frozenset


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

`int(value)` can raise an `OverflowError`, for example when called with very large floats.

<!-- Please give a short summary of the changes. -->

## Related issue number

#2345 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
