### PR TITLE
✨ Add a config field to make all model fields optional

### DIFF
--- a/changes/3121-christophelec.md
+++ b/changes/3121-christophelec.md
@@ -1,0 +1,1 @@
+Add a `total` configuration field to create models with all fields Optional

--- a/changes/3121-christophelec.md
+++ b/changes/3121-christophelec.md
@@ -1,1 +1,1 @@
-Add a `total` configuration field to create models with all fields Optional
+Add a `total` configuration field to create models with all fields `Optional`

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -115,6 +115,10 @@ not be included in the model schemas. **Note**: this means that attributes on th
 **`copy_on_model_validation`**
 : whether or not inherited models used as fields should be reconstructed (copied) on validation instead of being kept untouched (default: `True`)
 
+**`total`**
+: whether all fields must be present in the model. Setting this to `False` is equivalent to manually setting all fields as `Optional` with a `None` default (default: `True`)
+
+
 ## Change behaviour globally
 
 If you wish to change the behaviour of _pydantic_ globally, you can create your own custom `BaseModel`

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -62,6 +62,7 @@ class BaseConfig:
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[Type[Any], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
+    all_optionals: bool = False
 
     # Whether or not inherited models as fields should be reconstructed as base model
     copy_on_model_validation: bool = True
@@ -96,7 +97,9 @@ class BaseConfig:
         """
         Optional hook to check or modify fields during model creation.
         """
-        pass
+        if cls.all_optionals:
+            field.type_ = Optional[field.type_]
+            field.required = False
 
 
 def inherit_config(self_config: 'ConfigType', parent_config: 'ConfigType', **namespace: Any) -> 'ConfigType':

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -62,7 +62,7 @@ class BaseConfig:
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[Type[Any], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
-    all_optionals: bool = False
+    total: bool = True
 
     # Whether or not inherited models as fields should be reconstructed as base model
     copy_on_model_validation: bool = True
@@ -97,7 +97,7 @@ class BaseConfig:
         """
         Optional hook to check or modify fields during model creation.
         """
-        if cls.all_optionals:
+        if not cls.total:
             field.type_ = Optional[field.type_]
             field.required = False
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -209,7 +209,7 @@ def test_config_field_info_create_model():
 
 def test_config_all_optional_fields_model():
     class Config:
-        all_optionals = True
+        total = False
 
     m1 = create_model('M1', __config__=Config, a=(str, ...))
     assert m1()
@@ -219,11 +219,8 @@ def test_config_all_optional_fields_model_inheritance():
     class TestBase(BaseModel):
         b: str
 
-    class Test(TestBase):
+    class Test(TestBase, total=False):
         a: str
-
-        class Config:
-            all_optionals = True
 
     with pytest.raises(ValidationError):
         TestBase()

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -205,3 +205,26 @@ def test_config_field_info_create_model():
 
     m2 = create_model('M2', __config__=Config, a=(str, Field(...)))
     assert m2.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+
+
+def test_config_all_optional_fields_model():
+    class Config:
+        all_optionals = True
+
+    m1 = create_model('M1', __config__=Config, a=(str, ...))
+    assert m1()
+
+
+def test_config_all_optional_fields_model_inheritance():
+    class TestBase(BaseModel):
+        b: str
+
+    class Test(TestBase):
+        a: str
+
+        class Config:
+            all_optionals = True
+
+    with pytest.raises(ValidationError):
+        TestBase()
+    assert Test()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

This PR adds a Config to turn all fields of a model Optional with a None default.

The underlying use is to create a copy of an existing model, but where fields are Optional, to allow for an update of only the fields provided in FastAPI.

An example is provided in the issue below.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes https://github.com/samuelcolvin/pydantic/issues/3120

It seems it would also help with https://github.com/samuelcolvin/pydantic/issues/2272#issuecomment-771205557

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
