### PR TITLE
Bump docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,9 @@ flake8-quotes==3.3.0
 hypothesis==6.17.4
 markdown-include==0.6.0
 mdx-truly-sane-lists==1.2
-mkdocs==1.1.2
+mkdocs==1.2.2
 mkdocs-exclude==1.0.2
-mkdocs-material==7.1.6
+mkdocs-material==7.2.6
 sqlalchemy
 orjson
 ujson

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,9 +14,10 @@ theme:
 
 repo_name: samuelcolvin/pydantic
 repo_url: https://github.com/samuelcolvin/pydantic
-google_analytics:
-- 'UA-62733018-4'
-- 'auto'
+extra:
+  analytics:
+    provider: google
+    property: UA-62733018-4
 
 extra_css:
 - 'extra/terminal.css'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
`google_analytics` is deprecated and mkdocs raises an error in strict mode
Switched to new syntax
squidfunk/mkdocs-material#2055
https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics

Supersedes https://github.com/samuelcolvin/pydantic/pull/2998 and https://github.com/samuelcolvin/pydantic/pull/3167

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
