### PR TITLE
fix: coverage

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -216,7 +216,6 @@ class AnyUrl(str):
         assert m, 'URL regex failed unexpectedly'
 
         original_parts = cast('Parts', m.groupdict())
-        cls.hide_parts(original_parts)
         parts = cls.apply_default_parts(original_parts)
         parts = cls.validate_parts(parts)
 
@@ -308,10 +307,6 @@ class AnyUrl(str):
         return {}
 
     @classmethod
-    def hide_parts(cls, original_parts: 'Parts') -> None:
-        cls.hidden_parts = set()
-
-    @classmethod
     def apply_default_parts(cls, parts: 'Parts') -> 'Parts':
         for key, value in cls.get_default_parts(parts).items():
             if not parts[key]:  # type: ignore[misc]
@@ -331,16 +326,11 @@ class HttpUrl(AnyHttpUrl):
     tld_required = True
     # https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
     max_length = 2083
+    hidden_parts = {'port'}
 
     @staticmethod
     def get_default_parts(parts: 'Parts') -> 'Parts':
         return {'port': '80' if parts['scheme'] == 'http' else '443'}
-
-    @classmethod
-    def hide_parts(cls, original_parts: 'Parts') -> None:
-        super().hide_parts(original_parts)
-        if 'port' in original_parts:
-            cls.hidden_parts.add('port')
 
 
 class FileUrl(AnyUrl):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Small coverage regression introduced in #2447 because `hide_parts` would process on a dictionary with all values set to `None` or the set value so the `if 'port' in original_parts` was always true

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
