### PR TITLE
Add support for removing TypeVarDef in mypy 0.920

### DIFF
--- a/changes/3175-christianbundy.md
+++ b/changes/3175-christianbundy.md
@@ -1,0 +1,1 @@
+Add support for Mypy 0.920

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover
 
 try:
     from mypy.types import TypeVarDef
-except ImportError:  # type: ignore
+except ImportError:  # pragma: no cover
     # Backward-compatible with TypeVarDef from Mypy 0.910.
     from mypy.types import TypeVarType as TypeVarDef  # type: ignore[misc]
 

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover
 
 try:
     from mypy.types import TypeVarDef
-except ImportError:
+except ImportError:  # type: ignore
     # Backward-compatible with TypeVarDef from Mypy 0.910.
     from mypy.types import TypeVarType as TypeVarDef  # type: ignore[misc]
 

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -14,6 +14,14 @@ except ImportError:  # pragma: no cover
 
         warnings.warn('No TOML parser installed, cannot read configuration from `pyproject.toml`.')
         toml = None  # type: ignore
+
+try:
+    from mypy.types import TypeVarDef
+except ImportError:
+    # Backward-compatible with TypeVarDef from Mypy 0.910.
+    from mypy.types import TypeVarType as TypeVarDef  # type: ignore[misc]
+
+
 from mypy.errorcodes import ErrorCode
 from mypy.nodes import (
     ARG_NAMED,
@@ -59,7 +67,6 @@ from mypy.types import (
     Type,
     TypeOfAny,
     TypeType,
-    TypeVarDef,
     TypeVarType,
     UnionType,
     get_proper_type,
@@ -359,7 +366,13 @@ class PydanticModelTransformer:
         tvd = TypeVarDef(self_tvar_name, tvar_fullname, -1, [], obj_type)
         self_tvar_expr = TypeVarExpr(self_tvar_name, tvar_fullname, [], obj_type)
         ctx.cls.info.names[self_tvar_name] = SymbolTableNode(MDEF, self_tvar_expr)
-        self_type = TypeVarType(tvd)
+
+        # Backward-compatible with TypeVarDef from Mypy 0.910.
+        if isinstance(tvd, TypeVarType):
+            self_type = tvd
+        else:
+            self_type = TypeVarType(tvd)
+
         add_method(
             ctx,
             'construct',

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -368,7 +368,7 @@ class PydanticModelTransformer:
         ctx.cls.info.names[self_tvar_name] = SymbolTableNode(MDEF, self_tvar_expr)
 
         # Backward-compatible with TypeVarDef from Mypy 0.910.
-        if isinstance(tvd, TypeVarType):
+        if isinstance(tvd, TypeVarType):  # pragma: no cover
             self_type = tvd
         else:
             self_type = TypeVarType(tvd)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Problem: While using the Pydantic plugin with Mypy 0.920 there is an error about `TypeVarDef` not being defined.

Solution: Add support for Mypy 0.920 without breaking compat with Mypy 0.910.

See-also: https://github.com/python/mypy/pull/9951

## Related issue number

Fixes #3528 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
