### PR TITLE
feat: support custom `extra` in `validate_arguments`

### DIFF
--- a/changes/3161-PrettyWood.md
+++ b/changes/3161-PrettyWood.md
@@ -1,0 +1,1 @@
+`validate_arguments` now supports `extra` customization (used to always be `Extra.forbid`)

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -254,6 +254,6 @@ class ValidatedFunction:
                 raise TypeError(f'multiple values for argument{plural}: {keys}')
 
             class Config(CustomConfig):
-                extra = Extra.forbid
+                extra = getattr(CustomConfig, 'extra', Extra.forbid)
 
         self.model = create_model(to_camel(self.raw_function.__name__), __base__=DecoratorBaseModel, **fields)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from typing_extensions import Annotated
+from typing_extensions import Annotated, TypedDict
 
-from pydantic import BaseModel, Field, ValidationError, validate_arguments
+from pydantic import BaseModel, Extra, Field, ValidationError, validate_arguments
 from pydantic.decorator import ValidatedFunction
 from pydantic.errors import ConfigError
 
@@ -427,3 +427,20 @@ def foo(dt: datetime = Field(default_factory=lambda: 946684800), /):
     )
     assert module.foo() == datetime(2000, 1, 1, tzinfo=timezone.utc)
     assert module.foo(0) == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def test_validate_extra():
+    class TypedTest(TypedDict):
+        y: str
+
+    @validate_arguments(config={'extra': Extra.allow})
+    def test(other: TypedTest):
+        return other
+
+    assert test(other={'y': 'b', 'z': 'a'}) == {'y': 'b', 'z': 'a'}
+
+    @validate_arguments(config={'extra': Extra.ignore})
+    def test(other: TypedTest):
+        return other
+
+    assert test(other={'y': 'b', 'z': 'a'}) == {'y': 'b'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
fix #3161
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
