### PR TITLE
Add support for partial model validation

### DIFF
--- a/changes/3179-lsapan.md
+++ b/changes/3179-lsapan.md
@@ -1,0 +1,1 @@
+Add support for partial model validation

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -116,7 +116,7 @@ not be included in the model schemas. **Note**: this means that attributes on th
 : whether or not inherited models used as fields should be reconstructed (copied) on validation instead of being kept untouched (default: `True`)
 
 **`partial`**
-: whether or not the model should allow required fields to be omitted. Useful when working with CRUD operations, and you need to use an existing model for a PATCH operation. (default: `False`)
+: whether or not the model should allow required fields to be omitted. Useful when working with CRUD operations, and you need to use an existing model for a PATCH operation. Subclassing a partial model will result in any additional fields also not being required. (default: `False`)
 
 ## Change behaviour globally
 

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -115,6 +115,9 @@ not be included in the model schemas. **Note**: this means that attributes on th
 **`copy_on_model_validation`**
 : whether or not inherited models used as fields should be reconstructed (copied) on validation instead of being kept untouched (default: `True`)
 
+**`partial`**
+: whether or not the model should allow required fields to be omitted. Useful when working with CRUD operations, and you need to use an existing model for a PATCH operation. (default: `False`)
+
 ## Change behaviour globally
 
 If you wish to change the behaviour of _pydantic_ globally, you can create your own custom `BaseModel`

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     # parse
     'Protocol',
     # tools
+    'create_partial_model',
     'parse_file_as',
     'parse_obj_as',
     'parse_raw_as',

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -62,6 +62,7 @@ class BaseConfig:
     json_dumps: Callable[..., str] = json.dumps
     json_encoders: Dict[Type[Any], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
+    partial: bool = False
 
     # Whether or not inherited models as fields should be reconstructed as base model
     copy_on_model_validation: bool = True

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -97,7 +97,8 @@ class BaseConfig:
         """
         Optional hook to check or modify fields during model creation.
         """
-        pass
+        if cls.partial:
+            field.required = False
 
 
 def inherit_config(self_config: 'ConfigType', parent_config: 'ConfigType', **namespace: Any) -> 'ConfigType':

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -432,7 +432,9 @@ class ModelField(Representation):
 
         field_info, value = cls._get_field_info(name, annotation, value, config)
         required: 'BoolUndefined' = Undefined
-        if value is Required:
+        if config.partial:
+            required = False
+        elif value is Required:
             required = True
             value = None
         elif value is not Undefined:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -981,6 +981,8 @@ def validate_model(  # noqa: C901 (ignore complexity)
             if field.required:
                 errors.append(ErrorWrapper(MissingError(), loc=field.alias))
                 continue
+            elif config.partial:
+                continue
 
             value = field.get_default()
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -978,9 +978,6 @@ def validate_model(  # noqa: C901 (ignore complexity)
             using_name = True
 
         if value is _missing:
-            if config.partial:
-                continue
-
             if field.required:
                 errors.append(ErrorWrapper(MissingError(), loc=field.alias))
                 continue

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -756,20 +756,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         for f in cls.__fields__.values():
             update_field_forward_refs(f, globalns=globalns, localns=localns)
 
-    @classmethod
-    def partial_model(cls: Type['Model']) -> Type['Model']:
-        """
-        Create a version of the model that is suitable for partial validation.
-        Useful when working with CRUD operations, and you need to use an
-        existing model for a PATCH operation.
-        """
-
-        class PartialModel(cls):  # type: ignore
-            class Config(cls.Config):  # type: ignore
-                partial = True
-
-        return PartialModel
-
     def __iter__(self) -> 'TupleGenerator':
         """
         so `dict(model)` works

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -91,4 +91,5 @@ def create_partial_model(model: Type[BaseModel]) -> Type[BaseModel]:
         class Config(model.Config):  # type: ignore
             partial = True
 
+    PartialModel.__name__ = model.__name__
     return PartialModel

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -3,11 +3,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
+from .main import BaseModel
 from .parse import Protocol, load_file, load_str_bytes
 from .types import StrBytes
 from .typing import display_as_type
 
-__all__ = ('parse_file_as', 'parse_obj_as', 'parse_raw_as')
+__all__ = ('parse_file_as', 'parse_obj_as', 'parse_raw_as', 'create_partial_model')
 
 NameFactory = Union[str, Callable[[Type[Any]], str]]
 
@@ -77,3 +78,17 @@ def parse_raw_as(
         json_loads=json_loads,
     )
     return parse_obj_as(type_, obj, type_name=type_name)
+
+
+def create_partial_model(model: Type[BaseModel]) -> Type[BaseModel]:
+    """
+    Create a version of the model that is suitable for partial validation.
+    Useful when working with CRUD operations, and you need to use an
+    existing model for a PATCH operation.
+    """
+
+    class PartialModel(model):  # type: ignore
+        class Config(model.Config):  # type: ignore
+            partial = True
+
+    return PartialModel

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1892,3 +1892,17 @@ def test_arbitrary_types_allowed_custom_eq():
             arbitrary_types_allowed = True
 
     assert Model().x == Foo()
+
+
+def test_config_partial():
+    class Foo(BaseModel):
+        a: str = Field(...)
+        b: str = Field(...)
+
+    Bar = Foo.partial_model()
+
+    assert Foo.Config.partial is False
+    assert Bar.Config.partial is True
+
+    b = Bar(a='x')
+    assert b.dict(exclude_unset=True) == {'a': 'x'}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1940,7 +1940,7 @@ def test_config_partial():
     assert Baz.Config.partial is True
 
     class Buzz(Bar):
-        d: str
+        d: str = Field(...)
 
     buzz = Buzz(a='x', c=None)
     assert buzz.dict() == {'a': 'x', 'c': None}

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1907,3 +1907,9 @@ def test_config_partial():
 
     b = Bar(a='x')
     assert b.dict(exclude_unset=True) == {'a': 'x'}
+
+    with pytest.raises(ValidationError) as exc_info:
+        b = Bar(a='x', b=None)
+    assert exc_info.value.errors() == [
+        {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}
+    ]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -15,6 +15,7 @@ from pydantic import (
     StrBytes,
     ValidationError,
     constr,
+    create_partial_model,
     errors,
     validate_model,
     validator,
@@ -1899,7 +1900,7 @@ def test_config_partial():
         a: str = Field(...)
         b: str = Field(...)
 
-    Bar = Foo.partial_model()
+    Bar = create_partial_model(Foo)
 
     assert Foo.Config.partial is False
     assert Bar.Config.partial is True


### PR DESCRIPTION
## Change Summary

This is a simple change that will allow Pydantic models to be used for PATCH operations. It adds a `partial` config option which allows required fields to be omitted during validation. There has been various discussion on the topic of using pydantic for partial updates (particularly in the realm of FastAPI), but it seems like the suggested solutions were too complex for the perceived benefit. This change doesn't require adding any new types, it simply doesn't require fields to be present if the model has `partial = True` configured.

To illustrate why this change is necessary, imagine a scenario where you have a model with required fields, but you want to have an endpoint that can update just a few fields at a time:

```python
from typing import Optional

from pydantic import BaseModel, constr


class User(BaseModel):
    first_name: constr(min_length=1)
    last_name: constr(min_length=1)
    phone: Optional[constr(min_length=1)]

# We normally want the model to fail validation if last_name is left off, or null. i.e.:
User(first_name='John')
User(first_name='John', last_name=None)

# However, in the case of partial updates, we should be able to leave off last_name. We can do that now:
class PartialUser(BaseModel):
    first_name: constr(min_length=1)
    last_name: constr(min_length=1)
    phone: Optional[constr(min_length=1)]

    class Config:
        partial = True

# This no longer fails validation
PartialUser(first_name='John')

# This still fails validation, because last_name is still a required field
PartialUser(first_name='John', last_name=None)
``` 

There is an important distinction here. It has been recommended in the past to simply make every field optional, and use `dict(exclude_unset=True)`. However, that would allow setting `last_name=None`, bypassing the requirement that it always have a value. This change allows us to cleanly leave fields off when we aren't interested in updating them, while still ensuring they have a valid value when they're provided.

Speaking of clean, it's a bit impractical to define the same model twice! This change also introduces a class method to quickly generate a partial version of the model:

```python
PartialUser = User.partial_model()
```

## Related issue number

There are various issues in both this repo and FastAPI that have been seeking this functionality. My apologies for not opening a separate issue first, I just wanted to present the solution at the same time because it is an incredibly small change that adds a lot of flexibility. 👍 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
