### PR TITLE
Replacing encode_default instance check with strict type check

### DIFF
--- a/changes/3190-joaommartins.md
+++ b/changes/3190-joaommartins.md
@@ -1,0 +1,1 @@
+Replace `isinstance` check with strict `type` primitives check in schema `encode_default`.

--- a/changes/3190-joaommartins.md
+++ b/changes/3190-joaommartins.md
@@ -1,1 +1,1 @@
-Replace `isinstance` check with strict `type` primitives check in schema `encode_default`.
+Always use `Enum` value as default in generated JSON schema.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -909,7 +909,9 @@ def multitypes_literal_field_for_schema(values: Tuple[Any, ...], field: ModelFie
 
 
 def encode_default(dft: Any) -> Any:
-    if type(dft) in (int, float, str):
+    if isinstance(dft, Enum):
+        return dft.value
+    elif isinstance(dft, (int, float, str)):
         return dft
     elif sequence_like(dft):
         t = dft.__class__

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -909,7 +909,7 @@ def multitypes_literal_field_for_schema(values: Tuple[Any, ...], field: ModelFie
 
 
 def encode_default(dft: Any) -> Any:
-    if isinstance(dft, (int, float, str)):
+    if type(dft) in (int, float, str):
         return dft
     elif sequence_like(dft):
         t = dft.__class__

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1411,9 +1411,7 @@ def test_enum_str_default():
     class UserModel(BaseModel):
         friends: MyEnum = MyEnum.FOO
 
-    generated_schema_properties = UserModel.schema().get('properties', {})
-
-    assert generated_schema_properties.get('friends', {}).get('default', None) is MyEnum.FOO.value
+    assert UserModel.schema()['properties']['friends']['default'] is MyEnum.FOO.value
 
 
 def test_enum_int_default():
@@ -1423,9 +1421,7 @@ def test_enum_int_default():
     class UserModel(BaseModel):
         friends: MyEnum = MyEnum.FOO
 
-    generated_schema_properties = UserModel.schema().get('properties', {})
-
-    assert generated_schema_properties.get('friends', {}).get('default', None) is MyEnum.FOO.value
+    assert UserModel.schema()['properties']['friends']['default'] is MyEnum.FOO.value
 
 
 def test_dict_default():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1404,6 +1404,30 @@ def test_list_default():
     }
 
 
+def test_enum_str_default():
+    class MyEnum(str, Enum):
+        FOO = 'foo'
+
+    class UserModel(BaseModel):
+        friends: MyEnum = MyEnum.FOO
+
+    generated_schema_properties = UserModel.schema().get('properties', {})
+
+    assert generated_schema_properties.get('friends', {}).get('default', None) is MyEnum.FOO.value
+
+
+def test_enum_int_default():
+    class MyEnum(IntEnum):
+        FOO = 1
+
+    class UserModel(BaseModel):
+        friends: MyEnum = MyEnum.FOO
+
+    generated_schema_properties = UserModel.schema().get('properties', {})
+
+    assert generated_schema_properties.get('friends', {}).get('default', None) is MyEnum.FOO.value
+
+
 def test_dict_default():
     class UserModel(BaseModel):
         friends: Dict[str, float] = {'a': 1.1, 'b': 2.2}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Modifies the schema default resolution of `encode_default` to resolve IntEnum correctly by introducing a strict type check against primitives. IntEnum defaults are resolved by `pydantic_encoder` correctly in the same way Enum defaults are resolved.

## Related issue number
Closes #3190.
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
