### PR TITLE
Schema.md: use consistent (American) spelling

### DIFF
--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -37,7 +37,7 @@ The format of `$ref`s (`"#/definitions/FooBar"` above) can be altered by calling
 with the `ref_template` keyword argument, e.g. `ApplePie.schema(ref_template='/schemas/{model}.json#/')`, here `{model}`
 will be replaced with the model naming using `str.format()`.
 
-## Field customisation
+## Field customization
 
 Optionally, the `Field` function can be used to provide extra information about the field and validations.
 It has the following arguments:


### PR DESCRIPTION
Customisation is the British spelling. Below (and elsewhere) the American
spelling (customization) is used.

## Change Summary

Small spelling fix.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
