### PR TITLE
#3234 exclude extra field when represent model

### DIFF
--- a/changes/3234-cocolman.md
+++ b/changes/3234-cocolman.md
@@ -1,1 +1,1 @@
- exclude unpredictable "extra" fields from "repr"
+Fix display of `extra` fields with model `__repr__`

--- a/changes/3234-cocolman.md
+++ b/changes/3234-cocolman.md
@@ -1,0 +1,1 @@
+ exclude unpredictable "extra" fields from "repr"

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -854,7 +854,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
     def __repr_args__(self) -> 'ReprArgs':
         return [
-            (k, v) for k, v in self.__dict__.items() if self.__fields__.get(k) and self.__fields__[k].field_info.repr
+            (k, v) for k, v in self.__dict__.items() if k not in self.__fields__ or self.__fields__[k].field_info.repr
         ]
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -853,7 +853,9 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             return self.dict() == other
 
     def __repr_args__(self) -> 'ReprArgs':
-        return [(k, v) for k, v in self.__dict__.items() if self.__fields__[k].field_info.repr]
+        return [
+            (k, v) for k, v in self.__dict__.items() if self.__fields__.get(k) and self.__fields__[k].field_info.repr
+        ]
 
 
 _is_base_model_class_defined = True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -200,7 +200,7 @@ def test_allow_extra_repr():
 
         class Config:
             extra = Extra.allow
-    
+
     assert str(Model(a='10.2', b=12)) == f'a={10.2}'
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -194,6 +194,16 @@ def test_allow_extra():
     assert Model(a='10.2', b=12).dict() == {'a': 10.2, 'b': 12}
 
 
+def test_allow_extra_repr():
+    class Model(BaseModel):
+        a: float = ...
+
+        class Config:
+            extra = Extra.allow
+    
+    assert str(Model(a='10.2', b=12)) == f'a={10.2}'
+
+
 def test_forbidden_extra_success():
     class ForbiddenExtra(BaseModel):
         foo = 'whatever'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -201,7 +201,7 @@ def test_allow_extra_repr():
         class Config:
             extra = Extra.allow
 
-    assert str(Model(a='10.2', b=12)) == f'a={10.2}'
+    assert str(Model(a='10.2', b=12)) == 'a=10.2 b=12'
 
 
 def test_forbidden_extra_success():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary


has been modified to exclude unpredictable "extra" fields from "__repr__"


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
fix #3234

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
