### PR TITLE
fix: collect only valid fields in mypy plugin

### DIFF
--- a/changes/3146-hi-ogawa.md
+++ b/changes/3146-hi-ogawa.md
@@ -1,0 +1,1 @@
+Fix mypy plugin to collect fields based on `pydantic.utils.is_valid_field` so that it ignores untyped private variables

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -249,10 +249,7 @@ class PydanticModelTransformer:
                 continue
 
             lhs = stmt.lvalues[0]
-            if not isinstance(lhs, NameExpr):
-                continue
-
-            if not is_valid_field(lhs.name):
+            if not isinstance(lhs, NameExpr) or not is_valid_field(lhs.name):
                 continue
 
             if not stmt.new_syntax and self.plugin_config.warn_untyped_fields:

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -1,6 +1,8 @@
 from configparser import ConfigParser
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type as TypingType, Union
 
+from pydantic.utils import is_valid_field
+
 try:
     import toml
 except ImportError:  # pragma: no cover
@@ -248,6 +250,9 @@ class PydanticModelTransformer:
 
             lhs = stmt.lvalues[0]
             if not isinstance(lhs, NameExpr):
+                continue
+
+            if not is_valid_field(lhs.name):
                 continue
 
             if not stmt.new_syntax and self.plugin_config.warn_untyped_fields:

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,6 +1,6 @@
 from typing import ClassVar, Optional, Union
 
-from pydantic import BaseModel, BaseSettings, Field, create_model
+from pydantic import BaseModel, BaseSettings, Field, create_model, validator
 from pydantic.dataclasses import dataclass
 
 
@@ -169,3 +169,15 @@ class SettingsModel(BaseSettings):
 
 
 settings = SettingsModel.construct()
+
+
+def f(name: str) -> str:
+    return name
+
+
+class ModelWithAllowReuseValidator(BaseModel):
+    name: str
+    _normalize_name = validator('name', allow_reuse=True)(f)
+
+
+model_with_allow_reuse_validator = ModelWithAllowReuseValidator(name='xyz')

--- a/tests/mypy/outputs/plugin-success-strict.txt
+++ b/tests/mypy/outputs/plugin-success-strict.txt
@@ -1,4 +1,3 @@
 29: error: Unexpected keyword argument "z" for "Model"  [call-arg]
 64: error: Untyped fields disallowed  [pydantic-field]
 79: error: Argument "x" to "OverrideModel" has incompatible type "float"; expected "int"  [arg-type]
-125: error: Untyped fields disallowed  [pydantic-field]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

~EDIT: Sorry, I just noticed some tests are failing, so I'll switch it to draft PR now.~ (should be ready now)

## Change Summary

<!-- Please give a short summary of the changes. -->

In mypy plugin, currently it tries to find model fields by going through all the assignment statements in class body even if a variable name starts with underscore. When the plugin is used with the option `warn_untyped_fields` enabled, this leads to some of "normal" usage of class variables without type annotation (e.g. https://pydantic-docs.helpmanual.io/usage/validators/#reuse-validators) giving mypy error `error: Untyped fields disallowed  [pydantic-field]` (I think simple workaround would be to annotate with `ClassVar` though).

In this PR, I used `pydantic.utils.is_valid_field` to filter possible model fields before triggering errors for `warn_untyped_fields`, which essentially skips the variable name starting with underscore except `__root__` variable.

~I worried that skipping all the underscore-ed variable might have a bad effect on using private attributes, so in the unit test, I made sure its type is still inferred correctly.~ (EDIT: I couldn't find a way to test this cleanly. I tried `reveal_type` and `TYPE_CHECKING` but current test driver `test_mypy.py` didn't support them well).

Thanks for the code review!

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/samuelcolvin/pydantic/issues/3146

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
