### PR TITLE
Fix timedelta validation for small floats

### DIFF
--- a/changes/3250-yaochie.md
+++ b/changes/3250-yaochie.md
@@ -1,0 +1,1 @@
+Fix `timedelta` validation for small floats

--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -222,9 +222,10 @@ def parse_duration(value: StrBytesIntFloat) -> timedelta:
         return value
 
     if isinstance(value, (int, float)):
-        # below code requires a string
-        value = str(value)
-    elif isinstance(value, bytes):
+        # use timedelta directly
+        return timedelta(seconds=value)
+
+    if isinstance(value, bytes):
         value = value.decode()
 
     try:

--- a/tests/test_datetime_parse.py
+++ b/tests/test_datetime_parse.py
@@ -175,6 +175,8 @@ def test_parse_python_format(delta):
         ('30', timedelta(seconds=30)),
         (30, timedelta(seconds=30)),
         (30.1, timedelta(seconds=30, milliseconds=100)),
+        (1e-5, timedelta(microseconds=10)),
+        (3 * 0.1, timedelta(microseconds=300000)),
         # minutes seconds
         ('15:30', timedelta(minutes=15, seconds=30)),
         ('5:30', timedelta(minutes=5, seconds=30)),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Fix `timedelta` validation for small floats by using `timedelta(seconds=value)` to immediately validate when the value is `int` or `float`.

Current pydantic behaviour:
```
>>> import pydantic
>>> print(pydantic.utils.version_info())
             pydantic version: 1.8.2
            pydantic compiled: True
                 install path: /home/yc/.local/share/virtualenvs/pydantic-test-YPCeDF9M/lib/python3.7/site-packages/pydantic
               python version: 3.7.12 (default, Sep 21 2021, 21:47:19)  [GCC 11.2.1 20210728 (Red Hat 11.2.1-1)]
                     platform: Linux-5.13.16-200.fc34.x86_64-x86_64-with-fedora-34-Thirty_Four
     optional deps. installed: ['typing-extensions']
>>> from pydantic import BaseModel
>>> from datetime import timedelta
>>> class Model(BaseModel):
...   delta: timedelta
... 
>>> Model(delta=timedelta(seconds=1e-5))
Model(delta=datetime.timedelta(microseconds=10))
>>> Model(delta=1e-5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pydantic/main.py", line 406, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Model
delta
  invalid duration format (type=value_error.duration)
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#3315 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
