### PR TITLE
fix: support aliases in Annotated types with ForwardRef

### DIFF
--- a/changes/3283-klaa97.md
+++ b/changes/3283-klaa97.md
@@ -1,0 +1,2 @@
+Support `alias` and `description` in `Annotated` types, with postponed annotations.
+


### PR DESCRIPTION
## Change Summary

Support `alias` and `description` in `Annotated` types, with postponed annotations.

This is done by checking, during the preparation of `Annotated` types, whether we are analyzing a `ForwardRef` field, and in case retrieve the metadata directly (since it couldn't have been retrieved beforehand).

The following issue #3282 describes the problem in detail; moreover, I added tests that are currently failing.

Let me know if I'm missing something and there is a better approach 🙏 

## Related issue number

Fixes #3282

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
