### PR TITLE
Fix BaseModel.__repr__ with extra fields

### DIFF
--- a/changes/3234-povilasb.md
+++ b/changes/3234-povilasb.md
@@ -1,0 +1,3 @@
+* Fixes `BaseModel` repr regression introduced by https://github.com/samuelcolvin/pydantic/commit/362f4a51630390161c3a81929657f698743e7c20
+
+* This issue was specific to models with extra fields.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -853,7 +853,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             return self.dict() == other
 
     def __repr_args__(self) -> 'ReprArgs':
-        return [(k, v) for k, v in self.__dict__.items() if self.__fields__[k].field_info.repr]
+        return [(k, v) for k, v in self.__dict__.items() if k in self.__fields__ and self.__fields__[k].field_info.repr]
 
 
 _is_base_model_class_defined = True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,6 +68,18 @@ def test_ultra_simple_repr():
     assert str(m) == 'a=10.2 b=10'
 
 
+def test_repr_skips_extra_fields():
+    class Model(BaseModel):
+        a: int = 0
+
+        class Config:
+            extra = 'allow'
+
+    m = Model(a=1, b=2)
+
+    assert repr(m) == "Model(a=1)"
+
+
 def test_default_factory_field():
     def myfunc():
         return 1


### PR DESCRIPTION
## Change Summary

Consider this example:
```py
from pydantic import BaseModel


class Person(BaseModel):
    name: str

    class Config:
        extra = "allow"


me = Person(name="povilas")
me.age = 30
print(me)
```

Latest pydantic master branch would crash with
```text
Traceback (most recent call last):
  File "/private/tmp/main.py", line 13, in <module>
    print(me)
  File "/private/tmp/pydantic/pydantic/utils.py", line 361, in __str__
    return self.__repr_str__(' ')
  File "/private/tmp/pydantic/pydantic/utils.py", line 343, in __repr_str__
    return join_str.join(repr(v) if a is None else f'{a}={v!r}' for a, v in self.__repr_args__())
  File "/private/tmp/pydantic/pydantic/main.py", line 856, in __repr_args__
    return [(k, v) for k, v in self.__dict__.items() if self.__fields__[k].field_info.repr]
  File "/private/tmp/pydantic/pydantic/main.py", line 856, in <listcomp>
    return [(k, v) for k, v in self.__dict__.items() if self.__fields__[k].field_info.repr]
KeyError: 'age'
```

Pydantic `1.8.2` works fine and this is a regression after https://github.com/samuelcolvin/pydantic/commit/362f4a51630390161c3a81929657f698743e7c20 .


This commit makes sure we only try to access defined fields.
As a side effect this means extra fields do not get into model representation.

I'm not sure if that's the expected behavior though.

## Related issue number

https://github.com/samuelcolvin/pydantic/issues/3234

## Checklist

* [X] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable - no public interface changes
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review.
