### PR TITLE
Update validator function name in  examples to show that value must b…

### DIFF
--- a/changes/3327-michaelrios28.md
+++ b/changes/3327-michaelrios28.md
@@ -1,0 +1,1 @@
+Changed the validator method name in the [Custom Errors example](https://pydantic-docs.helpmanual.io/usage/models/#custom-errors) to more accurately describe what the validator is doing; changed from `name_must_contain_space` to ` value_must_equal_bar`.

--- a/docs/examples/models_errors2.py
+++ b/docs/examples/models_errors2.py
@@ -5,7 +5,7 @@ class Model(BaseModel):
     foo: str
 
     @validator('foo')
-    def name_must_contain_space(cls, v):
+    def value_must_equal_bar(cls, v):
         if v != 'bar':
             raise ValueError('value must be "bar"')
 

--- a/docs/examples/models_errors3.py
+++ b/docs/examples/models_errors3.py
@@ -10,7 +10,7 @@ class Model(BaseModel):
     foo: str
 
     @validator('foo')
-    def name_must_contain_space(cls, v):
+    def value_must_equal_bar(cls, v):
         if v != 'bar':
             raise NotABarError(wrong_value=v)
         return v


### PR DESCRIPTION
I was reading the docs as a new user and I noticed the validator method name did not match what the validator was doing. 

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Changed the validator method name in the [Custom Errors example](https://pydantic-docs.helpmanual.io/usage/models/#custom-errors) to more accurately describe what the validator is doing; changed from `name_must_contain_space` to `
value_must_equal_bar`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
