### PR TITLE
Mention Python >= 3.9.2 as an alternative to `typing_extensions.TypedDict`

### DIFF
--- a/changes/3374-BvB93.md
+++ b/changes/3374-BvB93.md
@@ -1,0 +1,1 @@
+Mention Python >= 3.9.2 as an alternative to `typing_extensions.TypedDict`.

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -22,7 +22,7 @@ def create_model_from_typeddict(
     # Best case scenario: with python 3.9+ or when `TypedDict` is imported from `typing_extensions`
     if not hasattr(typeddict_cls, '__required_keys__'):
         raise TypeError(
-            'You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` or Python >= 3.9.2. '
+            'You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2. '
             'Without it, there is no way to differentiate required and optional fields when subclassed.'
         )
 

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -22,7 +22,7 @@ def create_model_from_typeddict(
     # Best case scenario: with python 3.9+ or when `TypedDict` is imported from `typing_extensions`
     if not hasattr(typeddict_cls, '__required_keys__'):
         raise TypeError(
-            'You should use `typing_extensions.TypedDict` instead of `typing.TypedDict`. '
+            'You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` or Python >= 3.9.2. '
             'Without it, there is no way to differentiate required and optional fields when subclassed.'
         )
 

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -219,7 +219,7 @@ def test_partial_legacy_typeddict():
         TypeError,
         match=(
             '^You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` '
-            'or upgrade to Python >= 3.9.2'
+            'with Python < 3.9.2.'
         ),
     ):
 

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -13,7 +13,7 @@ from typing_extensions import TypedDict
 
 from pydantic import BaseModel, PositiveInt, ValidationError
 
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 9, 2):
     try:
         from typing import TypedDict as LegacyTypedDict
     except ImportError:

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -215,7 +215,13 @@ def test_partial_legacy_typeddict():
     class User(OptionalUser):
         id: int
 
-    with pytest.raises(TypeError, match='^You should use `typing_extensions.TypedDict` instead of `typing.TypedDict`'):
+    with pytest.raises(
+        TypeError,
+        match=(
+            '^You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` '
+            'or upgrade to Python >= 3.9.2'
+        ),
+    ):
 
         class Model(BaseModel):
             user: User

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -217,10 +217,7 @@ def test_partial_legacy_typeddict():
 
     with pytest.raises(
         TypeError,
-        match=(
-            '^You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` '
-            'with Python < 3.9.2.'
-        ),
+        match='^You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2.',
     ):
 
         class Model(BaseModel):


### PR DESCRIPTION
## Change Summary

Pydantic does not support older versions of `typing.TypedDict` due to [bpo-42059](https://bugs.python.org/issue42059), thus recomminding the use of `typing_extensions.TypedDict` instead. This issue was resolved in python 3.9.2 though, so mention upgrading python as an alternative to the `typing_extensions`-based approach.

## Related issue number

n.a.

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
