### PR TITLE
Bump Pydantic version to 1.9.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,61 @@
+## v1.9.0 (2021-11-21)
+
+* Fix issue when pydantic fail to parse `typing.ClassVar` string type annotation, #3401 by @uriyyo
+* `validate_arguments` now supports `extra` customization (used to always be `Extra.forbid`), #3161 by @PrettyWood
+* fix `validate_arguments` issue with `Config.validate_all`, #3135 by @PrettyWood
+* add support for `object` type, #3062 by @PrettyWood
+* Updates pydantic dataclasses to keep _special properties on parent classes, #3043 by @zulrang
+* Add a `TypedDict` class for error objects, #3038 by @matthewhughes934
+* Fix support for using a subclass of an annotation as a default, #3018 by @JacobHayes
+* make `create_model_from_typeddict` mypy compliant, #3008 by @PrettyWood
+* Make multiple inheritance work when using `PrivateAttr`, #2989 by @hmvp
+* Parse environment variables as JSON, if they have a `Union` type with a complex subfield, #2936 by @cbartz
+* Prevent `StrictStr` permitting `Enum` values where the enum inherits from `str`, #2929 by @samuelcolvin
+* add a dark mode to _pydantic_ documentation, #2913 by @gbdlin
+* Make `pydantic-mypy` plugin compatible with `pyproject.toml` configuration, consistent with `mypy` changes. See the [doc](https://pydantic-docs.helpmanual.io/mypy_plugin/#configuring-the-plugin) for more information, #2908 by @jrwalk
+* add python 3.10 support, #2885 by @PrettyWood
+* Correctly parse generic models with `Json[T]`, #2860 by @geekingfrog
+* Update contrib docs re: python version to use for building docs, #2856 by @paxcodes
+* Clarify documentation about _pydantic_'s support for custom validation and strict type checking, despite _pydantic_ being primarily a parsing library, #2855 by @paxcodes
+* Fix schema generation for `Deque` fields, #2810 by @sergejkozin
+* fix an edge case when mixing constraints and `Literal`, #2794 by @PrettyWood
+* Fix postponed annotation resolution for `NamedTuple` and `TypedDict` when they're used directly as the type of fields within Pydantic models, #2760 by @jameysharp
+* Fix bug when `mypy` plugin fails on `construct` method call for `BaseSettings` derived classes, #2753 by @uriyyo
+* Add function overloading for a `pydantic.create_model` function, #2748 by @uriyyo
+* Fix mypy plugin issue with self field declaration, #2743 by @uriyyo
+* The colon at the end of the line "The fields which were supplied when user was initialised:" suggests that the code following it is related.
+  Changed it to a period, #2733 by @krisaoe
+* Renamed variable `schema` to `schema_` to avoid shadowing of global variable name, #2724 by @shahriyarr
+* Add support for autocomplete in VS Code via `__dataclass_transform__`, #2721 by @tiangolo
+* add missing type annotations in `BaseConfig` and handle `max_length = 0`, #2719 by @PrettyWood
+* Change `orm_mode` checking to allow recursive ORM mode parsing with dicts, #2718 by @nuno-andre
+* Add episode 313 of the *Talk Python To Me* podcast, where Michael Kennedy and Samuel Colvin discuss *pydantic*, to the docs, #2712 by @RatulMaharaj
+* fix JSON schema generation when a field is of type `NamedTuple` and has a default value, #2707 by @PrettyWood
+* Switch docs preview and coverage display to use [smokeshow](https://smokeshow.helpmanual.io/), #2580 by @samuelcolvin
+* Add `__version__` attribute to pydantic module, #2572 by @paxcodes
+* Add `postgresql+asyncpg`, `postgresql+pg8000`, `postgresql+psycopg2`, `postgresql+psycopg2cffi`, `postgresql+py-postgresql` and `postgresql+pygresql` schemes for `PostgresDsn`, #2567 by @postgres-asyncpg
+* Enable the Hypothesis plugin to generate a constrained decimal when the `decimal_places` argument is specified, #2524 by @cwe5590
+* Allow `collections.abc.Callable` to be used as type in python 3.9, #2519 by @daviskirk
+* Documentation update how to custom compile pydantic when using pip install, small change in `setup.py` to allow for custom CFLAGS when compiling, #2517 by @peterroelants
+* remove side effect of `default_factory` to run it only once even if `Config.validate_all` is set, #2515 by @PrettyWood
+* Add lookahead to ip regexes for `AnyUrl` hosts. This allows urls with DNS labels
+  looking like IPs to validate as they are perfectly valid host names, #2512 by @sbv-csis
+* Add `strict` argument to `conbytes`, #2489 by @koxudaxi
+* Support user defined generic field types in generic models, #2465 by @daviskirk
+* Add an example and a short explanation of subclassing `GetterDict` to docs, #2463 by @nuno-andre
+* - add `KafkaDsn` type
+   - `HttpUrl` now has default port 80 for http and 443 for https, #2447 by @MihanixA
+* Add `PastDate` and `FutureDate` types, #2425 by @Kludex
+* Support generating schema for `Generic` fields with subtypes, #2375 by @maximberg
+* fix(encoder): serialize `NameEmail` to str, #2341 by @alecgerona
+* Add ability to use `typing.Counter` as a model field type, #2060 by @uriyyo
+* Create `FileUrl` type that allows URLs that conform to [RFC 8089](https://tools.ietf.org/html/rfc8089#section-2).
+  Add `host_required` parameter, which is `True` by default (`AnyUrl` and subclasses), `False` in `RedisDsn`, `FileUrl`, #1983 by @vgerak
+* stop calling parent class `root_validator` if overridden, #1895 by @PrettyWood
+* Add `repr` (defaults to `True`) parameter to `Field`, to hide it from the default representation of the `BaseModel`, #1831 by @fnep
+* Accept empty query/fragment URL parts, #1807 by @xavier
+* Add "exclude" as a field parameter so that it can be configured using model config instead of purely at `.dict` / `.json` export time, #660 by @daviskirk
+
 ## v1.8.2 (2021-05-11)
 
 !!! warning

--- a/changes/1807-xavier.md
+++ b/changes/1807-xavier.md
@@ -1,1 +1,0 @@
-Accept empty query/fragment URL parts

--- a/changes/1831-fnep.md
+++ b/changes/1831-fnep.md
@@ -1,1 +1,0 @@
-Add `repr` (defaults to `True`) parameter to `Field`, to hide it from the default representation of the `BaseModel`.

--- a/changes/1895-PrettyWood.md
+++ b/changes/1895-PrettyWood.md
@@ -1,1 +1,0 @@
-stop calling parent class `root_validator` if overridden

--- a/changes/1983-vgerak.md
+++ b/changes/1983-vgerak.md
@@ -1,2 +1,0 @@
-Create `FileUrl` type that allows URLs that conform to [RFC 8089](https://tools.ietf.org/html/rfc8089#section-2).
-Add `host_required` parameter, which is `True` by default (`AnyUrl` and subclasses), `False` in `RedisDsn`, `FileUrl`.

--- a/changes/2060-uriyyo.md
+++ b/changes/2060-uriyyo.md
@@ -1,1 +1,0 @@
-Add ability to use `typing.Counter` as a model field type.

--- a/changes/2341-alecgerona.md
+++ b/changes/2341-alecgerona.md
@@ -1,1 +1,0 @@
-fix(encoder): serialize `NameEmail` to str

--- a/changes/2375-maximberg.md
+++ b/changes/2375-maximberg.md
@@ -1,1 +1,0 @@
-Support generating schema for `Generic` fields with subtypes. 

--- a/changes/2425-Kludex.md
+++ b/changes/2425-Kludex.md
@@ -1,1 +1,0 @@
-Add `PastDate` and `FutureDate` types.

--- a/changes/2447-MihanixA.md
+++ b/changes/2447-MihanixA.md
@@ -1,2 +1,0 @@
- - add `KafkaDsn` type
- - `HttpUrl` now has default port 80 for http and 443 for https

--- a/changes/2463-nuno-andre.md
+++ b/changes/2463-nuno-andre.md
@@ -1,1 +1,0 @@
-Add an example and a short explanation of subclassing `GetterDict` to docs.

--- a/changes/2465-daviskirk.md
+++ b/changes/2465-daviskirk.md
@@ -1,1 +1,0 @@
-Support user defined generic field types in generic models.

--- a/changes/2489-koxudaxi.md
+++ b/changes/2489-koxudaxi.md
@@ -1,1 +1,0 @@
-Add `strict` argument to `conbytes`.

--- a/changes/2512-sbv-csis.md
+++ b/changes/2512-sbv-csis.md
@@ -1,2 +1,0 @@
-Add lookahead to ip regexes for `AnyUrl` hosts. This allows urls with DNS labels
-looking like IPs to validate as they are perfectly valid host names.

--- a/changes/2515-PrettyWood.md
+++ b/changes/2515-PrettyWood.md
@@ -1,1 +1,0 @@
-remove side effect of `default_factory` to run it only once even if `Config.validate_all` is set

--- a/changes/2517-peterroelants.md
+++ b/changes/2517-peterroelants.md
@@ -1,1 +1,0 @@
-Documentation update how to custom compile pydantic when using pip install, small change in `setup.py` to allow for custom CFLAGS when compiling.

--- a/changes/2519-daviskirk.md
+++ b/changes/2519-daviskirk.md
@@ -1,1 +1,0 @@
-Allow `collections.abc.Callable` to be used as type in python 3.9.

--- a/changes/2524-cwe5590.md
+++ b/changes/2524-cwe5590.md
@@ -1,1 +1,0 @@
-Enable the Hypothesis plugin to generate a constrained decimal when the `decimal_places` argument is specified.

--- a/changes/2567-postgres-asyncpg.md
+++ b/changes/2567-postgres-asyncpg.md
@@ -1,1 +1,0 @@
-Add `postgresql+asyncpg`, `postgresql+pg8000`, `postgresql+psycopg2`, `postgresql+psycopg2cffi`, `postgresql+py-postgresql` and `postgresql+pygresql` schemes for `PostgresDsn`

--- a/changes/2572-paxcodes.md
+++ b/changes/2572-paxcodes.md
@@ -1,1 +1,0 @@
-Add `__version__` attribute to pydantic module.

--- a/changes/2580-samuelcolvin.md
+++ b/changes/2580-samuelcolvin.md
@@ -1,1 +1,0 @@
-Switch docs preview and coverage display to use [smokeshow](https://smokeshow.helpmanual.io/)

--- a/changes/2707-PrettyWood.md
+++ b/changes/2707-PrettyWood.md
@@ -1,1 +1,0 @@
-fix JSON schema generation when a field is of type `NamedTuple` and has a default value

--- a/changes/2712-RatulMaharaj.md
+++ b/changes/2712-RatulMaharaj.md
@@ -1,1 +1,0 @@
-Add episode 313 of the *Talk Python To Me* podcast, where Michael Kennedy and Samuel Colvin discuss *pydantic*, to the docs.

--- a/changes/2718-nuno-andre.md
+++ b/changes/2718-nuno-andre.md
@@ -1,1 +1,0 @@
-Change `orm_mode` checking to allow recursive ORM mode parsing with dicts.

--- a/changes/2719-PrettyWood.md
+++ b/changes/2719-PrettyWood.md
@@ -1,1 +1,0 @@
-add missing type annotations in `BaseConfig` and handle `max_length = 0`

--- a/changes/2721-tiangolo.md
+++ b/changes/2721-tiangolo.md
@@ -1,1 +1,0 @@
-Add support for autocomplete in VS Code via `__dataclass_transform__`

--- a/changes/2724-shahriyarr.md
+++ b/changes/2724-shahriyarr.md
@@ -1,1 +1,0 @@
-Renamed variable `schema` to `schema_` to avoid shadowing of global variable name.

--- a/changes/2733-krisaoe.md
+++ b/changes/2733-krisaoe.md
@@ -1,2 +1,0 @@
-The colon at the end of the line "The fields which were supplied when user was initialised:" suggests that the code following it is related.
-Changed it to a period.

--- a/changes/2743-uriyyo.md
+++ b/changes/2743-uriyyo.md
@@ -1,1 +1,0 @@
-Fix mypy plugin issue with self field declaration.

--- a/changes/2748-uriyyo.md
+++ b/changes/2748-uriyyo.md
@@ -1,1 +1,0 @@
-Add function overloading for a `pydantic.create_model` function.

--- a/changes/2753-uriyyo.md
+++ b/changes/2753-uriyyo.md
@@ -1,1 +1,0 @@
-Fix bug when `mypy` plugin fails on `construct` method call for `BaseSettings` derived classes.

--- a/changes/2760-jameysharp.md
+++ b/changes/2760-jameysharp.md
@@ -1,1 +1,0 @@
-Fix postponed annotation resolution for `NamedTuple` and `TypedDict` when they're used directly as the type of fields within Pydantic models

--- a/changes/2794-PrettyWood.md
+++ b/changes/2794-PrettyWood.md
@@ -1,1 +1,0 @@
-fix an edge case when mixing constraints and `Literal`

--- a/changes/2810-sergejkozin.md
+++ b/changes/2810-sergejkozin.md
@@ -1,1 +1,0 @@
-Fix schema generation for `Deque` fields

--- a/changes/2855-paxcodes.md
+++ b/changes/2855-paxcodes.md
@@ -1,1 +1,0 @@
-Clarify documentation about _pydantic_'s support for custom validation and strict type checking, despite _pydantic_ being primarily a parsing library.

--- a/changes/2856-paxcodes.md
+++ b/changes/2856-paxcodes.md
@@ -1,1 +1,0 @@
-Update contrib docs re: python version to use for building docs.

--- a/changes/2860-geekingfrog.md
+++ b/changes/2860-geekingfrog.md
@@ -1,1 +1,0 @@
-Correctly parse generic models with `Json[T]`.

--- a/changes/2885-PrettyWood.md
+++ b/changes/2885-PrettyWood.md
@@ -1,1 +1,0 @@
-add python 3.10 support

--- a/changes/2908-jrwalk.md
+++ b/changes/2908-jrwalk.md
@@ -1,1 +1,0 @@
-Make `pydantic-mypy` plugin compatible with `pyproject.toml` configuration, consistent with `mypy` changes. See the [doc](https://pydantic-docs.helpmanual.io/mypy_plugin/#configuring-the-plugin) for more information.

--- a/changes/2913-gbdlin.md
+++ b/changes/2913-gbdlin.md
@@ -1,1 +1,0 @@
-add a dark mode to _pydantic_ documentation

--- a/changes/2929-samuelcolvin.md
+++ b/changes/2929-samuelcolvin.md
@@ -1,1 +1,0 @@
-Prevent `StrictStr` permitting `Enum` values where the enum inherits from `str`.

--- a/changes/2936-cbartz.md
+++ b/changes/2936-cbartz.md
@@ -1,1 +1,0 @@
-Parse environment variables as JSON, if they have a `Union` type with a complex subfield.

--- a/changes/2989-hmvp.md
+++ b/changes/2989-hmvp.md
@@ -1,1 +1,0 @@
-Make multiple inheritance work when using `PrivateAttr`

--- a/changes/3008-PrettyWood.md
+++ b/changes/3008-PrettyWood.md
@@ -1,1 +1,0 @@
-make `create_model_from_typeddict` mypy compliant

--- a/changes/3018-JacobHayes.md
+++ b/changes/3018-JacobHayes.md
@@ -1,1 +1,0 @@
-Fix support for using a subclass of an annotation as a default

--- a/changes/3038-matthewhughes934.md
+++ b/changes/3038-matthewhughes934.md
@@ -1,1 +1,0 @@
-Add a `TypedDict` class for error objects

--- a/changes/3043-zulrang.md
+++ b/changes/3043-zulrang.md
@@ -1,1 +1,0 @@
-Updates pydantic dataclasses to keep _special properties on parent classes

--- a/changes/3062-PrettyWood.md
+++ b/changes/3062-PrettyWood.md
@@ -1,1 +1,0 @@
-add support for `object` type

--- a/changes/3135-PrettyWood.md
+++ b/changes/3135-PrettyWood.md
@@ -1,1 +1,0 @@
-fix `validate_arguments` issue with `Config.validate_all`

--- a/changes/3161-PrettyWood.md
+++ b/changes/3161-PrettyWood.md
@@ -1,1 +1,0 @@
-`validate_arguments` now supports `extra` customization (used to always be `Extra.forbid`)

--- a/changes/3401-uriyyo.md
+++ b/changes/3401-uriyyo.md
@@ -1,1 +1,0 @@
-Fix issue when pydantic fail to parse `typing.ClassVar` string type annotation.

--- a/changes/660-daviskirk.md
+++ b/changes/660-daviskirk.md
@@ -1,1 +1,0 @@
-Add "exclude" as a field parameter so that it can be configured using model config instead of purely at `.dict` / `.json` export time.

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -1,6 +1,6 @@
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '1.8.2'
+VERSION = '1.9.0'
 
 
 def version_info() -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Problem: There's been lots of work done on Pydantic since 1.8.2, and
there hasn't been a release cut for 1.9.0 yet.

Solution: Try to reduce maintainer load by following the '1.8.2 prep'
example to help with the 1.9.0 release.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
See-also: https://github.com/samuelcolvin/pydantic/pull/2780

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
