### PR TITLE
Add optional `field` argument to `__modify_schema__`

### DIFF
--- a/changes/3434-jasujm.md
+++ b/changes/3434-jasujm.md
@@ -1,0 +1,2 @@
+When generating field schema, pass optional `field` argument (of type
+`pydantic.fields.ModelField`) to `__modify_schema__()` if present

--- a/docs/examples/schema_with_field.py
+++ b/docs/examples/schema_with_field.py
@@ -1,0 +1,31 @@
+# output-json
+from typing import Optional
+
+from pydantic import BaseModel, Field
+from pydantic.fields import ModelField
+
+
+class RestrictedAlphabetStr(str):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value, field: ModelField):
+        alphabet = field.field_info.extra['alphabet']
+        if any(c not in alphabet for c in value):
+            raise ValueError(f'{value!r} is not restricted to {alphabet!r}')
+        return cls(value)
+
+    @classmethod
+    def __modify_schema__(cls, field_schema, field: Optional[ModelField]):
+        if field:
+            alphabet = field.field_info.extra['alphabet']
+            field_schema['examples'] = [c * 3 for c in alphabet]
+
+
+class MyModel(BaseModel):
+    value: RestrictedAlphabetStr = Field(alphabet='ABC')
+
+
+print(MyModel.schema_json(indent=2))

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -137,6 +137,21 @@ For versions of Python prior to 3.9, `typing_extensions.Annotated` can be used.
 Custom field types can customise the schema generated for them using the `__modify_schema__` class method;
 see [Custom Data Types](types.md#custom-data-types) for more details.
 
+`__modify_schema__` can also take a `field` argument which will have type `Optional[ModelField]`.
+*pydantic* will inspect the signature of `__modify_schema__` to determine whether the `field` argument should be
+included.
+
+```py
+{!.tmp_examples/schema_with_field.py!}
+```
+_(This script is complete, it should run "as is")_
+
+Outputs:
+
+```json
+{!.tmp_examples/schema_with_field.json!}
+```
+
 ## JSON Schema Types
 
 Types, custom field types, and constraints (like `max_length`) are mapped to the corresponding spec formats in the


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Add optional `field` parameter to `model.__modify_schema__()` to opt in to receiving the `ModelField` object of the field. This makes it possible e.g. for the implementation of `__modify_schema__()` of generic type to know the runtime type of its subfields.

The concept is inspired by the optional parameters in validators, implemented in the `pydantic.class_validators` module. There are some differences:

* Only `field` is supported. `values` does not make sense in this context, since validation deals with concrete *object*, and this with the class itself. Model `config` might be supported, but is not included in this PR.
* `field` is `Optional[ModelField]` as opposed to `ModelField`, unlike validators. This is because the `schema` methods can be used on things that are not model fields, in which case `None` will be passed to as the `field` argument.
* Whereas `class_validators` does plenty of checks on the validator method signature before wrapping it, my implementation simply checks for the presence of `field`, and calls `__modify_schema__()` with or without the `field` parameter. This is because with validators there is separate prepare and execute steps, whereas `__modify_schema__()` is called directly when generating schema. If the signature doesn't match the expected, the error message and stack trace will be clear enough.

## Related issue number

There are multiple requests for this:
* https://github.com/samuelcolvin/pydantic/discussions/2902
* https://github.com/samuelcolvin/pydantic/discussions/3445
* My own [hrefs](https://github.com/jasujm/hrefs) project also uses generic types as model fields and needs to access the field spec to properly generate schema

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100% (expected to pass since actually running on CI is gate keeped)
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
