### PR TITLE
Allow `None` when using a `Union` containing `Any` or `object`

### DIFF
--- a/changes/3444-tharradine.md
+++ b/changes/3444-tharradine.md
@@ -1,0 +1,1 @@
+Fix issue where `None` was considered invalid when using a `Union` type containing `Any` or `object`

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -34,7 +34,6 @@ from .typing import (
     Callable,
     ForwardRef,
     NoArgAnyCallable,
-    NoneType,
     display_as_type,
     get_args,
     get_origin,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -563,10 +563,11 @@ class ModelField(Representation):
         if is_union_origin(origin):
             types_ = []
             for type_ in get_args(self.type_):
-                if type_ is NoneType:
+                if type_ is NoneType or type_ is Any or type_ is object:
                     if self.required is Undefined:
                         self.required = False
                     self.allow_none = True
+                if type_ is NoneType:
                     continue
                 types_.append(type_)
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -563,11 +563,11 @@ class ModelField(Representation):
         if is_union_origin(origin):
             types_ = []
             for type_ in get_args(self.type_):
-                if type_ is NoneType or type_ is Any or type_ is object:
+                if is_none_type(type_) or type_ is Any or type_ is object:
                     if self.required is Undefined:
                         self.required = False
                     self.allow_none = True
-                if type_ is NoneType:
+                if is_none_type(type_):
                     continue
                 types_.append(type_)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -83,6 +83,23 @@ def test_union_int_str():
     ]
 
 
+def test_union_int_any():
+    class Model(BaseModel):
+        v: Union[int, Any]
+
+    m = Model(v=123)
+    assert m.v == 123
+
+    m = Model(v='123')
+    assert m.v == 123
+
+    m = Model(v='foobar')
+    assert m.v == 'foobar'
+
+    m = Model(v=None)
+    assert m.v is None
+
+
 def test_union_priority():
     class ModelOne(BaseModel):
         v: Union[int, str] = ...


### PR DESCRIPTION
## Change Summary

This sets `allow_none` and `required` correctly when `Any` or `Object` are contained in a `Union` type.

## Related issue number

Resolves #3444.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/3444-tharradine.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
