### PR TITLE
allow existing additionalProperties when Config.extra is Extra.forbid

### DIFF
--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -637,7 +637,7 @@ def model_type_schema(
         out_schema = {'type': 'object', 'properties': properties}
         if required:
             out_schema['required'] = required
-    if model.__config__.extra == 'forbid':
+    if model.__config__.extra == 'forbid' and not out_schema['additionalProperties']:
         out_schema['additionalProperties'] = False
     return out_schema, definitions, nested_models
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -637,7 +637,7 @@ def model_type_schema(
         out_schema = {'type': 'object', 'properties': properties}
         if required:
             out_schema['required'] = required
-    if model.__config__.extra == 'forbid' and not out_schema['additionalProperties']:
+    if model.__config__.extra == 'forbid' and not out_schema.get('additionalProperties'):
         out_schema['additionalProperties'] = False
     return out_schema, definitions, nested_models
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2109,6 +2109,7 @@ def test_new_union_origin():
         'required': ['x'],
     }
 
+
 def test_forbid_extra_additionalproperties():
     class ForbiddenConfig:
         extra = Extra.forbid
@@ -2128,7 +2129,7 @@ def test_forbid_extra_additionalproperties():
         class Config(ForbiddenConfig):
             ...
 
-    assert DictModel.schema() == ForbiddenDict.schema()
-    assert Model.schema() != ForbiddenModel.schema()
-    assert ForbiddenModel.schema()["additionalProperties"] is False
-    assert Model.schema().get("additionalProperties") is None
+    assert DictModel.schema()['additionalProperties'] == ForbiddenDict.schema()['additionalProperties']
+    assert Model.schema().get('additionalProperties') != ForbiddenModel.schema()['additionalProperties']
+    assert ForbiddenModel.schema()['additionalProperties'] is False
+    assert Model.schema().get('additionalProperties') is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2108,3 +2108,27 @@ def test_new_union_origin():
         'properties': {'x': {'title': 'X', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
         'required': ['x'],
     }
+
+def test_forbid_extra_additionalproperties():
+    class ForbiddenConfig:
+        extra = Extra.forbid
+
+    class DictModel(BaseModel):
+        __root__: Dict[str, List[int]]
+
+    class ForbiddenDict(DictModel):
+        class Config(ForbiddenConfig):
+            ...
+
+    class Model(BaseModel):
+        some_str: str
+        some_int: int
+
+    class ForbiddenModel(Model):
+        class Config(ForbiddenConfig):
+            ...
+
+    assert DictModel.schema() == ForbiddenDict.schema()
+    assert Model.schema() != ForbiddenModel.schema()
+    assert ForbiddenModel.schema()["additionalProperties"] is False
+    assert Model.schema().get("additionalProperties") is None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Tentative PR for #3505 

Prevents any existing `additionalProperties` schema data from being overwritten when a model has `Config.extra = Extra.forbid`.

## Related issue number

fix #3505 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
