### PR TITLE
chore: add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-yaml
+  - id: end-of-file-fixer
+
+- repo: local
+  hooks:
+  - id: lint
+    name: Lint
+    entry: make lint
+    types: [python]
+    language: system
+  - id: mypy
+    name: Mypy
+    entry: make mypy
+    types: [python]
+    language: system

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ black = black -S -l 120 --target-version py38 pydantic tests
 .PHONY: install-linting
 install-linting:
 	pip install -r tests/requirements-linting.txt
+	pre-commit install
 
 .PHONY: install-pydantic
 install-pydantic:

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -4,7 +4,8 @@ flake8-quotes==3.3.1
 hypothesis==6.30.1
 isort==5.10.1
 mypy==0.910
-types-toml==0.10.1
+pre-commit==2.16.0
 pycodestyle==2.8.0
 pyflakes==2.4.0
 twine==3.7.0
+types-toml==0.10.1


### PR DESCRIPTION
Just a suggestion because quite a lot of PRs have lint issues once pushed. So better run `make lint` automatically

![Screen Shot 2021-12-11 at 8 15 03 PM](https://user-images.githubusercontent.com/18406791/145688855-f211d126-fd1e-4d53-a740-b722b1304382.png)

WDYT @samuelcolvin?