### PR TITLE
generate x86_64 and arm64 binaries to support MacOS M1 CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     needs: [lint, test-linux, test-windows-mac, test-fastapi, benchmark]
-    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
+#    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"  FIXME: uncomment!
     strategy:
       fail-fast: false
       matrix:
@@ -279,6 +279,8 @@ jobs:
         CIBW_TEST_COMMAND: 'pytest {project}/tests'
         CIBW_MANYLINUX_X86_64_IMAGE: 'manylinux2014'
         CIBW_MANYLINUX_I686_IMAGE: 'manylinux2014'
+        CIBW_ARCHS_MACOS: 'x86_64 arm64'
+        CIBW_TEST_SKIP: '*-macosx_arm64'  # see https://cibuildwheel.readthedocs.io/en/stable/faq/#universal2
 
     # TODO build windows 32bit binaries
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     needs: [lint, test-linux, test-windows-mac, test-fastapi, benchmark]
-#    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"  FIXME: uncomment!
+    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
     strategy:
       fail-fast: false
       matrix:

--- a/changes/3498-samuelcolvin.md
+++ b/changes/3498-samuelcolvin.md
@@ -1,0 +1,1 @@
+Add `arm64` binaries suitable for MacOS with an M1 CPU to PyPI


### PR DESCRIPTION
## Change Summary

Add `arm64` binaries suitable for MacOS with an M1 CPU to PyPI.

**Question 1:** does this work? Can someone with an M1 mac please check.

**Question 2:** as per [the docs](https://cibuildwheel.readthedocs.io/en/stable/faq/#universal2) it looks like `x86_64` and `arm64` is correct, would anyone prefer `universal2` as well/instead?

## Related issue number

fix #3498

