### PR TITLE
fix: Raise exception with clearer error message

### DIFF
--- a/changes/3525-aiotter.md
+++ b/changes/3525-aiotter.md
@@ -1,0 +1,1 @@
+When Decimal('infinity') or Decimal('NaN') is being serialized, raise `TypeError: Decimal('Infinity') is not JSON serializable` instead of `TypeError: '>=' not supported between instances of 'str' and 'int'`.

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -42,6 +42,9 @@ def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
     >>> decimal_encoder(Decimal("1"))
     1
     """
+    if not dec_value.is_finite():
+        raise TypeError(f"{dec_value!r} is not JSON serializable")
+
     if dec_value.as_tuple().exponent >= 0:
         return int(dec_value)
     else:

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -43,7 +43,7 @@ def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
     1
     """
     if not dec_value.is_finite():
-        raise TypeError(f"{dec_value!r} is not JSON serializable")
+        raise TypeError(f'{dec_value!r} is not JSON serializable')
 
     if dec_value.as_tuple().exponent >= 0:
         return int(dec_value)


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Error message will be clear.

When Decimal('infinity') or Decimal('NaN') is being serialized,  raise `TypeError: Decimal('Infinity') is not JSON serializable` instead of current `TypeError: '>=' not supported between instances of 'str' and 'int'`.

## Related issue number
Nothing

## Checklist

* ~~[ ] Unit tests for the changes exist~~  I don't think unit test for this PR is needed because tests for proper decimal values already exist.
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
