### PR TITLE
Remove `__root__` from BaseModel typing-only attrs

### DIFF
--- a/changes/3540-layday.md
+++ b/changes/3540-layday.md
@@ -1,0 +1,1 @@
+Removed typing-only `__root__` attribute from `BaseModel`

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -306,7 +306,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         __pre_root_validators__: ClassVar[List[AnyCallable]]
         __post_root_validators__: ClassVar[List[Tuple[bool, AnyCallable]]]
         __config__: ClassVar[Type[BaseConfig]] = BaseConfig
-        __root__: ClassVar[Any] = None
         __json_encoder__: ClassVar[Callable[[Any], Any]] = lambda x: x
         __schema_cache__: ClassVar['DictAny'] = {}
         __custom_root_type__: ClassVar[bool] = False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

`__root__` is not a class variable nor is it always present.

The switch to `ClassVar` caused type errors to be reported in Pylance/Pyright.

<!-- Please give a short summary of the changes. -->

## Related issue number

—

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
