### PR TITLE
fix: keep old behaviour of `json()` by default

### DIFF
--- a/docs/examples/exporting_models_json_forward_ref.py
+++ b/docs/examples/exporting_models_json_forward_ref.py
@@ -31,4 +31,4 @@ wolfgang = User(
         User(name='John', address=Address(city='London', country='UK')),
     ],
 )
-print(wolfgang.json())
+print(wolfgang.json(models_as_dict=False))

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -109,6 +109,9 @@ _(This script is complete, it should run "as is")_
 
 ### Serialising self-reference or other models
 
+By default, models are serialised as dictionaries.
+If you want to serialise them differently, you can add `models_as_dict=False` when calling `json()` method
+and add the classes of the model in `json_encoders`.
 In case of forward references, you can use a string with the class name instead of the class itself
 ```py
 {!.tmp_examples/exporting_models_json_forward_ref.py!}

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -454,7 +454,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
-        to_dict: bool = True,
+        models_as_dict: bool = True,
         **dumps_kwargs: Any,
     ) -> str:
         """
@@ -475,7 +475,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         # This allows users to write custom JSON encoders for given `BaseModel` classes.
         data = dict(
             self._iter(
-                to_dict=to_dict,
+                to_dict=models_as_dict,
                 by_alias=by_alias,
                 include=include,
                 exclude=exclude,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -454,6 +454,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
+        to_dict: bool = True,
         **dumps_kwargs: Any,
     ) -> str:
         """
@@ -469,11 +470,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             exclude_unset = skip_defaults
         encoder = cast(Callable[[Any], Any], encoder or self.__json_encoder__)
 
-        # We don't directly call `self.dict()`, which does exactly the same thing but
-        # with `to_dict = True` because we want to keep raw `BaseModel` instances and not as `dict`.
+        # We don't directly call `self.dict()`, which is does exactly this with `to_dict=True`
+        # because we want to be able to keep raw `BaseModel` instances and not as `dict`.
         # This allows users to write custom JSON encoders for given `BaseModel` classes.
         data = dict(
             self._iter(
+                to_dict=to_dict,
                 by_alias=by_alias,
                 include=include,
                 exclude=exclude,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -470,7 +470,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             exclude_unset = skip_defaults
         encoder = cast(Callable[[Any], Any], encoder or self.__json_encoder__)
 
-        # We don't directly call `self.dict()`, which is does exactly this with `to_dict=True`
+        # We don't directly call `self.dict()`, which does exactly this with `to_dict=True`
         # because we want to be able to keep raw `BaseModel` instances and not as `dict`.
         # This allows users to write custom JSON encoders for given `BaseModel` classes.
         data = dict(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -281,7 +281,7 @@ def test_custom_decode_encode():
     assert m.json() == '{\n  "a": 1,\n  "b": "foo"\n}'
 
 
-def test_json_nested_encode():
+def test_json_nested_encode_models():
     class Phone(BaseModel):
         manufacturer: str
         number: int
@@ -314,11 +314,15 @@ def test_json_nested_encode():
 
     timon.friend = pumbaa
 
-    assert iphone.json() == '{"manufacturer": "Apple", "number": 18002752273}'
+    assert iphone.json(models_as_dict=False) == '{"manufacturer": "Apple", "number": 18002752273}'
     assert (
-        pumbaa.json() == '{"name": "Pumbaa", "SSN": 234, "birthday": 737424000.0, "phone": 18007267864, "friend": null}'
+        pumbaa.json(models_as_dict=False)
+        == '{"name": "Pumbaa", "SSN": 234, "birthday": 737424000.0, "phone": 18007267864, "friend": null}'
     )
-    assert timon.json() == '{"name": "Timon", "SSN": 123, "birthday": 738892800.0, "phone": 18002752273, "friend": 234}'
+    assert (
+        timon.json(models_as_dict=False)
+        == '{"name": "Timon", "SSN": 123, "birthday": 738892800.0, "phone": 18002752273, "friend": 234}'
+    )
 
 
 def test_custom_encode_fallback_basemodel():
@@ -357,3 +361,11 @@ def test_custom_encode_error():
 
     with pytest.raises(TypeError, match='not serialisable'):
         Foo(x=MyExoticType()).json(encoder=custom_encoder)
+
+
+def test_recursive():
+    class Model(BaseModel):
+        value: Optional[str]
+        nested: Optional[BaseModel]
+
+    assert Model(value=None, nested=Model(value=None)).json(exclude_none=True) == '{"nested": {}}'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
fix regression on 1.9 introduced in #2650 (see https://github.com/samuelcolvin/pydantic/discussions/3538#discussioncomment-1843005)

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] ~Documentation reflects the changes where applicable~
* [ ] ~`changes/<pull request or issue id>-<github username>.md` file added describing change~ (I didn't add a change file since it's due to a new feature of 1.9)
~(see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)~
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
