### PR TITLE
fix for issue #2581

### DIFF
--- a/changes/2581-MaratBR.md
+++ b/changes/2581-MaratBR.md
@@ -1,0 +1,2 @@
+Fixes [#2581](/samuelcolvin/pydantic/issues/2581). Using constraints such as `gt` or `le`
+no longer raises `ValueError` due to unenforced constraint.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -526,7 +526,7 @@ class ModelField(Representation):
         e.g. calling it it multiple times may modify the field and configure it incorrectly.
         """
         self._set_default_and_type()
-        if self.type_.__class__ is ForwardRef or self.type_.__class__ is DeferredType:
+        if self.type_.__class__ is ForwardRef or self.type_ is DeferredType:
             # self.type_ is currently a ForwardRef and there's nothing we can do now,
             # user will need to call model.update_forward_refs()
             return
@@ -734,7 +734,7 @@ class ModelField(Representation):
         """
         assert self.discriminator_key is not None
 
-        if self.type_.__class__ is DeferredType:
+        if self.type_ is DeferredType:
             return
 
         assert self.sub_fields is not None
@@ -823,7 +823,7 @@ class ModelField(Representation):
         self, v: Any, values: Dict[str, Any], *, loc: 'LocStr', cls: Optional['ModelOrDc'] = None
     ) -> 'ValidateReturn':
 
-        assert self.type_.__class__ is not DeferredType
+        assert self.type_ is not DeferredType
 
         if self.type_.__class__ is ForwardRef:
             assert cls is not None


### PR DESCRIPTION
## Change Summary
Modifies `get_annotation_with_constraints` so it will return all constraints for `DeferredType` or `TypeVar` as "used" to avoid "constraints are set but not enforced" error. 
`DeferredType` is now used directly rather than being constructed (i.e. `DeferredType` instead of `DeferredType()`). 

## Related issue number
fix #2581 
fix #3358 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
