### PR TITLE
Support mypy 0.910 to 0.930 including CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,52 @@ jobs:
         name: coverage
         path: coverage
 
+  test-old-mypy:
+    name: test mypy v${{ matrix.mypy-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mypy-version: ['0.910', '0.920', '0.921']
+    env:
+      PYTHON: '3.10'
+      OS: linux
+      COMPILED: no
+      DEPS: yes
+      MYPY: ${{ matrix.mypy-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: install
+      run: |
+        make install-testing
+        pip freeze
+
+    - name: install specific mypy version
+      run: pip install mypy==${{ matrix.mypy-version }}
+
+    - run: mkdir coverage
+
+    - name: run tests
+      run: make test
+      env:
+        COVERAGE_FILE: coverage/.coverage.linux-py3.10-mypy${{ matrix.mypy-version }}
+        CONTEXT: linux-py3.10-mypy${{ matrix.mypy-version }}
+
+    - name: store coverage files
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage
+
   coverage-combine:
-    needs: [test-linux, test-windows-mac]
+    needs: [test-linux, test-windows-mac, test-old-mypy]
     runs-on: ubuntu-latest
 
     steps:
@@ -236,7 +280,7 @@ jobs:
 
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
-    needs: [lint, test-linux, test-windows-mac, test-fastapi, benchmark]
+    needs: [lint, test-linux, test-windows-mac, test-old-mypy, test-fastapi, benchmark]
     if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
         make install-testing
         pip freeze
 
+    - name: uninstall deps
+      run: pip uninstall -y mypy tomli toml
+
     - name: install specific mypy version
       run: pip install mypy==${{ matrix.mypy-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     - run: mkdir coverage
 
     - name: run tests
-      run: make test
+      run: pytest --cov=pydantic tests/mypy
       env:
         COVERAGE_FILE: coverage/.coverage.linux-py3.10-mypy${{ matrix.mypy-version }}
         CONTEXT: linux-py3.10-mypy${{ matrix.mypy-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       COMPILED: no
       DEPS: yes
 
-    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2
 
@@ -171,12 +171,6 @@ jobs:
       fail-fast: false
       matrix:
         mypy-version: ['0.910', '0.920', '0.921']
-    env:
-      PYTHON: '3.10'
-      OS: linux
-      COMPILED: no
-      DEPS: yes
-      MYPY: ${{ matrix.mypy-version }}
 
     steps:
     - uses: actions/checkout@v2
@@ -293,7 +287,7 @@ jobs:
         - os: windows
           ls: dir
 
-    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/docs/mypy_plugin.md
+++ b/docs/mypy_plugin.md
@@ -86,6 +86,8 @@ To get started, all you need to do is create a `mypy.ini` file with following co
 plugins = pydantic.mypy
 ```
 
+The plugin is compatible with mypy versions 0.910, 0.920, 0.921 and 0.930.
+
 See the [mypy usage](usage/mypy.md) and [plugin configuration](#configuring-the-plugin) docs for more details.
 
 ### Plugin Settings

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -9,6 +9,9 @@ from .errors import ConfigError
 from .typing import AnyCallable
 from .utils import ROOT_KEY, in_ipython
 
+if TYPE_CHECKING:
+    from .typing import AnyClassMethod
+
 
 class Validator:
     __slots__ = 'func', 'pre', 'each_item', 'always', 'check_fields', 'skip_on_failure'
@@ -54,7 +57,7 @@ def validator(
     check_fields: bool = True,
     whole: bool = None,
     allow_reuse: bool = False,
-) -> Callable[[AnyCallable], classmethod]:  # type: ignore[type-arg]
+) -> Callable[[AnyCallable], 'AnyClassMethod']:
     """
     Decorate methods on the class indicating that they should be used to validate fields
     :param fields: which field(s) the method should be called on
@@ -81,7 +84,7 @@ def validator(
         assert each_item is False, '"each_item" and "whole" conflict, remove "whole"'
         each_item = not whole
 
-    def dec(f: AnyCallable) -> classmethod:  # type: ignore[type-arg]
+    def dec(f: AnyCallable) -> 'AnyClassMethod':
         f_cls = _prepare_validator(f, allow_reuse)
         setattr(
             f_cls,
@@ -97,20 +100,20 @@ def validator(
 
 
 @overload
-def root_validator(_func: AnyCallable) -> classmethod:  # type: ignore[type-arg]
+def root_validator(_func: AnyCallable) -> 'AnyClassMethod':
     ...
 
 
 @overload
 def root_validator(
     *, pre: bool = False, allow_reuse: bool = False, skip_on_failure: bool = False
-) -> Callable[[AnyCallable], classmethod]:  # type: ignore[type-arg]
+) -> Callable[[AnyCallable], 'AnyClassMethod']:
     ...
 
 
 def root_validator(
     _func: Optional[AnyCallable] = None, *, pre: bool = False, allow_reuse: bool = False, skip_on_failure: bool = False
-) -> Union[classmethod, Callable[[AnyCallable], classmethod]]:  # type: ignore[type-arg]
+) -> Union['AnyClassMethod', Callable[[AnyCallable], 'AnyClassMethod']]:
     """
     Decorate methods on a model indicating that they should be used to validate (and perhaps modify) data either
     before or after standard model parsing/validation is performed.
@@ -122,7 +125,7 @@ def root_validator(
         )
         return f_cls
 
-    def dec(f: AnyCallable) -> classmethod:  # type: ignore[type-arg]
+    def dec(f: AnyCallable) -> 'AnyClassMethod':
         f_cls = _prepare_validator(f, allow_reuse)
         setattr(
             f_cls, ROOT_VALIDATOR_CONFIG_KEY, Validator(func=f_cls.__func__, pre=pre, skip_on_failure=skip_on_failure)
@@ -132,7 +135,7 @@ def root_validator(
     return dec
 
 
-def _prepare_validator(function: AnyCallable, allow_reuse: bool) -> classmethod:  # type: ignore[type-arg]
+def _prepare_validator(function: AnyCallable, allow_reuse: bool) -> 'AnyClassMethod':
     """
     Avoid validators with duplicated names since without this, validators can be overwritten silently
     which generally isn't the intended behaviour, don't run in ipython (see #312) or if allow_reuse is False.
@@ -325,7 +328,7 @@ def _generic_validator_basic(validator: AnyCallable, sig: 'Signature', args: Set
         return lambda cls, v, values, field, config: validator(v, values=values, field=field, config=config)
 
 
-def gather_all_validators(type_: 'ModelOrDc') -> Dict[str, classmethod]:  # type: ignore[type-arg]
+def gather_all_validators(type_: 'ModelOrDc') -> Dict[str, 'AnyClassMethod']:
     all_attributes = ChainMap(*[cls.__dict__ for cls in type_.__mro__])
     return {
         k: v

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from .types import ModelOrDc
     from .typing import (
         AbstractSetIntStr,
+        AnyClassMethod,
         CallableGenerator,
         DictAny,
         DictStrAny,
@@ -890,7 +891,7 @@ def create_model(
     __config__: Optional[Type[BaseConfig]] = None,
     __base__: None = None,
     __module__: str = __name__,
-    __validators__: Dict[str, classmethod] = None,  # type: ignore[type-arg]
+    __validators__: Dict[str, 'AnyClassMethod'] = None,
     **field_definitions: Any,
 ) -> Type['BaseModel']:
     ...
@@ -903,7 +904,7 @@ def create_model(
     __config__: Optional[Type[BaseConfig]] = None,
     __base__: Union[Type['Model'], Tuple[Type['Model'], ...]],
     __module__: str = __name__,
-    __validators__: Dict[str, classmethod] = None,  # type: ignore[type-arg]
+    __validators__: Dict[str, 'AnyClassMethod'] = None,
     **field_definitions: Any,
 ) -> Type['Model']:
     ...
@@ -915,7 +916,7 @@ def create_model(
     __config__: Optional[Type[BaseConfig]] = None,
     __base__: Union[None, Type['Model'], Tuple[Type['Model'], ...]] = None,
     __module__: str = __name__,
-    __validators__: Dict[str, classmethod] = None,  # type: ignore[type-arg]
+    __validators__: Dict[str, 'AnyClassMethod'] = None,
     **field_definitions: Any,
 ) -> Type['Model']:
     """

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -724,12 +724,12 @@ def parse_toml(config_file: str) -> Optional[Dict[str, Any]]:
     read_mode = 'rb'
     try:
         import tomli as toml_
-    except ImportError:  # pragma: no cover
+    except ImportError:
         # older versions of mypy have toml as a dependency, not tomli
         read_mode = 'r'
         try:
             import toml as toml_  # type: ignore[no-redef]
-        except ImportError:
+        except ImportError:  # pragma: no cover
             import warnings
 
             warnings.warn('No TOML parser installed, cannot read configuration from `pyproject.toml`.')

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -1,8 +1,6 @@
 from configparser import ConfigParser
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type as TypingType, Union
 
-from pydantic.utils import is_valid_field
-
 from mypy.errorcodes import ErrorCode
 from mypy.nodes import (
     ARG_NAMED,
@@ -55,6 +53,8 @@ from mypy.types import (
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
+
+from pydantic.utils import is_valid_field
 
 try:
     from mypy.types import TypeVarDef  # type: ignore[attr-defined]
@@ -731,6 +731,7 @@ def parse_toml(config_file: str) -> Optional[Dict[str, Any]]:
             import toml as toml_  # type: ignore[no-redef]
         except ImportError:
             import warnings
+
             warnings.warn('No TOML parser installed, cannot read configuration from `pyproject.toml`.')
             return None
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -228,6 +228,7 @@ if TYPE_CHECKING:
     MappingIntStrAny = Mapping[IntStr, Any]
     CallableGenerator = Generator[AnyCallable, None, None]
     ReprArgs = Sequence[Tuple[Optional[str], Any]]
+    AnyClassMethod = classmethod[Any]
 
 __all__ = (
     'ForwardRef',
@@ -258,6 +259,7 @@ __all__ = (
     'DictIntStrAny',
     'CallableGenerator',
     'ReprArgs',
+    'AnyClassMethod',
     'CallableGenerator',
     'WithArgsTypes',
     'get_args',

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -574,7 +574,8 @@ class ValueItems(Representation):
         elif isinstance(items, AbstractSet):
             items = dict.fromkeys(items, ...)
         else:
-            raise TypeError(f'Unexpected type of exclude value {items.__class__}')  # type: ignore[attr-defined]
+            class_name = getattr(items, '__class__', '???')
+            raise TypeError(f'Unexpected type of exclude value {class_name}')
         return items
 
     @classmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,3 +76,6 @@ ignore_missing_imports = true
 
 [mypy-dotenv]
 ignore_missing_imports = true
+
+[mypy-toml]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,5 +74,8 @@ disallow_untyped_defs = True
 [mypy-email_validator]
 ignore_missing_imports = true
 
+[mypy-dotenv]
+ignore_missing_imports = true
+
 [mypy-toml]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,8 +74,5 @@ disallow_untyped_defs = True
 [mypy-email_validator]
 ignore_missing_imports = true
 
-[mypy-dotenv]
-ignore_missing_imports = true
-
 [mypy-toml]
 ignore_missing_imports = true

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -7,8 +7,10 @@ import pytest
 
 try:
     from mypy import api as mypy_api
+    from mypy.version import __version__ as mypy_version
 except ImportError:
     mypy_api = None  # type: ignore
+    mypy_version = '0'
 
 try:
     import dotenv
@@ -72,6 +74,15 @@ def test_mypy_results(config_filename: str, python_filename: str, output_filenam
         raise RuntimeError(f'wrote actual output to {output_path} since file did not exist')
 
     expected_out = Path(output_path).read_text() if output_path else ''
+
+    # fix for compatibility between mypy versions: (this can be dropped once we drop support for mypy<0.930)
+    if actual_out and float(mypy_version) < 0.930:
+        actual_out = actual_out.lower()
+        expected_out = expected_out.lower()
+        actual_out = actual_out.replace('variant:', 'variants:')
+        actual_out = re.sub(r'^(\d+: note: {4}).*', r'\1...', actual_out, flags=re.M)
+        expected_out = re.sub(r'^(\d+: note: {4}).*', r'\1...', expected_out, flags=re.M)
+
     assert actual_out == expected_out, actual_out
 
 

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -8,4 +8,3 @@ pre-commit==2.16.0
 pycodestyle==2.8.0
 pyflakes==2.4.0
 twine==3.7.1
-types-toml==0.10.1


### PR DESCRIPTION
Some cleanup from #3573, also stealing logic from #3572.

I normally don't think changing the versions of mypy which the plugin is compatible with would be a problem in a minor release, but since we've already made two beta release of v1.9, breaking mypy compatibility now would be ugly.