### PR TITLE
apply `update_forward_refs` to `json_encoders`

### DIFF
--- a/changes/3583-samuelcolvin.md
+++ b/changes/3583-samuelcolvin.md
@@ -1,0 +1,1 @@
+Apply `update_forward_refs` to `Config.json_encodes` prevent name clashes in types defined via strings.

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -2,6 +2,7 @@ import json
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Union
 
+from .typing import AnyCallable
 from .utils import GetterDict
 
 if TYPE_CHECKING:
@@ -11,7 +12,6 @@ if TYPE_CHECKING:
 
     from .fields import ModelField
     from .main import BaseModel
-    from .typing import AnyCallable, ForwardRef
 
     ConfigType = Type['BaseConfig']
 
@@ -59,8 +59,8 @@ class BaseConfig:
     schema_extra: Union[Dict[str, Any], 'SchemaExtraCallable'] = {}
     json_loads: Callable[[str], Any] = json.loads
     json_dumps: Callable[..., str] = json.dumps
-    # type hint has to be a comment until we drop support for py3.6 due to ForwardRef
-    json_encoders: 'Dict[Union[Type[Any], str, ForwardRef], AnyCallable]' = {}
+    # key type should include ForwardRef, but that breaks with python3.6
+    json_encoders: Dict[Union[Type[Any], str], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
 
     # whether inherited models as fields should be reconstructed as base model

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Union
 
-from .typing import AnyCallable
+from .typing import AnyCallable, ForwardRef
 from .utils import GetterDict
 
 if TYPE_CHECKING:
@@ -59,7 +59,7 @@ class BaseConfig:
     schema_extra: Union[Dict[str, Any], 'SchemaExtraCallable'] = {}
     json_loads: Callable[[str], Any] = json.loads
     json_dumps: Callable[..., str] = json.dumps
-    json_encoders: Dict[Type[Any], AnyCallable] = {}
+    json_encoders: Dict[Union[Type[Any], str, ForwardRef], AnyCallable] = {}
     underscore_attrs_are_private: bool = False
 
     # whether inherited models as fields should be reconstructed as base model

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -2,7 +2,6 @@ import json
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Union
 
-from .typing import AnyCallable, ForwardRef
 from .utils import GetterDict
 
 if TYPE_CHECKING:
@@ -12,6 +11,7 @@ if TYPE_CHECKING:
 
     from .fields import ModelField
     from .main import BaseModel
+    from .typing import AnyCallable, ForwardRef
 
     ConfigType = Type['BaseConfig']
 
@@ -59,7 +59,8 @@ class BaseConfig:
     schema_extra: Union[Dict[str, Any], 'SchemaExtraCallable'] = {}
     json_loads: Callable[[str], Any] = json.loads
     json_dumps: Callable[..., str] = json.dumps
-    json_encoders: Dict[Union[Type[Any], str, ForwardRef], AnyCallable] = {}
+    # type hint has to be a comment until we drop support for py3.6 due to ForwardRef
+    json_encoders: 'Dict[Union[Type[Any], str, ForwardRef], AnyCallable]' = {}
     underscore_attrs_are_private: bool = False
 
     # whether inherited models as fields should be reconstructed as base model

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -103,10 +103,7 @@ def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]]
         try:
             encoder = type_encoders[base]
         except KeyError:
-            try:
-                encoder = type_encoders[base.__name__]
-            except KeyError:
-                continue
+            continue
 
         return encoder(obj)
     else:  # We have exited the for loop without finding a suitable encoder

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -769,14 +769,14 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         Same as update_forward_refs but will not raise exception
         when forward references are not defined.
         """
-        update_model_forward_refs(cls, cls.__fields__.values(), {}, (NameError,))
+        update_model_forward_refs(cls, cls.__fields__.values(), cls.__config__.json_encoders, {}, (NameError,))
 
     @classmethod
     def update_forward_refs(cls, **localns: Any) -> None:
         """
         Try to update ForwardRefs on fields based on this Model, globalns and localns.
         """
-        update_model_forward_refs(cls, cls.__fields__.values(), localns)
+        update_model_forward_refs(cls, cls.__fields__.values(), cls.__config__.json_encoders, localns)
 
     def __iter__(self) -> 'TupleGenerator':
         """

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -489,7 +489,7 @@ def update_model_forward_refs(
 
         try:
             new_key = evaluate_forwardref(fr, globalns, localns or None)
-        except exc_to_suppress:
+        except exc_to_suppress:  # pragma: no cover
             continue
 
         json_encoders[new_key] = json_encoders.pop(key)

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -459,7 +459,7 @@ def update_field_forward_refs(field: 'ModelField', globalns: Any, localns: Any) 
 def update_model_forward_refs(
     model: Type[Any],
     fields: Iterable['ModelField'],
-    json_encoders: Dict[Union[Type[Any], str, ForwardRef], AnyCallable],
+    json_encoders: Dict[Union[Type[Any], str], AnyCallable],
     localns: 'DictStrAny',
     exc_to_suppress: Tuple[Type[BaseException], ...] = (),
 ) -> None:

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -459,6 +459,7 @@ def update_field_forward_refs(field: 'ModelField', globalns: Any, localns: Any) 
 def update_model_forward_refs(
     model: Type[Any],
     fields: Iterable['ModelField'],
+    json_encoders: Dict[Union[Type[Any], str, ForwardRef], AnyCallable],
     localns: 'DictStrAny',
     exc_to_suppress: Tuple[Type[BaseException], ...] = (),
 ) -> None:
@@ -477,6 +478,21 @@ def update_model_forward_refs(
             update_field_forward_refs(f, globalns=globalns, localns=localns)
         except exc_to_suppress:
             pass
+
+    for key in set(json_encoders.keys()):
+        if isinstance(key, str):
+            fr: ForwardRef = ForwardRef(key)
+        elif isinstance(key, ForwardRef):
+            fr = key
+        else:
+            continue
+
+        try:
+            new_key = evaluate_forwardref(fr, globalns, localns or None)
+        except exc_to_suppress:
+            continue
+
+        json_encoders[new_key] = json_encoders.pop(key)
 
 
 def get_class(type_: Type[Any]) -> Union[None, bool, Type[Any]]:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -650,7 +650,7 @@ class User(BaseModel):
 class Model(BaseModel):
     foo_user: FooUser
     user: User
-    
+
     class Config:
         json_encoders = {
             'User': lambda v: f'User({v.y})',


### PR DESCRIPTION
## Change Summary

Apply `update_forward_refs` to `Config.json_encodes` prevent name clashes in types defined via strings.

## Related issue number

fix #3583

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
