### PR TITLE
Guard default object dict() from list of dictionaries

### DIFF
--- a/changes/3614-mkromer-tc.md
+++ b/changes/3614-mkromer-tc.md
@@ -1,0 +1,11 @@
+# Fix 3614
+
+Insert `_guard_list_of_dicts()` as a guard point against trying
+to instantiate a dict() of a list of dictionaries, which will inevitably give
+incorrect results.
+
+Python will convert `dict([{'key_a': 'value_a', 'key_b': 'value_b'}])` to `{'key_a': 'key_b'}`
+but because the conversion succeeds (albeit with incorrect results) it is impossible to allow
+model fields of the type `Union[Thing, List[Thing]]` whereas `Union[List[Thing], Thing]` works as
+expected.  Raising an exception when trying to perform a `dict()` operation on a list of
+dictionaries allows both forms to work.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -103,6 +103,9 @@ def __dataclass_transform__(
 ) -> Callable[[_T], _T]:
     return lambda a: a
 
+def _guard_list_of_dicts(obj: Any) -> bool:
+    if obj and isinstance(obj, (list, tuple)) and isinstance(obj[0], dict):
+        raise ValueError('List of dictionaries as an input will return invalid results')
 
 def validate_custom_root_type(fields: Dict[str, ModelField]) -> None:
     if len(fields) > 1:
@@ -504,6 +507,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         obj = cls._enforce_dict_if_root(obj)
         if not isinstance(obj, dict):
             try:
+                _guard_list_of_dicts(obj)
                 obj = dict(obj)
             except (TypeError, ValueError) as e:
                 exc = TypeError(f'{cls.__name__} expected dict not {obj.__class__.__name__}')
@@ -678,6 +682,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             return cls.from_orm(value)
         else:
             try:
+                _guard_list_of_dicts(value)
                 value_as_dict = dict(value)
             except (TypeError, ValueError) as e:
                 raise DictError() from e

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@ from collections import deque
 from datetime import datetime
 from enum import Enum
 from itertools import product
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 from typing_extensions import Literal
@@ -1301,3 +1301,23 @@ def test_overridden_root_validators(mocker):
 
     B(x='pika')
     assert validate_stub.call_args_list == [mocker.call('B', 'pre'), mocker.call('B', 'post')]
+
+
+def test_union_list_of_dicts():
+    class KV(BaseModel):
+        key: str
+        type: Optional[str]
+        value: Any
+    
+    class TestModel(BaseModel):
+        input_1: Union[KV, List[KV]]
+        input_2: Union[List[KV], KV]
+    
+    data = [
+        {"key": "key_a", "value": "value_a"},
+        {"key": "key_b", "value": "value_b"},
+    ]
+
+    tm = TestModel(input_1 = data, input_2 = data)
+
+    assert tm.input_1 == tm.input_2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Guard use of `dict()` such that if the input to dict is a *list of dictionaries* a ValueError is raised, rather than allow
dict to construct a new dictionary based on the keys of element 0 which yields incorrect results.

## Related issue number

fix #3614 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
