### PR TITLE
CentOS 7: `read_text(encoding='utf-8')`

### DIFF
--- a/changes/3625-read_text-encoding-utf-8.md
+++ b/changes/3625-read_text-encoding-utf-8.md
@@ -1,0 +1,1 @@
+Add `read_text(encoding='utf-8')` for `setup.py`

--- a/setup.py
+++ b/setup.py
@@ -59,12 +59,12 @@ class ReplaceLinks:
 description = 'Data validation and settings management using python type hints'
 THIS_DIR = Path(__file__).resolve().parent
 try:
-    history = (THIS_DIR / 'HISTORY.md').read_text()
+    history = (THIS_DIR / 'HISTORY.md').read_text(encoding='utf-8')
     history = re.sub(r'#(\d+)', r'[#\1](https://github.com/samuelcolvin/pydantic/issues/\1)', history)
     history = re.sub(r'( +)@([\w\-]+)', r'\1[@\2](https://github.com/\2)', history, flags=re.I)
     history = re.sub('@@', '@', history)
 
-    long_description = (THIS_DIR / 'README.md').read_text() + '\n\n' + history
+    long_description = (THIS_DIR / 'README.md').read_text(encoding='utf-8') + '\n\n' + history
 except FileNotFoundError:
     long_description = description + '.\n\nSee https://pydantic-docs.helpmanual.io/ for documentation.'
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

With CentOS 7 Python 3.6, running install from source with pip failed:

    sudo podman run -ti --rm centos:7
    yum -y update
    yum -y install epel-release
    yum -y install git python3 python3-devel python3-pip python3-setuptools python3-wheel
    git clone https://github.com/samuelcolvin/pydantic.git
    cd pydantic
    pip3 install .

With following error message:

    [root@c99d0585636c pydantic]# pip3 install .
    Processing /pydantic
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/tmp/pip-91v_ixvz-build/setup.py", line 62, in <module>
            history = (THIS_DIR / 'HISTORY.md').read_text()
          File "/usr/lib64/python3.6/pathlib.py", line 1197, in read_text
            return f.read()
          File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
            return codecs.ascii_decode(input, self.errors)[0]
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 14648: ordinal not in range(128)

        ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-91v_ixvz-build/

This PR add the required `read_text(encoding='utf-8')` for `setup.py`.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
