### PR TITLE
fix: `Config.copy_on_model_validation` does a deep copy and not a shallow one

### DIFF
--- a/changes/3641-PrettyWood.md
+++ b/changes/3641-PrettyWood.md
@@ -1,0 +1,1 @@
+`Config.copy_on_model_validation\` does a deep copy and not a shallow one

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -666,7 +666,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
     def validate(cls: Type['Model'], value: Any) -> 'Model':
         if isinstance(value, cls):
             if cls.__config__.copy_on_model_validation:
-                return value._copy_and_set_values(value.__dict__, value.__fields_set__, deep=False)
+                return value._copy_and_set_values(value.__dict__, value.__fields_set__, deep=True)
             else:
                 return value
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1561,10 +1561,26 @@ def test_model_exclude_copy_on_model_validation():
 
     assert t.user is not my_user
     assert t.user.hobbies == ['scuba diving']
-    assert t.user.hobbies is my_user.hobbies  # `Config.copy_on_model_validation` only does a shallow copy
+    assert t.user.hobbies is not my_user.hobbies  # `Config.copy_on_model_validation` does a deep copy
     assert t.user._priv == 13
     assert t.user.password.get_secret_value() == 'hashedpassword'
     assert t.dict() == {'id': '1234567890', 'user': {'id': 42, 'hobbies': ['scuba diving']}}
+
+
+def test_validation_deep_copy():
+    """By default, Config.copy_on_model_validation should do a deep copy"""
+
+    class A(BaseModel):
+        name: str
+
+    class B(BaseModel):
+        list_a: List[A]
+
+    a = A(name='a')
+    b = B(list_a=[a])
+    assert b.list_a == [A(name='a')]
+    a.name = 'b'
+    assert b.list_a == [A(name='a')]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Regression introduced in https://github.com/samuelcolvin/pydantic/pull/3201.
`Config.copy_on_model_validation` used to do in fact a deep copy because we used to call `Model.dict()` and then do a shallow copy. Now that we use directly `.__dict__`, we should do a deep one
<!-- Please give a short summary of the changes. -->

## Related issue number
closes #3641
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
