### PR TITLE
Fix fastAPI tests workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
     - name: set up python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.10'
 
     - name: install
       run: make install-testing

--- a/changes/3684-dolfinus.md
+++ b/changes/3684-dolfinus.md
@@ -1,0 +1,1 @@
+Update fastAPI tests Python version to 3.10


### PR DESCRIPTION
## Change Summary

After https://github.com/tiangolo/fastapi/pull/3712 CI workflow `test fastAPI` started constantly failing:
https://github.com/dolfinus/pydantic/runs/4766269380?check_suite_focus=true
```
============================= test session starts ==============================
platform linux -- Python 3.7.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/runner/work/pydantic/pydantic/fastapi, configfile: pyproject.toml
plugins: anyio-3.4.0, sugar-0.9.4, hypothesis-6.31.6, cov-3.0.0, mock-3.6.1
collected 1244 items / 3 errors / 1241 selected

==================================== ERRORS ====================================
________ ERROR collecting docs_src/app_testing/app_b_py310/test_main.py ________
docs_src/app_testing/app_b_py310/test_main.py:3: in <module>
    from .main import app
docs_src/app_testing/app_b_py310/main.py:14: in <module>
    class Item(BaseModel):
docs_src/app_testing/app_b_py310/main.py:17: in Item
    description: str | None = None
E   TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
_ ERROR collecting docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py __
docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py:6: in <module>
    from ..main import app, get_db
docs_src/sql_databases/sql_app_py310/main.py:4: in <module>
    from . import crud, models, schemas
docs_src/sql_databases/sql_app_py310/crud.py:3: in <module>
    from . import models, schemas
docs_src/sql_databases/sql_app_py310/schemas.py:4: in <module>
    class ItemBase(BaseModel):
docs_src/sql_databases/sql_app_py310/schemas.py:6: in ItemBase
    description: str | None = None
E   TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
__ ERROR collecting docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py __
docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py:6: in <module>
    from ..main import app, get_db
docs_src/sql_databases/sql_app_py39/main.py:4: in <module>
    from . import crud, models, schemas
docs_src/sql_databases/sql_app_py39/crud.py:3: in <module>
    from . import models, schemas
docs_src/sql_databases/sql_app_py39/schemas.py:31: in <module>
    class User(UserBase):
docs_src/sql_databases/sql_app_py39/schemas.py:34: in User
    items: list[Item] = []
E   TypeError: 'type' object is not subscriptable
=========================== short test summary info ============================
ERROR docs_src/app_testing/app_b_py310/test_main.py - TypeError: unsupported ...
ERROR docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py - TypeError:...
ERROR docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py - TypeError: ...
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 3 errors in 4.68s ===============================
```

This is because `list[Item]` syntax used [here](https://github.com/tiangolo/fastapi/blob/672c55ac626b20cc6219696023cdcc5871e5141d/docs_src/sql_databases/sql_app_py39/schemas.py#L34) is not valid in Python3.7 version used in the CI workflow.

So I've upgraded it to Python 3.10.

## Related issue number
fix #3684

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
