### PR TITLE
fix: allow `None` as `default` in `Field` in `Annotated`

### DIFF
--- a/changes/3702-fictorial.md
+++ b/changes/3702-fictorial.md
@@ -1,0 +1,1 @@
+In `Field` in an `Annotation`, this allows for default of `None` where only `Undefined` was allowed previously.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -450,6 +450,7 @@ class ModelField(Representation):
             if field_info is not None:
                 field_info.update_from_config(field_info_from_config)
                 if field_info.default not in (Undefined, None):
+                    print('field info default is invalid', field_info.default, type(field_info.default))
                     raise ValueError(f'`Field` default cannot be set in `Annotated` for {field_name!r}')
                 if value is not Undefined and value is not Required:
                     # check also `Required` because of `validate_arguments` that sets `...` as default value

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -447,7 +447,7 @@ class ModelField(Representation):
             field_info = next(iter(field_infos), None)
             if field_info is not None:
                 field_info.update_from_config(field_info_from_config)
-                if field_info.default is not Undefined:
+                if field_info.default not in (Undefined, None):
                     raise ValueError(f'`Field` default cannot be set in `Annotated` for {field_name!r}')
                 if value is not Undefined and value is not Required:
                     # check also `Required` because of `validate_arguments` that sets `...` as default value

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -401,6 +401,8 @@ class ModelField(Representation):
         self.default_factory: Optional[NoArgAnyCallable] = default_factory
         self.required: 'BoolUndefined' = required
         self.model_config = model_config
+        if field_info is not None:
+            field_info = smart_deepcopy(field_info)
         self.field_info: FieldInfo = field_info or FieldInfo(default)
         self.discriminator_key: Optional[str] = self.field_info.discriminator
         self.discriminator_alias: Optional[str] = self.discriminator_key


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

In `Field` in an `Annotation`, this allows for default of `None` where only `Undefined` was allowed previously.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

fix #3702

## Checklist

* [ ] Unit tests for the changes exist – no, too short a change
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable – n/a
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

please review
