### PR TITLE
Fix issue with self-referencing dataclass

### DIFF
--- a/changes/3675-uriyyo.md
+++ b/changes/3675-uriyyo.md
@@ -1,0 +1,1 @@
+Fix issue with self-referencing dataclass

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -184,7 +184,12 @@ def _process_class(
 
     validators = gather_all_validators(cls)
     cls.__pydantic_model__ = create_model(
-        cls.__name__, __config__=config, __module__=_cls.__module__, __validators__=validators, **field_definitions
+        cls.__name__,
+        __config__=config,
+        __module__=_cls.__module__,
+        __validators__=validators,
+        __cls_kwargs__={'__resolve_forward_refs__': False},
+        **field_definitions,
     )
 
     cls.__initialised__ = False
@@ -195,6 +200,8 @@ def _process_class(
 
     if cls.__pydantic_model__.__config__.validate_assignment and not frozen:
         cls.__setattr__ = setattr_validate_assignment  # type: ignore[assignment]
+
+    cls.__pydantic_model__.__try_update_forward_refs__(**{cls.__name__: cls})
 
     return cls
 

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -98,6 +98,7 @@ class GenericModel(BaseModel):
                 __base__=(cls,) + tuple(cls.__parameterized_bases__(typevars_map)),
                 __config__=None,
                 __validators__=validators,
+                __cls_kwargs__=None,
                 **fields,
             ),
         )

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -154,6 +154,7 @@ class ModelMetaclass(ABCMeta):
                 class_vars.update(base.__class_vars__)
                 hash_func = base.__hash__
 
+        resolve_forward_refs = kwargs.pop('__resolve_forward_refs__', True)
         allowed_config_kwargs: SetStr = {
             key
             for key in dir(config)
@@ -289,7 +290,8 @@ class ModelMetaclass(ABCMeta):
         cls = super().__new__(mcs, name, bases, new_namespace, **kwargs)
         # set __signature__ attr only for model class, but not for its instances
         cls.__signature__ = ClassAttribute('__signature__', generate_model_signature(cls.__init__, fields, config))
-        cls.__try_update_forward_refs__()
+        if resolve_forward_refs:
+            cls.__try_update_forward_refs__()
 
         return cls
 
@@ -765,12 +767,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             return v
 
     @classmethod
-    def __try_update_forward_refs__(cls) -> None:
+    def __try_update_forward_refs__(cls, **localns: Any) -> None:
         """
         Same as update_forward_refs but will not raise exception
         when forward references are not defined.
         """
-        update_model_forward_refs(cls, cls.__fields__.values(), cls.__config__.json_encoders, {}, (NameError,))
+        update_model_forward_refs(cls, cls.__fields__.values(), cls.__config__.json_encoders, localns, (NameError,))
 
     @classmethod
     def update_forward_refs(cls, **localns: Any) -> None:
@@ -892,6 +894,7 @@ def create_model(
     __base__: None = None,
     __module__: str = __name__,
     __validators__: Dict[str, 'AnyClassMethod'] = None,
+    __cls_kwargs__: Dict[str, Any] = None,
     **field_definitions: Any,
 ) -> Type['BaseModel']:
     ...
@@ -905,6 +908,7 @@ def create_model(
     __base__: Union[Type['Model'], Tuple[Type['Model'], ...]],
     __module__: str = __name__,
     __validators__: Dict[str, 'AnyClassMethod'] = None,
+    __cls_kwargs__: Dict[str, Any] = None,
     **field_definitions: Any,
 ) -> Type['Model']:
     ...
@@ -917,6 +921,7 @@ def create_model(
     __base__: Union[None, Type['Model'], Tuple[Type['Model'], ...]] = None,
     __module__: str = __name__,
     __validators__: Dict[str, 'AnyClassMethod'] = None,
+    __cls_kwargs__: Dict[str, Any] = None,
     **field_definitions: Any,
 ) -> Type['Model']:
     """
@@ -926,6 +931,7 @@ def create_model(
     :param __base__: base class for the new model to inherit from
     :param __module__: module of the created model
     :param __validators__: a dict of method names and @validator class methods
+    :param __cls_kwargs__: a dict for class creation
     :param field_definitions: fields of the model (or extra fields if a base is supplied)
         in the format `<name>=(<type>, <default default>)` or `<name>=<default value>, e.g.
         `foobar=(str, ...)` or `foobar=123`, or, for complex use-cases, in the format
@@ -939,6 +945,8 @@ def create_model(
             __base__ = (__base__,)
     else:
         __base__ = (cast(Type['Model'], BaseModel),)
+
+    __cls_kwargs__ = __cls_kwargs__ or {}
 
     fields = {}
     annotations = {}
@@ -969,7 +977,7 @@ def create_model(
     if __config__:
         namespace['Config'] = inherit_config(__config__, BaseConfig)
 
-    return type(__model_name, __base__, namespace)
+    return type(__model_name, __base__, namespace, **__cls_kwargs__)
 
 
 _missing = object()

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -989,3 +989,11 @@ def test_keeps_custom_properties():
         instance = cls(a=test_string)
         assert instance._special_property == 1
         assert instance.a == test_string
+
+
+def test_self_reference_dataclass():
+    @pydantic.dataclasses.dataclass
+    class MyDataclass:
+        self_reference: 'MyDataclass'
+
+    assert MyDataclass.__pydantic_model__.__fields__['self_reference'].type_ is MyDataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Fix issue when dataclass field that references on self point to inner pydantic model instead of dataclass.
```py
from pydantic.dataclasses import dataclass


@dataclass
class Foo:
    a: Foo


# before this PR
assert Foo.__pydantic_model__.__fields__['a'].type_ is Foo.__pydantic_model__

# after this PR
assert Foo.__pydantic_model__.__fields__['a'].type_ is Foo
```

## Related issue number
fix: #3675 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
