### PR TITLE
Add Robusta.dev to list of Pydantic users

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -115,8 +115,8 @@ Hundreds of organisations and packages are using *pydantic*, including:
   asynchronous task queue) to reliably power multiple mission-critical microservices.
 
 [Robusta.dev](https://robusta.dev/)
-: are using *pydantic* for their Kubernetes troubleshooting and automation platform. For example, their open source
-  [tools to instanatly debug and profile Python applications on Kubernetes](https://home.robusta.dev/python/) use
+: are using *pydantic* to automate Kubernetes troubleshooting and maintenance. For example, their open source
+  [tools to debug and profile Python applications on Kubernetes](https://home.robusta.dev/python/) use
   *pydantic* models.
 
 For a more comprehensive list of open-source projects using *pydantic* see the 

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,11 @@ Hundreds of organisations and packages are using *pydantic*, including:
 : trusts *pydantic* (via FastAPI) and [*arq*](https://github.com/samuelcolvin/arq) (Samuel's excellent
   asynchronous task queue) to reliably power multiple mission-critical microservices.
 
+[Robusta.dev](https://robusta.dev/)
+: are using *pydantic* for their Kubernetes troubleshooting and automation platform. For example, their open source
+  [tools to instanatly debug and profile Python applications on Kubernetes](https://home.robusta.dev/python/) use
+  *pydantic* models.
+
 For a more comprehensive list of open-source projects using *pydantic* see the 
 [list of dependents on github](https://github.com/samuelcolvin/pydantic/network/dependents).
 


### PR DESCRIPTION
If possible, we would be honored to be listed on the homepage. We're really excited about how we're utilizing Pydantic to automate Kubernetes troubleshooting. Pydantic makes formerly tedious code simple and elegant.