### PR TITLE
Fix pytest crashes with hypothesis and pydantic

### DIFF
--- a/pydantic/_hypothesis_plugin.py
+++ b/pydantic/_hypothesis_plugin.py
@@ -358,7 +358,7 @@ def resolve_constr(cls):  # type: ignore[no-untyped-def]  # pragma: no cover
 
 
 # Finally, register all previously-defined types, and patch in our new function
-for typ in pydantic.types._DEFINED_TYPES:
+for typ in list(pydantic.types._DEFINED_TYPES):
     _registered(typ)
 pydantic.types._registered = _registered
 st.register_type_strategy(pydantic.Json, resolve_json)


### PR DESCRIPTION
Pytest (sometimes?) crashes when it is invoked with `-vv` and pydantic and hypthesis are installed.

This is because `_registered(typ)` modifies `_DEFINED_TYPES` while it is being iterated:

```
INTERNALERROR>   File ".../lib/python3.9/site-packages/pydantic/_hypothesis_plugin.py", line 361, in <module>
INTERNALERROR>     for typ in pydantic.types._DEFINED_TYPES:
INTERNALERROR>   File ".../lib/python3.9/_weakrefset.py", line 65, in __iter__
INTERNALERROR>     for itemref in self.data:
INTERNALERROR> RuntimeError: Set changed size during iteration
```

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
