### PR TITLE
Remove incorrect comment about lazy evaluation of setting sources

### DIFF
--- a/changes/3806-garyd203.md
+++ b/changes/3806-garyd203.md
@@ -1,0 +1,1 @@
+Update documentation about lazy evaluation of sources for Settings (it's not actually done).

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -278,6 +278,3 @@ You might also want to disable a source:
 {!.tmp_examples/settings_disable_source.py!}
 ```
 _(This script is complete, it should run "as is", here you might need to set the `my_api_key` environment variable)_
-
-Because of the callables approach of `customise_sources`, evaluation of sources is lazy so unused sources don't
-have an adverse effect on performance.


### PR DESCRIPTION
## Change Summary

It looks like the current implementation always evaluates every source before coalescing them into a single dictionary to pass to `BaseModel`:

https://github.com/samuelcolvin/pydantic/blob/9d631a3429a66f30742c1a52c94ac18ec6ba848d/pydantic/env_settings.py#L73

So the comment about lazy evaluation in the documentation is incorrect and should be removed.

## Related issue number

N/A - minor documentation tweak

## Checklist

* [x] ~Unit tests for the changes exist~ N/A for documentation
* [x] ~Tests pass on CI and coverage remains at 100%~ N/A for documentation
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
