### PR TITLE
Fix regression in handling of nested dataclasses in `get_flat_models_from_field`

### DIFF
--- a/changes/3819-himbeles.md
+++ b/changes/3819-himbeles.md
@@ -1,0 +1,1 @@
+Fix nested Python dataclass schema regression in version 1.9

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -419,10 +419,13 @@ def get_flat_models_from_field(field: ModelField, known_models: TypeModelSet) ->
     # Handle dataclass-based models
     if is_builtin_dataclass(field.type_):
         field.type_ = dataclass(field.type_)
+        was_dataclass = True
+    else:
+        was_dataclass = False
     field_type = field.type_
     if lenient_issubclass(getattr(field_type, '__pydantic_model__', None), BaseModel):
         field_type = field_type.__pydantic_model__
-    if field.sub_fields and not lenient_issubclass(field_type, BaseModel):
+    if field.sub_fields and (not lenient_issubclass(field_type, BaseModel) or was_dataclass):
         flat_models |= get_flat_models_from_fields(field.sub_fields, known_models=known_models)
     elif lenient_issubclass(field_type, BaseModel) and field_type not in known_models:
         flat_models |= get_flat_models_from_model(field_type, known_models=known_models)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2884,3 +2884,34 @@ def test_alias_same():
             },
         },
     }
+
+
+def test_nested_python_dataclasses():
+    """
+    Test schema generation for nested python dataclasses
+    """
+
+    from dataclasses import dataclass as python_dataclass
+
+    @python_dataclass
+    class ChildModel:
+        name: str
+
+    @python_dataclass
+    class NestedModel:
+        child: List[ChildModel]
+
+    assert model_schema(dataclass(NestedModel)) == {
+        'title': 'NestedModel',
+        'type': 'object',
+        'properties': {'child': {'title': 'Child', 'type': 'array', 'items': {'$ref': '#/definitions/ChildModel'}}},
+        'required': ['child'],
+        'definitions': {
+            'ChildModel': {
+                'title': 'ChildModel',
+                'type': 'object',
+                'properties': {'name': {'title': 'Name', 'type': 'string'}},
+                'required': ['name'],
+            }
+        },
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This fixes a regression #3658 introduced in PR #2364, which lead to not handling nested python dataclasses in `get_flat_models_from_field` properly, and in consequence, leading to a schema generation error. 

## Related issue number

fix #3658 
fix #3848 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
