### PR TITLE
Expand contribution docs.

### DIFF
--- a/changes/3843-danalbert.md
+++ b/changes/3843-danalbert.md
@@ -1,0 +1,1 @@
+Expand contribution docs with dev dependencies.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,27 +43,36 @@ cd pydantic
 # 2. Set up a virtualenv for running tests
 virtualenv -p `which python3.8` env
 source env/bin/activate
+python -m pip install -e .
 # Building docs requires 3.8. If you don't need to build docs you can use
 # whichever version; 3.7 will work too.
 
-# 3. Install pydantic, dependencies, test dependencies and doc dependencies
+# 3. Install additional packages required for development.
+python -m pip install black flake8 isort pytest pytest-cov pytest-mock
+# Install these for more complete test coverage. Support for these packages will
+# not be tested if they are not installed.
+python -m pip install hypothesis mypy sqlalchemy orjson ujson
+# These are only needed if you need to build the docs.
+python -m pip install ansi2html
+
+# 4. Install pydantic, dependencies, test dependencies and doc dependencies
 make install
 
-# 4. Checkout a new branch and make your changes
+# 5. Checkout a new branch and make your changes
 git checkout -b my-new-feature-branch
 # make your changes...
 
-# 5. Fix formatting and imports
+# 6. Fix formatting and imports
 make format
 # Pydantic uses black to enforce formatting and isort to fix imports
 # (https://github.com/ambv/black, https://github.com/timothycrosley/isort)
 
-# 6. Run tests and linting
+# 7. Run tests and linting
 make
 # there are a few sub-commands in Makefile like `test`, `testcov` and `lint`
 # which you might want to use, but generally just `make` should be all you need
 
-# 7. Build documentation
+# 8. Build documentation
 make docs
 # if you have changed the documentation make sure it builds successfully
 # you can also use `make docs-serve` to serve the documentation at localhost:8000


### PR DESCRIPTION
## Change Summary

This names the dev dependencies explicitly in the contribution docs. They aren't being added to requirements.txt because it can't distinguish between dependencies and dev dependencies.

## Related issue number

None, trivial

## Checklist

* [X] Unit tests for the changes exist (N/A)
* [X] Tests pass on CI and coverage remains at 100% 
* [X] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

(it wasn't at 100% coverage when I got here, but this is a markdown change so it hasn't gotten any worse)