### PR TITLE
fix: ensure forward refs are properly set when used with generics standard collections

### DIFF
--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -140,9 +140,13 @@ else:
             get_args(Callable[[], T][int]) == ([], int)
         """
         if type(tp).__name__ in AnnotatedTypeNames:
-            return tp.__args__ + tp.__metadata__
-        # the fallback is needed for the same reasons as `get_origin` (see above)
-        return _typing_get_args(tp) or getattr(tp, '__args__', ()) or _generic_get_args(tp)
+            tp_args = tp.__args__ + tp.__metadata__
+        else:
+            # the fallback is needed for the same reasons as `get_origin` (see above)
+            tp_args = _typing_get_args(tp) or getattr(tp, '__args__', ()) or _generic_get_args(tp)
+        # ensure args are valid
+        # e.g. with tp = list['MyClass'], args == ('MyClass',) but we expect (ForwardRef('MyClass'),))
+        return tuple(ForwardRef(x) if isinstance(x, str) else x for x in tp_args)
 
 
 if sys.version_info < (3, 10):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2156,3 +2156,11 @@ def test_new_union_origin():
         'properties': {'x': {'title': 'X', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
         'required': ['x'],
     }
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='need 3.9 version for PEP 585')
+def test_standard_collection_generic_forward_ref():
+    class Nested(BaseModel):
+        nested_list: dict[str, 'Nested']  # noqa: F821
+
+    assert repr(Nested(nested_list={})) == 'Nested(nested_list={})'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
https://github.com/samuelcolvin/pydantic/issues/1298#issuecomment-1068634254

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
