### PR TITLE
Fix mypy error in models_recursive.py example.

### DIFF
--- a/changes/3995-healarconr.md
+++ b/changes/3995-healarconr.md
@@ -1,1 +1,0 @@
-Fix mypy error in models_recursive.py example.

--- a/changes/3995-healarconr.md
+++ b/changes/3995-healarconr.md
@@ -1,0 +1,1 @@
+Fix mypy error in models_recursive.py example.

--- a/docs/examples/models_recursive.py
+++ b/docs/examples/models_recursive.py
@@ -1,10 +1,10 @@
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 
 
 class Foo(BaseModel):
     count: int
-    size: float = None
+    size: Optional[float] = None
 
 
 class Bar(BaseModel):


### PR DESCRIPTION
## Change Summary

I changed the type of a field in an example of the documentation from `float` to `Optional[float]` to be consistent with the assignment of `None` that the same example already does.

Mypy error:

```
docs/examples/models_recursive.py:7: error: Incompatible types in assignment (expression has type "None", variable has type "float")  [assignment]
Found 1 error in 1 file (checked 1 source file)
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
