### PR TITLE
Adds `dataclass_transform` to dataclass

### DIFF
--- a/changes/4006-giuliano-oliveira.md
+++ b/changes/4006-giuliano-oliveira.md
@@ -1,0 +1,1 @@
+Add support for autocomplete in VS Code via `__dataclass_transform__` when using `pydantic.dataclasses.dataclass`

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Optional, Type, TypeVar, Union, overload
 
 from .class_validators import gather_all_validators
 from .error_wrappers import ValidationError
 from .errors import DataclassTypeError
 from .fields import Field, FieldInfo, Required, Undefined
-from .main import create_model, validate_model
+from .main import __dataclass_transform__, create_model, validate_model
 from .typing import resolve_annotations
 from .utils import ClassAttribute
 
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
     DataclassT = TypeVar('DataclassT', bound='Dataclass')
 
     class Dataclass:
-        __pydantic_model__: Type[BaseModel]
-        __initialised__: bool
-        __post_init_original__: Optional[Callable[..., None]]
-        __processed__: Optional[ClassAttribute]
-        __has_field_info_default__: bool  # whether or not a `pydantic.Field` is used as default value
+        __pydantic_model__: ClassVar[Type[BaseModel]]
+        __initialised__: ClassVar[bool]
+        __post_init_original__: ClassVar[Optional[Callable[..., None]]]
+        __processed__: ClassVar[Optional[ClassAttribute]]
+        __has_field_info_default__: ClassVar[bool]  # whether or not a `pydantic.Field` is used as default value
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
@@ -199,6 +199,7 @@ def _process_class(
     return cls
 
 
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 @overload
 def dataclass(
     *,
@@ -213,6 +214,7 @@ def dataclass(
     ...
 
 
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 @overload
 def dataclass(
     _cls: Type[Any],
@@ -228,6 +230,7 @@ def dataclass(
     ...
 
 
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 def dataclass(
     _cls: Optional[Type[Any]] = None,
     *,


### PR DESCRIPTION
## Change Summary
This PR continues #2721 by adding `__dataclass_transform__` decorator to the pydantic dataclass decorator so that pyright can infer the `__init__` method as well as the instance attributes and types.

For more info about this decorator make sure to check out #2721.

## Related issue number

Fixes #4006
## Checklist

* [ ] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
