### PR TITLE
guard against ClassVar in fields

### DIFF
--- a/changes/3679-samuelcolvin.md
+++ b/changes/3679-samuelcolvin.md
@@ -1,0 +1,1 @@
+Allow self referencing `ClassVar`s in models but checking for class vars after forward refs are resolved.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -37,6 +37,7 @@ from .typing import (
     display_as_type,
     get_args,
     get_origin,
+    is_classvar,
     is_literal_type,
     is_new_type,
     is_none_type,
@@ -610,6 +611,8 @@ class ModelField(Representation):
                 self.allow_none = True
             return
         elif origin is Callable:
+            return
+        elif is_classvar(origin):
             return
         elif is_union(origin):
             types_ = []

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -3,7 +3,7 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, ClassVar
 
 import pytest
 
@@ -1932,3 +1932,17 @@ def test_int_subclass():
 
     m = MyModel(my_int=IntSubclass(123))
     assert m.my_int.__class__ == IntSubclass
+
+
+def test_class_var_forward_ref(create_module):
+    create_module(
+        # language=Python
+        """
+from __future__ import annotations
+from typing import ClassVar
+from pydantic import BaseModel
+
+class WithClassVar(BaseModel):
+    Instances: ClassVar[dict[str, WithClassVar]] = {}
+"""
+    )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -3,7 +3,7 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, ClassVar
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
 import pytest
 
@@ -1935,6 +1935,7 @@ def test_int_subclass():
 
 
 def test_class_var_forward_ref(create_module):
+    # see #3679
     create_module(
         # language=Python
         """

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1932,18 +1932,3 @@ def test_int_subclass():
 
     m = MyModel(my_int=IntSubclass(123))
     assert m.my_int.__class__ == IntSubclass
-
-
-def test_class_var_forward_ref(create_module):
-    # see #3679
-    create_module(
-        # language=Python
-        """
-from __future__ import annotations
-from typing import ClassVar
-from pydantic import BaseModel
-
-class WithClassVar(BaseModel):
-    Instances: ClassVar[dict[str, WithClassVar]] = {}
-"""
-    )

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional, Tuple
 
 import pytest
@@ -669,3 +670,19 @@ class User(BaseModel):
 
     m = module.User(name='anne', friends=[{'name': 'ben'}, {'name': 'charlie'}])
     assert m.json(models_as_dict=False) == '{"name": "anne", "friends": ["User(ben)", "User(charlie)"]}'
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='needs 3.9 or newer')
+def test_class_var_forward_ref(create_module):
+    # see #3679
+    create_module(
+        # language=Python
+        """
+from __future__ import annotations
+from typing import ClassVar
+from pydantic import BaseModel
+
+class WithClassVar(BaseModel):
+    Instances: ClassVar[dict[str, WithClassVar]] = {}
+"""
+    )


### PR DESCRIPTION
## Change Summary

Allow self referencing `ClassVar`s in models but checking for class vars after forward refs are resolved.

## Related issue number

fix #3679

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] ~~Documentation reflects the changes where applicable~~
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
