### PR TITLE
Fix typo `# pylance: ignore` > `# pyright: ignore`

### DIFF
--- a/docs/visual_studio_code.md
+++ b/docs/visual_studio_code.md
@@ -269,7 +269,7 @@ reasons behind this, and why we can't avoid the problem.
 
 There are two potential workarounds:
 
-* use an ignore comment (`# pylance: ignore`) when initialising `settings`
+* use an ignore comment (`# pyright: ignore`) when initialising `settings`
 * or, use `settings.parse_obj({})` to avoid the warning
 
 ## Adding a default with `Field`


### PR DESCRIPTION
## Change Summary

In #3972, `# pyright: ignore` was added in multiple places in the docs, and `# pylance: ignore` only once. I believe it's a typo, as AFAIK such a typing ignore comment flag doesn't exist.

## Related issue number

Related PR: #3972.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
