### PR TITLE
speedup __instancecheck__ check on BaseModel when they fail

### DIFF
--- a/changes/4081-samuelcolvin.md
+++ b/changes/4081-samuelcolvin.md
@@ -1,0 +1,1 @@
+Speedup `__isinstancecheck__` on pydantic models when the type is not a model, may also avoid memory "leaks".

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -295,7 +295,7 @@ class ModelMetaclass(ABCMeta):
 
         return cls
 
-    def __instancecheck__(self, instance):
+    def __instancecheck__(self, instance: Any) -> bool:
         """
         Avoid calling ABC _abc_subclasscheck unless we're pretty sure.
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -295,6 +295,14 @@ class ModelMetaclass(ABCMeta):
 
         return cls
 
+    def __instancecheck__(self, instance):
+        """
+        Avoid calling ABC _abc_subclasscheck unless we're pretty sure.
+
+        See #3829 and python/cpython#92810
+        """
+        return hasattr(instance, '__fields__') and super().__instancecheck__(instance)
+
 
 object_setattr = object.__setattr__
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1932,3 +1932,17 @@ def test_int_subclass():
 
     m = MyModel(my_int=IntSubclass(123))
     assert m.my_int.__class__ == IntSubclass
+
+
+def test_model_issubclass():
+    assert not issubclass(int, BaseModel)
+
+    class MyModel(BaseModel):
+        x: int
+
+    assert issubclass(MyModel, BaseModel)
+
+    class Custom:
+        __fields__ = True
+
+    assert not issubclass(Custom, BaseModel)


### PR DESCRIPTION
## Change Summary

abc `__isinstancecheck__` can be very slow and eat a lot of memory, this seems to be particularly bad in the check returns False.

We do this check a lot when generating schemas, often for types we can easily check are not Models.

## Related issue number

FIx possibly for #3829, avoid performance depredation and memory growth in abc `__isinstancecheck__`, see https://github.com/python/cpython/issues/92810 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
