### PR TITLE
Update Jupyter's use of pydantic

### DIFF
--- a/changes/4082-davidbrochart.md
+++ b/changes/4082-davidbrochart.md
@@ -1,0 +1,1 @@
+Add Jupyverse and FPS as Jupyter projects using pydantic

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,9 @@ Hundreds of organisations and packages are using *pydantic*, including:
 
 [Project Jupyter](https://jupyter.org/)
 : developers of the Jupyter notebook are using *pydantic* 
-  [for subprojects](https://github.com/samuelcolvin/pydantic/issues/773).
+  [for subprojects](https://github.com/samuelcolvin/pydantic/issues/773), through the FastAPI-based Jupyter server
+  [Jupyverse](https://github.com/jupyter-server/jupyverse), and for FPS[https://github.com/jupyter-server/fps]'s
+  configuration management.
 
 **Microsoft**
 : are using *pydantic* (via FastAPI) for 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ Hundreds of organisations and packages are using *pydantic*, including:
 [Project Jupyter](https://jupyter.org/)
 : developers of the Jupyter notebook are using *pydantic* 
   [for subprojects](https://github.com/samuelcolvin/pydantic/issues/773), through the FastAPI-based Jupyter server
-  [Jupyverse](https://github.com/jupyter-server/jupyverse), and for FPS[https://github.com/jupyter-server/fps]'s
+  [Jupyverse](https://github.com/jupyter-server/jupyverse), and for [FPS](https://github.com/jupyter-server/fps)'s
   configuration management.
 
 **Microsoft**


### PR DESCRIPTION
## Change Summary

Add Jupyverse and FPS as Jupyter projects using pydantic.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
