### PR TITLE
Update docs for dotenv env_file not checking parent directories

### DIFF
--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -144,6 +144,10 @@ In either case, the value of the passed argument can be any valid path or filena
 current working directory. From there, *pydantic* will handle everything for you by loading in your variables and
 validating them.
 
+!!! note
+    If a filename is specified for `env_file`, Pydantic will only check the current working directory and
+    won't check any parent directories for the `.env` file.
+
 Even when using a dotenv file, *pydantic* will still read environment variables as well as the dotenv file,
 **environment variables will always take priority over values loaded from a dotenv file**.
 


### PR DESCRIPTION
## Change Summary

Update docs for BaseSettings dotenv env_file not checking parent directories when a filename is specified.

## Related issue number

Fixes https://github.com/samuelcolvin/pydantic/issues/4058

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
