### PR TITLE
Add default to JSON schema when const is True

### DIFF
--- a/changes/4031-aminalaee.md
+++ b/changes/4031-aminalaee.md
@@ -1,0 +1,1 @@
+Add `default` value in JSON Schema when `const=True`

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -210,12 +210,7 @@ def get_field_info_schema(field: ModelField, schema_overrides: bool = False) -> 
         schema_['description'] = field.field_info.description
         schema_overrides = True
 
-    if (
-        not field.required
-        and not field.field_info.const
-        and field.default is not None
-        and not is_callable_type(field.outer_type_)
-    ):
+    if not field.required and field.default is not None and not is_callable_type(field.outer_type_):
         schema_['default'] = encode_default(field.default)
         schema_overrides = True
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -585,12 +585,14 @@ def test_const_list():
         'properties': {
             'a': {
                 'const': [SubModel(b=1), SubModel(b=2), SubModel(b=3)],
+                'default': [{'b': 1}, {'b': 2}, {'b': 3}],
                 'items': {'$ref': '#/definitions/SubModel'},
                 'title': 'A',
                 'type': 'array',
             },
             'b': {
                 'const': [{'b': 4}, {'b': 5}, {'b': 6}],
+                'default': [{'b': 4}, {'b': 5}, {'b': 6}],
                 'items': {'$ref': '#/definitions/SubModel'},
                 'title': 'B',
                 'type': 'array',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -549,7 +549,7 @@ def test_const_str():
     assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'string', 'const': 'some string'}},
+        'properties': {'a': {'title': 'A', 'type': 'string', 'const': 'some string', 'default': 'some string'}},
     }
 
 


### PR DESCRIPTION
## Change Summary

Right now for the following Model:

```python
from pydantic import BaseModel, Field

class MyModel(BaseModel):
    x: int = Field(default=0, const=True)
```

The JSON schema is:

```json
{
  "title": "MyModel",
  "type": "object",
  "properties": {
    "x": {
      "title": "X",
      "const": 0,
      "type": "integer"
    }
  }
}
```

Which will include the `default`:

```json
{
  "title": "MyModel",
  "type": "object",
  "properties": {
    "x": {
      "title": "X",
      "const": 0,
      "default": 0,
      "type": "integer"
    }
  }
}
```

Fixes 

## Related issue number

Fixes https://github.com/samuelcolvin/pydantic/issues/4031

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
