### PR TITLE
Exclusive fix

### DIFF
--- a/changes/4108-OrIOg.md
+++ b/changes/4108-OrIOg.md
@@ -1,0 +1,1 @@
+Making '*greater than*' / '*gt*' and '*lesser than*' /  '*lt*' set *minumum* and *maximum* values while setting *exclusiveMinimum* and *exclusiveMaximum* as the [specification](https://swagger.io/docs/specification/data-models/data-types/#range) defines.

--- a/docs/examples/schema_unenforced_constraints.py
+++ b/docs/examples/schema_unenforced_constraints.py
@@ -10,9 +10,9 @@ except ValueError as e:
 
 
 # but you can set the schema attribute directly:
-# (Note: here exclusiveMaximum will not be enforce)
+# (Note: here exclusiveMaximum will not be enforced)
 class Model(BaseModel):
-    foo: PositiveInt = Field(..., exclusiveMaximum=10)
+    foo: PositiveInt = Field(..., maximum=10, exclusiveMaximum=True)
 
 
 print(Model.schema())

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -312,6 +312,11 @@ def get_field_schema_validations(field: ModelField) -> Dict[str, Any]:
             attr = getattr(field.field_info, attr_name, None)
             if isinstance(attr, t):
                 f_schema[keyword] = attr
+                # FIXME: Find a better way to set 'side effect' values
+                if attr_name == 'gt':
+                    f_schema['exclusiveMinimum'] = True
+                elif attr_name == 'lt':
+                    f_schema['exclusiveMaximum'] = True
     if field.field_info is not None and field.field_info.const:
         f_schema['const'] = field.default
     if field.field_info.extra:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -281,8 +281,8 @@ _str_types_attrs: Tuple[Tuple[str, Union[type, Tuple[type, ...]], str], ...] = (
 )
 
 _numeric_types_attrs: Tuple[Tuple[str, Union[type, Tuple[type, ...]], str], ...] = (
-    ('gt', numeric_types, 'exclusiveMinimum'),
-    ('lt', numeric_types, 'exclusiveMaximum'),
+    ('gt', numeric_types, 'minimum'),
+    ('lt', numeric_types, 'maximum'),
     ('ge', numeric_types, 'minimum'),
     ('le', numeric_types, 'maximum'),
     ('multiple_of', numeric_types, 'multipleOf'),

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -199,12 +199,14 @@ class ConstrainedInt(int, metaclass=ConstrainedNumberMeta):
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        is_gt_set = cls.gt is not None
+        is_lt_set = cls.lt is not None
         update_not_none(
             field_schema,
-            exclusiveMinimum=cls.gt,
-            exclusiveMaximum=cls.lt,
-            minimum=cls.ge,
-            maximum=cls.le,
+            exclusiveMinimum=True if is_gt_set else None,
+            exclusiveMaximum=True if is_lt_set else None,
+            minimum=cls.gt if is_gt_set else cls.ge,
+            maximum=cls.lt if is_lt_set else cls.le,
             multipleOf=cls.multiple_of,
         )
 
@@ -260,23 +262,29 @@ class ConstrainedFloat(float, metaclass=ConstrainedNumberMeta):
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        is_gt_set = cls.gt is not None
+        is_lt_set = cls.lt is not None
         update_not_none(
             field_schema,
-            exclusiveMinimum=cls.gt,
-            exclusiveMaximum=cls.lt,
-            minimum=cls.ge,
-            maximum=cls.le,
+            exclusiveMinimum=True if is_gt_set else None,
+            exclusiveMaximum=True if is_lt_set else None,
+            minimum=cls.gt if is_gt_set else cls.ge,
+            maximum=cls.lt if is_lt_set else cls.le,
             multipleOf=cls.multiple_of,
         )
+
+        minimum_is_inf = field_schema.get('minimum') == -math.inf
+        maximum_is_inf = field_schema.get('maximum') == math.inf
+
         # Modify constraints to account for differences between IEEE floats and JSON
-        if field_schema.get('exclusiveMinimum') == -math.inf:
-            del field_schema['exclusiveMinimum']
-        if field_schema.get('minimum') == -math.inf:
+        if minimum_is_inf:
             del field_schema['minimum']
-        if field_schema.get('exclusiveMaximum') == math.inf:
-            del field_schema['exclusiveMaximum']
-        if field_schema.get('maximum') == math.inf:
+            if field_schema.get('exclusiveMinimum'):
+                del field_schema['exclusiveMinimum']
+        if maximum_is_inf:
             del field_schema['maximum']
+            if field_schema.get('exclusiveMaximum'):
+                del field_schema['exclusiveMaximum']
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
@@ -633,12 +641,14 @@ class ConstrainedDecimal(Decimal, metaclass=ConstrainedNumberMeta):
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        is_gt_set = cls.gt is not None
+        is_lt_set = cls.lt is not None
         update_not_none(
             field_schema,
-            exclusiveMinimum=cls.gt,
-            exclusiveMaximum=cls.lt,
-            minimum=cls.ge,
-            maximum=cls.le,
+            exclusiveMinimum=True if is_gt_set else None,
+            exclusiveMaximum=True if is_lt_set else None,
+            minimum=cls.gt if is_gt_set else cls.ge,
+            maximum=cls.lt if is_lt_set else cls.le,
             multipleOf=cls.multiple_of,
         )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -852,11 +852,11 @@ def test_secret_types(field_type, inner_type):
     'field_type,expected_schema',
     [
         (ConstrainedInt, {}),
-        (conint(gt=5, lt=10), {'exclusiveMinimum': 5, 'exclusiveMaximum': 10}),
+        (conint(gt=5, lt=10), {'minimum': 5, 'maximum': 10, 'exclusiveMinimum': True, 'exclusiveMaximum': True}),
         (conint(ge=5, le=10), {'minimum': 5, 'maximum': 10}),
         (conint(multiple_of=5), {'multipleOf': 5}),
-        (PositiveInt, {'exclusiveMinimum': 0}),
-        (NegativeInt, {'exclusiveMaximum': 0}),
+        (PositiveInt, {'minimum': 0, 'exclusiveMinimum': True}),
+        (NegativeInt, {'maximum': 0, 'exclusiveMaximum': True}),
         (NonNegativeInt, {'minimum': 0}),
         (NonPositiveInt, {'maximum': 0}),
     ],
@@ -880,15 +880,15 @@ def test_special_int_types(field_type, expected_schema):
     'field_type,expected_schema',
     [
         (ConstrainedFloat, {}),
-        (confloat(gt=5, lt=10), {'exclusiveMinimum': 5, 'exclusiveMaximum': 10}),
+        (confloat(gt=5, lt=10), {'minimum': 5, 'maximum': 10, 'exclusiveMinimum': True, 'exclusiveMaximum': True}),
         (confloat(ge=5, le=10), {'minimum': 5, 'maximum': 10}),
         (confloat(multiple_of=5), {'multipleOf': 5}),
-        (PositiveFloat, {'exclusiveMinimum': 0}),
-        (NegativeFloat, {'exclusiveMaximum': 0}),
+        (PositiveFloat, {'minimum': 0, 'exclusiveMinimum': True}),
+        (NegativeFloat, {'maximum': 0, 'exclusiveMaximum': True}),
         (NonNegativeFloat, {'minimum': 0}),
         (NonPositiveFloat, {'maximum': 0}),
         (ConstrainedDecimal, {}),
-        (condecimal(gt=5, lt=10), {'exclusiveMinimum': 5, 'exclusiveMaximum': 10}),
+        (condecimal(gt=5, lt=10), {'minimum': 5, 'maximum': 10, 'exclusiveMinimum': True, 'exclusiveMaximum': True}),
         (condecimal(ge=5, le=10), {'minimum': 5, 'maximum': 10}),
         (condecimal(multiple_of=5), {'multipleOf': 5}),
     ],
@@ -1482,13 +1482,13 @@ def test_dict_default():
         ({'min_length': 2}, str, {'type': 'string', 'minLength': 2}),
         ({'max_length': 5}, bytes, {'type': 'string', 'maxLength': 5, 'format': 'binary'}),
         ({'regex': '^foo$'}, str, {'type': 'string', 'pattern': '^foo$'}),
-        ({'gt': 2}, int, {'type': 'integer', 'exclusiveMinimum': 2}),
-        ({'lt': 5}, int, {'type': 'integer', 'exclusiveMaximum': 5}),
+        ({'gt': 2}, int, {'type': 'integer', 'minimum': 2, 'exclusiveMinimum': True}),
+        ({'lt': 5}, int, {'type': 'integer', 'maximum': 5, 'exclusiveMaximum': True}),
         ({'ge': 2}, int, {'type': 'integer', 'minimum': 2}),
         ({'le': 5}, int, {'type': 'integer', 'maximum': 5}),
         ({'multiple_of': 5}, int, {'type': 'integer', 'multipleOf': 5}),
-        ({'gt': 2}, float, {'type': 'number', 'exclusiveMinimum': 2}),
-        ({'lt': 5}, float, {'type': 'number', 'exclusiveMaximum': 5}),
+        ({'gt': 2}, float, {'type': 'number', 'minimum': 2, 'exclusiveMinimum': True}),
+        ({'lt': 5}, float, {'type': 'number', 'maximum': 5, 'exclusiveMaximum': True}),
         ({'ge': 2}, float, {'type': 'number', 'minimum': 2}),
         ({'le': 5}, float, {'type': 'number', 'maximum': 5}),
         ({'gt': -math.inf}, float, {'type': 'number'}),
@@ -1496,8 +1496,8 @@ def test_dict_default():
         ({'ge': -math.inf}, float, {'type': 'number'}),
         ({'le': math.inf}, float, {'type': 'number'}),
         ({'multiple_of': 5}, float, {'type': 'number', 'multipleOf': 5}),
-        ({'gt': 2}, Decimal, {'type': 'number', 'exclusiveMinimum': 2}),
-        ({'lt': 5}, Decimal, {'type': 'number', 'exclusiveMaximum': 5}),
+        ({'gt': 2}, Decimal, {'type': 'number', 'minimum': 2, 'exclusiveMinimum': True}),
+        ({'lt': 5}, Decimal, {'type': 'number', 'maximum': 5, 'exclusiveMaximum': True}),
         ({'ge': 2}, Decimal, {'type': 'number', 'minimum': 2}),
         ({'le': 5}, Decimal, {'type': 'number', 'maximum': 5}),
         ({'multiple_of': 5}, Decimal, {'type': 'number', 'multipleOf': 5}),
@@ -1979,12 +1979,18 @@ def test_model_with_extra_forbidden():
 @pytest.mark.parametrize(
     'annotation,kwargs,field_schema',
     [
-        (int, dict(gt=0), {'title': 'A', 'exclusiveMinimum': 0, 'type': 'integer'}),
-        (Optional[int], dict(gt=0), {'title': 'A', 'exclusiveMinimum': 0, 'type': 'integer'}),
+        (int, dict(gt=0), {'title': 'A', 'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'}),
+        (Optional[int], dict(gt=0), {'title': 'A', 'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'}),
         (
             Tuple[int, ...],
             dict(gt=0),
-            {'title': 'A', 'exclusiveMinimum': 0, 'type': 'array', 'items': {'exclusiveMinimum': 0, 'type': 'integer'}},
+            {
+                'title': 'A',
+                'minimum': 0,
+                'exclusiveMinimum': True,
+                'type': 'array',
+                'items': {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
+            },
         ),
         (
             Tuple[int, int, int],
@@ -1993,9 +1999,9 @@ def test_model_with_extra_forbidden():
                 'title': 'A',
                 'type': 'array',
                 'items': [
-                    {'exclusiveMinimum': 0, 'type': 'integer'},
-                    {'exclusiveMinimum': 0, 'type': 'integer'},
-                    {'exclusiveMinimum': 0, 'type': 'integer'},
+                    {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
+                    {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
+                    {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
                 ],
                 'minItems': 3,
                 'maxItems': 3,
@@ -2006,28 +2012,44 @@ def test_model_with_extra_forbidden():
             dict(gt=0),
             {
                 'title': 'A',
-                'anyOf': [{'exclusiveMinimum': 0, 'type': 'integer'}, {'exclusiveMinimum': 0, 'type': 'number'}],
+                'anyOf': [
+                    {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
+                    {'minimum': 0, 'exclusiveMinimum': True, 'type': 'number'},
+                ],
             },
         ),
         (
             List[int],
             dict(gt=0),
-            {'title': 'A', 'exclusiveMinimum': 0, 'type': 'array', 'items': {'exclusiveMinimum': 0, 'type': 'integer'}},
+            {
+                'title': 'A',
+                'minimum': 0,
+                'exclusiveMinimum': True,
+                'type': 'array',
+                'items': {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
+            },
         ),
         (
             Dict[str, int],
             dict(gt=0),
             {
                 'title': 'A',
-                'exclusiveMinimum': 0,
+                'minimum': 0,
+                'exclusiveMinimum': True,
                 'type': 'object',
-                'additionalProperties': {'exclusiveMinimum': 0, 'type': 'integer'},
+                'additionalProperties': {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
             },
         ),
         (
             Union[str, int],
             dict(gt=0, max_length=5),
-            {'title': 'A', 'anyOf': [{'maxLength': 5, 'type': 'string'}, {'exclusiveMinimum': 0, 'type': 'integer'}]},
+            {
+                'title': 'A',
+                'anyOf': [
+                    {'maxLength': 5, 'type': 'string'},
+                    {'minimum': 0, 'exclusiveMinimum': True, 'type': 'integer'},
+                ],
+            },
         ),
     ],
 )
@@ -2048,7 +2070,7 @@ def test_real_vs_phony_constraints():
             title = 'Test Model'
 
     class Model2(BaseModel):
-        foo: int = Field(..., exclusiveMinimum=123)
+        foo: int = Field(..., minimum=123, exclusiveMinimum=True)
 
         class Config:
             title = 'Test Model'
@@ -2064,7 +2086,7 @@ def test_real_vs_phony_constraints():
         == {
             'title': 'Test Model',
             'type': 'object',
-            'properties': {'foo': {'title': 'Foo', 'exclusiveMinimum': 123, 'type': 'integer'}},
+            'properties': {'foo': {'title': 'Foo', 'minimum': 123, 'exclusiveMinimum': True, 'type': 'integer'}},
             'required': ['foo'],
         }
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Making exclusive limits follows the [specification](https://swagger.io/docs/specification/data-models/data-types/#range) by setting the value as a boolean when "lt" or "gt" are set. 
Their values are used in "minimum" and "maximum".

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #4108

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
  Coverage "can't be" at 100% since some parts depends on python/dependencies' version
* [ ] Documentation reflects the changes where applicable
  I can't build the docs:
  > make docs
flake8 --max-line-length=80 docs/examples/
python docs/build/main.py
error in hypothesis_property_based_test.py: Traceback (most recent call last):
  File "/home/21706220/Documents/Projets/colab/pydantic/docs/examples/hypothesis_property_based_test.py", line 2, in <module>
    from hypothesis import given, strategies as st
AttributeError: type object 'Path' has no attribute '_flavour'
1 errors, not writing files
make: *** [Makefile:114 : docs] Erreur 1

* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
