### PR TITLE
Bump mypy to 0.971

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -101,7 +101,7 @@ class PydanticPlugin(Plugin):
 
     def get_class_decorator_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
         if fullname == DATACLASS_FULLNAME:
-            return dataclasses.dataclass_class_maker_callback
+            return dataclasses.dataclass_class_maker_callback  # type: ignore[return-value]
         return None
 
     def _pydantic_model_class_maker_callback(self, ctx: ClassDefContext) -> None:

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -4,7 +4,7 @@ flake8-quotes==3.3.1
 hypothesis==6.53.0
 isort==5.10.1
 pyupgrade==2.37.3
-mypy==0.950
+mypy==0.971
 pre-commit==2.20.0
 pycodestyle==2.9.0
 pyflakes==2.5.0

--- a/tests/requirements-testing.txt
+++ b/tests/requirements-testing.txt
@@ -2,7 +2,7 @@ coverage==6.4.2
 hypothesis==6.53.0
 # pin importlib-metadata as upper versions need typing-extensions to work if on Python < 3.8
 importlib-metadata==3.1.0;python_version<"3.8"
-mypy==0.950
+mypy==0.971
 pytest==7.1.2
 pytest-cov==3.0.0
 pytest-mock==3.8.2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Bump mypy to 0.961

Here is the error that I ignored:
```
pydantic/mypy.py:104: error: Incompatible return value type (got "Callable[[ClassDefContext], bool]", expected "Optional[Callable[[ClassDefContext], None]]")  [return-value]
Found 1 error in 1 file (checked 26 source files)
```
It seems mypy introduced the change in return type of `get_class_decorator_hook` in https://github.com/python/mypy/commit/03901ef657daf6f477e6fe933c42ac270cf5034b
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
