### PR TITLE
Improved example

### DIFF
--- a/changes/4231-drorata.md
+++ b/changes/4231-drorata.md
@@ -1,1 +1,0 @@
-Adjusted the example to reflect the casting of values.

--- a/changes/4231-drorata.md
+++ b/changes/4231-drorata.md
@@ -1,0 +1,1 @@
+Adjusted the example to reflect the casting of values.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -42,7 +42,7 @@ assert user.id == 123
 assert user_x.id == 123
 assert isinstance(user_x.id, int)  # Note that 123.45 was casted to an int and its value is 123
 ```
-More details on the casting in the case of `user_x` can be found [here](#data-conversion).
+More details on the casting in the case of `user_x` can be found in [Data Conversion](#data-conversion).
 Fields of a model can be accessed as normal attributes of the user object.
 The string '123' has been cast to an int as per the field type
 ```py

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -37,7 +37,8 @@ user = User(id='123')
 `user` here is an instance of `User`. Initialisation of the object will perform all parsing and validation,
 if no `ValidationError` is raised, you know the resulting model instance is valid.
 ```py
-assert user.id == 123
+# Note that 123.45 was casted to an int and its value is 123
+assert isinstance(User(id=123.45).id, int)
 ```
 Fields of a model can be accessed as normal attributes of the user object.
 The string '123' has been cast to an int as per the field type

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -1,4 +1,4 @@
-The primary means of defining objects in *pydantic* is via models 
+The primary means of defining objects in *pydantic* is via models
 (models are simply classes which inherit from `BaseModel`).
 
 You can think of models as similar to types in strictly typed languages, or as the requirements of a single endpoint
@@ -27,19 +27,22 @@ class User(BaseModel):
     id: int
     name = 'Jane Doe'
 ```
-`User` here is a model with two fields `id` which is an integer and is required, 
+`User` here is a model with two fields `id` which is an integer and is required,
 and `name` which is a string and is not required (it has a default value). The type of `name` is inferred from the
-default value, and so a type annotation is not required (however note [this](#field-ordering) warning about field 
+default value, and so a type annotation is not required (however note [this](#field-ordering) warning about field
 order when some fields do not have type annotations).
 ```py
 user = User(id='123')
+user_x = User(id='123.45')
 ```
 `user` here is an instance of `User`. Initialisation of the object will perform all parsing and validation,
 if no `ValidationError` is raised, you know the resulting model instance is valid.
 ```py
-# Note that 123.45 was casted to an int and its value is 123
-assert isinstance(User(id=123.45).id, int)
+assert user.id == 123
+assert user_x.id == 123
+assert isinstance(user_x.id, int)  # Note that 123.45 was casted to an int and its value is 123
 ```
+More details on the casting in the case of `user_x` can be found [here](#data-conversion).
 Fields of a model can be accessed as normal attributes of the user object.
 The string '123' has been cast to an int as per the field type
 ```py
@@ -62,15 +65,15 @@ This model is mutable so field values can be changed.
 
 ### Model properties
 
-The example above only shows the tip of the iceberg of what models can do. 
+The example above only shows the tip of the iceberg of what models can do.
 Models possess the following methods and attributes:
 
 `dict()`
-: returns a dictionary of the model's fields and values; 
+: returns a dictionary of the model's fields and values;
   cf. [exporting models](exporting_models.md#modeldict)
 
 `json()`
-: returns a JSON string representation `dict()`; 
+: returns a JSON string representation `dict()`;
   cf. [exporting models](exporting_models.md#modeljson)
 
 `copy()`
@@ -96,7 +99,7 @@ Models possess the following methods and attributes:
 : returns a JSON string representation of `schema()`; cf. [schema](schema.md)
 
 `construct()`
-: a class method for creating models without running validation; 
+: a class method for creating models without running validation;
   cf. [Creating models without validation](#creating-models-without-validation)
 
 `__fields_set__`
@@ -168,7 +171,7 @@ Arbitrary classes are processed by *pydantic* using the `GetterDict` class (see
 provide a dictionary-like interface to any class. You can customise how this works by setting your own
 sub-class of `GetterDict` as the value of `Config.getter_dict` (see [config](model_config.md)).
 
-You can also customise class validation using [root_validators](validators.md#root-validators) with `pre=True`. 
+You can also customise class validation using [root_validators](validators.md#root-validators) with `pre=True`.
 In this case your validator function will be passed a `GetterDict` instance which you may copy and modify.
 
 The `GetterDict` instance will be called for each field with a sentinel as a fallback (if no other default
@@ -265,12 +268,12 @@ _(This script is complete, it should run "as is")_
 !!! warning
     To quote the [official `pickle` docs](https://docs.python.org/3/library/pickle.html),
     "The pickle module is not secure against erroneous or maliciously constructed data.
-    Never unpickle data received from an untrusted or unauthenticated source." 
-    
+    Never unpickle data received from an untrusted or unauthenticated source."
+
 !!! info
     Because it can result in arbitrary code execution, as a security measure, you need
     to explicitly pass `allow_pickle` to the parsing function in order to load `pickle` data.
-    
+
 ### Creating models without validation
 
 *pydantic* also provides the `construct()` method which allows models to be created **without validation** this
@@ -286,11 +289,11 @@ as efficiently as possible (`construct()` is generally around 30x faster than cr
 ```
 _(This script is complete, it should run "as is")_
 
-The `_fields_set` keyword argument to `construct()` is optional, but allows you to be more precise about 
+The `_fields_set` keyword argument to `construct()` is optional, but allows you to be more precise about
 which fields were originally set and which weren't. If it's omitted `__fields_set__` will just be the keys
-of the data provided. 
+of the data provided.
 
-For example, in the example above, if `_fields_set` was not provided, 
+For example, in the example above, if `_fields_set` was not provided,
 `new_user.__fields_set__` would be `{'id', 'age', 'name'}`.
 
 ## Generic Models
@@ -323,7 +326,7 @@ you would expect mypy to provide if you were to declare the type without using `
     Internally, pydantic uses `create_model` to generate a (cached) concrete `BaseModel` at runtime,
     so there is essentially zero overhead introduced by making use of `GenericModel`.
 
-To inherit from a GenericModel without replacing the `TypeVar` instance, a class must also inherit from 
+To inherit from a GenericModel without replacing the `TypeVar` instance, a class must also inherit from
 `typing.Generic`:
 
 ```py
@@ -331,7 +334,7 @@ To inherit from a GenericModel without replacing the `TypeVar` instance, a class
 ```
 _(This script is complete, it should run "as is")_
 
-You can also create a generic subclass of a `GenericModel` that partially or fully replaces the type 
+You can also create a generic subclass of a `GenericModel` that partially or fully replaces the type
 parameters in the superclass.
 
 ```py
@@ -354,7 +357,7 @@ Using the same TypeVar in nested models allows you to enforce typing relationshi
 _(This script is complete, it should run "as is")_
 
 Pydantic also treats `GenericModel` similarly to how it treats built-in generic types like `List` and `Dict` when it
-comes to leaving them unparameterized, or using bounded `TypeVar` instances:    
+comes to leaving them unparameterized, or using bounded `TypeVar` instances:
 
 * If you don't specify parameters before instantiating the generic model, they will be treated as `Any`
 * You can parametrize models with one or more *bounded* parameters to add subclass checks
@@ -379,7 +382,7 @@ Here `StaticFoobarModel` and `DynamicFoobarModel` are identical.
 
 !!! warning
     See the note in [Required Optional Fields](#required-optional-fields) for the distinction between an ellipsis as a
-    field default and annotation-only fields. 
+    field default and annotation-only fields.
     See [samuelcolvin/pydantic#1047](https://github.com/samuelcolvin/pydantic/issues/1047) for more details.
 
 Fields are defined by either a tuple of the form `(<type>, <default value>)` or just a default value. The
@@ -410,7 +413,7 @@ Those methods have the exact same keyword arguments as `create_model`.
 
 ## Custom Root Types
 
-Pydantic models can be defined with a custom root type by declaring the `__root__` field. 
+Pydantic models can be defined with a custom root type by declaring the `__root__` field.
 
 The root type can be any type supported by pydantic, and is specified by the type hint on the `__root__` field.
 The root value can be passed to the model `__init__` via the `__root__` keyword argument, or as
@@ -427,7 +430,7 @@ the following logic is used:
   the argument itself is always validated against the custom root type.
 * For other custom root types, if the dict has precisely one key with the value `__root__`,
   the corresponding value will be validated against the custom root type.
-* Otherwise, the dict itself is validated against the custom root type.    
+* Otherwise, the dict itself is validated against the custom root type.
 
 This is demonstrated in the following example:
 
@@ -438,7 +441,7 @@ This is demonstrated in the following example:
 !!! warning
     Calling the `parse_obj` method on a dict with the single key `"__root__"` for non-mapping custom root types
     is currently supported for backwards compatibility, but is not recommended and may be dropped in a future version.
-    
+
 If you want to access items in the `__root__` field directly or to iterate over the items, you can implement custom `__iter__` and `__getitem__` functions, as shown in the following example.
 
 ```py
@@ -475,7 +478,7 @@ _(This script is complete, it should run "as is")_
 
 Field order is important in models for the following reasons:
 
-* validation is performed in the order fields are defined; [fields validators](validators.md) 
+* validation is performed in the order fields are defined; [fields validators](validators.md)
   can access the values of earlier fields, but not later ones
 * field order is preserved in the model [schema](schema.md)
 * field order is preserved in [validation errors](#error-handling)
@@ -498,7 +501,7 @@ _(This script is complete, it should run "as is")_
 
 ## Required fields
 
-To declare a field as required, you may declare it using just an annotation, or you may use an ellipsis (`...`) 
+To declare a field as required, you may declare it using just an annotation, or you may use an ellipsis (`...`)
 as the value:
 
 ```py
@@ -568,7 +571,7 @@ using `PrivateAttr`:
 ```
 _(This script is complete, it should run "as is")_
 
-Private attribute names must start with underscore to prevent conflicts with model fields: both `_attr` and `__attr__` 
+Private attribute names must start with underscore to prevent conflicts with model fields: both `_attr` and `__attr__`
 are supported.
 
 If `Config.underscore_attrs_are_private` is `True`, any non-ClassVar underscore attribute will be treated as private:
@@ -586,7 +589,7 @@ logic used to populate pydantic models in a more ad-hoc way. This function behav
 `BaseModel.parse_obj`, but works with arbitrary pydantic-compatible types.
 
 This is especially useful when you want to parse results into a type that is not a direct subclass of `BaseModel`.
-For example: 
+For example:
 
 ```py
 {!.tmp_examples/parse_obj_as.py!}
@@ -609,7 +612,7 @@ For example:
 ```
 _(This script is complete, it should run "as is")_
 
-This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See 
+This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See
 [here](https://github.com/samuelcolvin/pydantic/issues/578) for a longer discussion on the subject.
 
 Nevertheless, [strict type checking](types.md#strict-types) is partially supported.
@@ -630,13 +633,13 @@ The generated signature will also respect custom `__init__` functions:
 {!.tmp_examples/models_signature_custom_init.py!}
 ```
 
-To be included in the signature, a field's alias or name must be a valid Python identifier. 
-*pydantic* prefers aliases over names, but may use field names if the alias is not a valid Python identifier. 
+To be included in the signature, a field's alias or name must be a valid Python identifier.
+*pydantic* prefers aliases over names, but may use field names if the alias is not a valid Python identifier.
 
 If a field's alias and name are both invalid identifiers, a `**data` argument will be added.
 In addition, the `**data` argument will always be present in the signature if `Config.extra` is `Extra.allow`.
 
 !!! note
-    Types in the model signature are the same as declared in model annotations, 
+    Types in the model signature are the same as declared in model annotations,
     not necessarily all the types that can actually be provided to that field.
     This may be fixed one day once [#1055](https://github.com/samuelcolvin/pydantic/issues/1055) is solved.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -1,4 +1,4 @@
-The primary means of defining objects in *pydantic* is via models
+The primary means of defining objects in *pydantic* is via models 
 (models are simply classes which inherit from `BaseModel`).
 
 You can think of models as similar to types in strictly typed languages, or as the requirements of a single endpoint
@@ -27,9 +27,9 @@ class User(BaseModel):
     id: int
     name = 'Jane Doe'
 ```
-`User` here is a model with two fields `id` which is an integer and is required,
+`User` here is a model with two fields `id` which is an integer and is required, 
 and `name` which is a string and is not required (it has a default value). The type of `name` is inferred from the
-default value, and so a type annotation is not required (however note [this](#field-ordering) warning about field
+default value, and so a type annotation is not required (however note [this](#field-ordering) warning about field 
 order when some fields do not have type annotations).
 ```py
 user = User(id='123')
@@ -65,15 +65,15 @@ This model is mutable so field values can be changed.
 
 ### Model properties
 
-The example above only shows the tip of the iceberg of what models can do.
+The example above only shows the tip of the iceberg of what models can do. 
 Models possess the following methods and attributes:
 
 `dict()`
-: returns a dictionary of the model's fields and values;
+: returns a dictionary of the model's fields and values; 
   cf. [exporting models](exporting_models.md#modeldict)
 
 `json()`
-: returns a JSON string representation `dict()`;
+: returns a JSON string representation `dict()`; 
   cf. [exporting models](exporting_models.md#modeljson)
 
 `copy()`
@@ -99,7 +99,7 @@ Models possess the following methods and attributes:
 : returns a JSON string representation of `schema()`; cf. [schema](schema.md)
 
 `construct()`
-: a class method for creating models without running validation;
+: a class method for creating models without running validation; 
   cf. [Creating models without validation](#creating-models-without-validation)
 
 `__fields_set__`
@@ -171,7 +171,7 @@ Arbitrary classes are processed by *pydantic* using the `GetterDict` class (see
 provide a dictionary-like interface to any class. You can customise how this works by setting your own
 sub-class of `GetterDict` as the value of `Config.getter_dict` (see [config](model_config.md)).
 
-You can also customise class validation using [root_validators](validators.md#root-validators) with `pre=True`.
+You can also customise class validation using [root_validators](validators.md#root-validators) with `pre=True`. 
 In this case your validator function will be passed a `GetterDict` instance which you may copy and modify.
 
 The `GetterDict` instance will be called for each field with a sentinel as a fallback (if no other default
@@ -268,12 +268,12 @@ _(This script is complete, it should run "as is")_
 !!! warning
     To quote the [official `pickle` docs](https://docs.python.org/3/library/pickle.html),
     "The pickle module is not secure against erroneous or maliciously constructed data.
-    Never unpickle data received from an untrusted or unauthenticated source."
-
+    Never unpickle data received from an untrusted or unauthenticated source." 
+    
 !!! info
     Because it can result in arbitrary code execution, as a security measure, you need
     to explicitly pass `allow_pickle` to the parsing function in order to load `pickle` data.
-
+    
 ### Creating models without validation
 
 *pydantic* also provides the `construct()` method which allows models to be created **without validation** this
@@ -289,11 +289,11 @@ as efficiently as possible (`construct()` is generally around 30x faster than cr
 ```
 _(This script is complete, it should run "as is")_
 
-The `_fields_set` keyword argument to `construct()` is optional, but allows you to be more precise about
+The `_fields_set` keyword argument to `construct()` is optional, but allows you to be more precise about 
 which fields were originally set and which weren't. If it's omitted `__fields_set__` will just be the keys
-of the data provided.
+of the data provided. 
 
-For example, in the example above, if `_fields_set` was not provided,
+For example, in the example above, if `_fields_set` was not provided, 
 `new_user.__fields_set__` would be `{'id', 'age', 'name'}`.
 
 ## Generic Models
@@ -326,7 +326,7 @@ you would expect mypy to provide if you were to declare the type without using `
     Internally, pydantic uses `create_model` to generate a (cached) concrete `BaseModel` at runtime,
     so there is essentially zero overhead introduced by making use of `GenericModel`.
 
-To inherit from a GenericModel without replacing the `TypeVar` instance, a class must also inherit from
+To inherit from a GenericModel without replacing the `TypeVar` instance, a class must also inherit from 
 `typing.Generic`:
 
 ```py
@@ -334,7 +334,7 @@ To inherit from a GenericModel without replacing the `TypeVar` instance, a class
 ```
 _(This script is complete, it should run "as is")_
 
-You can also create a generic subclass of a `GenericModel` that partially or fully replaces the type
+You can also create a generic subclass of a `GenericModel` that partially or fully replaces the type 
 parameters in the superclass.
 
 ```py
@@ -357,7 +357,7 @@ Using the same TypeVar in nested models allows you to enforce typing relationshi
 _(This script is complete, it should run "as is")_
 
 Pydantic also treats `GenericModel` similarly to how it treats built-in generic types like `List` and `Dict` when it
-comes to leaving them unparameterized, or using bounded `TypeVar` instances:
+comes to leaving them unparameterized, or using bounded `TypeVar` instances:    
 
 * If you don't specify parameters before instantiating the generic model, they will be treated as `Any`
 * You can parametrize models with one or more *bounded* parameters to add subclass checks
@@ -382,7 +382,7 @@ Here `StaticFoobarModel` and `DynamicFoobarModel` are identical.
 
 !!! warning
     See the note in [Required Optional Fields](#required-optional-fields) for the distinction between an ellipsis as a
-    field default and annotation-only fields.
+    field default and annotation-only fields. 
     See [samuelcolvin/pydantic#1047](https://github.com/samuelcolvin/pydantic/issues/1047) for more details.
 
 Fields are defined by either a tuple of the form `(<type>, <default value>)` or just a default value. The
@@ -413,7 +413,7 @@ Those methods have the exact same keyword arguments as `create_model`.
 
 ## Custom Root Types
 
-Pydantic models can be defined with a custom root type by declaring the `__root__` field.
+Pydantic models can be defined with a custom root type by declaring the `__root__` field. 
 
 The root type can be any type supported by pydantic, and is specified by the type hint on the `__root__` field.
 The root value can be passed to the model `__init__` via the `__root__` keyword argument, or as
@@ -430,7 +430,7 @@ the following logic is used:
   the argument itself is always validated against the custom root type.
 * For other custom root types, if the dict has precisely one key with the value `__root__`,
   the corresponding value will be validated against the custom root type.
-* Otherwise, the dict itself is validated against the custom root type.
+* Otherwise, the dict itself is validated against the custom root type.    
 
 This is demonstrated in the following example:
 
@@ -441,7 +441,7 @@ This is demonstrated in the following example:
 !!! warning
     Calling the `parse_obj` method on a dict with the single key `"__root__"` for non-mapping custom root types
     is currently supported for backwards compatibility, but is not recommended and may be dropped in a future version.
-
+    
 If you want to access items in the `__root__` field directly or to iterate over the items, you can implement custom `__iter__` and `__getitem__` functions, as shown in the following example.
 
 ```py
@@ -478,7 +478,7 @@ _(This script is complete, it should run "as is")_
 
 Field order is important in models for the following reasons:
 
-* validation is performed in the order fields are defined; [fields validators](validators.md)
+* validation is performed in the order fields are defined; [fields validators](validators.md) 
   can access the values of earlier fields, but not later ones
 * field order is preserved in the model [schema](schema.md)
 * field order is preserved in [validation errors](#error-handling)
@@ -501,7 +501,7 @@ _(This script is complete, it should run "as is")_
 
 ## Required fields
 
-To declare a field as required, you may declare it using just an annotation, or you may use an ellipsis (`...`)
+To declare a field as required, you may declare it using just an annotation, or you may use an ellipsis (`...`) 
 as the value:
 
 ```py
@@ -571,7 +571,7 @@ using `PrivateAttr`:
 ```
 _(This script is complete, it should run "as is")_
 
-Private attribute names must start with underscore to prevent conflicts with model fields: both `_attr` and `__attr__`
+Private attribute names must start with underscore to prevent conflicts with model fields: both `_attr` and `__attr__` 
 are supported.
 
 If `Config.underscore_attrs_are_private` is `True`, any non-ClassVar underscore attribute will be treated as private:
@@ -589,7 +589,7 @@ logic used to populate pydantic models in a more ad-hoc way. This function behav
 `BaseModel.parse_obj`, but works with arbitrary pydantic-compatible types.
 
 This is especially useful when you want to parse results into a type that is not a direct subclass of `BaseModel`.
-For example:
+For example: 
 
 ```py
 {!.tmp_examples/parse_obj_as.py!}
@@ -612,7 +612,7 @@ For example:
 ```
 _(This script is complete, it should run "as is")_
 
-This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See
+This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See 
 [here](https://github.com/samuelcolvin/pydantic/issues/578) for a longer discussion on the subject.
 
 Nevertheless, [strict type checking](types.md#strict-types) is partially supported.
@@ -633,13 +633,13 @@ The generated signature will also respect custom `__init__` functions:
 {!.tmp_examples/models_signature_custom_init.py!}
 ```
 
-To be included in the signature, a field's alias or name must be a valid Python identifier.
-*pydantic* prefers aliases over names, but may use field names if the alias is not a valid Python identifier.
+To be included in the signature, a field's alias or name must be a valid Python identifier. 
+*pydantic* prefers aliases over names, but may use field names if the alias is not a valid Python identifier. 
 
 If a field's alias and name are both invalid identifiers, a `**data` argument will be added.
 In addition, the `**data` argument will always be present in the signature if `Config.extra` is `Extra.allow`.
 
 !!! note
-    Types in the model signature are the same as declared in model annotations,
+    Types in the model signature are the same as declared in model annotations, 
     not necessarily all the types that can actually be provided to that field.
     This may be fixed one day once [#1055](https://github.com/samuelcolvin/pydantic/issues/1055) is solved.


### PR DESCRIPTION
Stressed in the example that values are casted to the type defined in the model.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

When reading the docs, I though that the example given in [here](https://pydantic-docs.helpmanual.io/usage/models/#basic-model-usage):

```py
assert user.id == 123
```

can be improved so it is clearer that the process casts the input values to the type defined in the model.

## Related issue number

N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
