### PR TITLE
Empty string is a valid JSON-key

### DIFF
--- a/changes/4253-sergeytsaplin.md
+++ b/changes/4253-sergeytsaplin.md
@@ -1,1 +1,1 @@
-Field aliases are compared with None instead of simple `bool(alias)` because an empty string is a valid JSON attribute name.
+Allow empty string aliases by using a `alias is not None` check, rather than `bool(alias)`

--- a/changes/4253-sergeytsaplin.md
+++ b/changes/4253-sergeytsaplin.md
@@ -1,0 +1,1 @@
+Field aliases are compared with None instead of simple `bool(alias)` because an empty string is a valid JSON attribute name.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -148,7 +148,7 @@ class FieldInfo(Representation):
         self.default = default
         self.default_factory = kwargs.pop('default_factory', None)
         self.alias = kwargs.pop('alias', None)
-        self.alias_priority = kwargs.pop('alias_priority', 2 if self.alias else None)
+        self.alias_priority = kwargs.pop('alias_priority', 2 if self.alias is not None else None)
         self.title = kwargs.pop('title', None)
         self.description = kwargs.pop('description', None)
         self.exclude = kwargs.pop('exclude', None)
@@ -395,7 +395,7 @@ class ModelField(Representation):
 
         self.name: str = name
         self.has_alias: bool = bool(alias)
-        self.alias: str = alias or name
+        self.alias: str = alias if alias is not None else name
         self.type_: Any = convert_generics(type_)
         self.outer_type_: Any = type_
         self.class_validators = class_validators or {}

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -394,7 +394,7 @@ class ModelField(Representation):
     ) -> None:
 
         self.name: str = name
-        self.has_alias: bool = bool(alias)
+        self.has_alias: bool = alias is not None
         self.alias: str = alias if alias is not None else name
         self.type_: Any = convert_generics(type_)
         self.outer_type_: Any = type_

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -335,3 +335,13 @@ def test_alias_priority():
         'd_config_parent',
         'e_generator_child',
     ]
+
+
+def test_empty_string_alias():
+    class Model(BaseModel):
+        empty_string_key: int = Field(alias='')
+
+    data = {'': 123}
+    m = Model(**data)
+    assert m.empty_string_key == 123
+    assert m.dict(by_alias=True) == data


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

An empty string is a valid JSON attribute name, so aliases checking cannot be just like `bool(alias)` it should be strictly compared with `None`.

## Related issue number

fix #4253

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
