### PR TITLE
Fix mutated values after validation in constructor

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import ABCMeta
-from copy import deepcopy
+from copy import copy, deepcopy
 from enum import Enum
 from functools import partial
 from pathlib import Path
@@ -1035,7 +1035,7 @@ def validate_model(  # noqa: C901 (ignore complexity)
             if check_extra:
                 names_used.add(field.name if using_name else field.alias)
 
-        v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)
+        v_, errors_ = field.validate(value, copy(values), loc=field.alias, cls=cls_)
         if isinstance(errors_, ErrorWrapper):
             errors.append(errors_)
         elif isinstance(errors_, list):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1308,22 +1308,23 @@ def test_mutated_values():
         a: int
         b: int
 
-        @validator("a")
+        @validator('a')
         def v_a(cls, value, values):
             assert value < 10
             return value
 
-        @validator("b")
+        @validator('b')
         def v_b(cls, value, values):
-            values["a"] = 50
+            values['a'] = 50
             return value
-    
+
     with pytest.raises(ValidationError):
         A(a=50, b=1)
 
     a = A(a=1, b=1)
     assert a.a == 1
     assert a.b == 1
+
 
 def test_assignement_mutated_values():
     class A(BaseModel):
@@ -1332,17 +1333,17 @@ def test_assignement_mutated_values():
 
         class Config:
             validate_assignment = True
-            
-        @validator("a")
+
+        @validator('a')
         def v_a(cls, value, values):
             assert value < 10
             return value
 
-        @validator("b")
+        @validator('b')
         def v_b(cls, value, values):
-            values["a"] = 50
+            values['a'] = 50
             return value
-    
+
     a = A()
     a.a = 9
     assert a.a == 9


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Fix mutated values after validation in constructor:
- use a copy of previously validated fields to feed next validators
- add tests, both at construction time but also at assignement (even if it's not a problem because a single field is validated)

## Related issue number
Closes #4273 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
