### PR TITLE
Use `pip` directly to install FastAPI in its integration test

### DIFF
--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -9,7 +9,6 @@ latest_tag_commit=$(git rev-list --tags --max-count=1)
 latest_tag=$(git describe --tags "${latest_tag_commit}")
 git checkout "${latest_tag}"
 
-pip install -U flit
-flit install
+pip install .[all,dev,doc,test]
 
 ./scripts/test.sh


### PR DESCRIPTION
## Change Summary

This change results in:

1. Slightly reduced CI time
2. Allowance for FastAPI to use a different build backend if they wish. For example, moving away from Flit would introduce the possibility of using plugins that could source the version from Git, compile code with Mypyc, etc.

## Related issue number

N/A

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
