### PR TITLE
Typecheck Json type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 env/
 venv/
+.venv/
 env3*/
 Pipfile
 *.lock

--- a/docs/examples/types_json_type.py
+++ b/docs/examples/types_json_type.py
@@ -1,29 +1,29 @@
-from typing import List
+from typing import Any, List
 
 from pydantic import BaseModel, Json, ValidationError
 
 
-class SimpleJsonModel(BaseModel):
-    json_obj: Json
+class AnyJsonModel(BaseModel):
+    json_obj: Json[Any]
 
 
-class ComplexJsonModel(BaseModel):
+class ConstrainedJsonModel(BaseModel):
     json_obj: Json[List[int]]
 
 
-print(SimpleJsonModel(json_obj='{"b": 1}'))
-print(ComplexJsonModel(json_obj='[1, 2, 3]'))
+print(AnyJsonModel(json_obj='{"b": 1}'))
+print(ConstrainedJsonModel(json_obj='[1, 2, 3]'))
 try:
-    ComplexJsonModel(json_obj=12)
+    ConstrainedJsonModel(json_obj=12)
 except ValidationError as e:
     print(e)
 
 try:
-    ComplexJsonModel(json_obj='[a, b]')
+    ConstrainedJsonModel(json_obj='[a, b]')
 except ValidationError as e:
     print(e)
 
 try:
-    ComplexJsonModel(json_obj='["a", "b"]')
+    ConstrainedJsonModel(json_obj='["a", "b"]')
 except ValidationError as e:
     print(e)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -113,6 +113,8 @@ OptionalIntFloatDecimal = Union[OptionalIntFloat, Decimal]
 StrIntFloat = Union[str, int, float]
 
 if TYPE_CHECKING:
+    from typing_extensions import Annotated
+
     from .dataclasses import Dataclass
     from .main import BaseModel
     from .typing import CallableGenerator
@@ -782,11 +784,14 @@ class JsonWrapper:
 
 class JsonMeta(type):
     def __getitem__(self, t: Type[Any]) -> Type[JsonWrapper]:
+        if t is Any:
+            return Json  # allow Json[Any] to replecate plain Json
         return _registered(type('JsonWrapperValue', (JsonWrapper,), {'inner_type': t}))
 
 
 if TYPE_CHECKING:
-    Json = str
+    Json = Annotated[T, ...]  # Json[list[str]] will be recognized by type checkers as list[str]
+
 else:
 
     class Json(metaclass=JsonMeta):

--- a/tests/mypy/modules/fail1.py
+++ b/tests/mypy/modules/fail1.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, NoneStr
+from pydantic.types import Json
 
 
 class Model(BaseModel):
@@ -13,8 +14,10 @@ class Model(BaseModel):
     last_name: NoneStr = None
     signup_ts: Optional[datetime] = None
     list_of_ints: List[int]
+    json_list_of_ints: Json[list[int]]
 
 
 m = Model(age=42, list_of_ints=[1, '2', b'3'])
 
 print(m.age + 'not integer')
+m.json_list_of_ints[0] + 'not integer'

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -230,7 +230,8 @@ class PydanticTypes(BaseModel):
     my_dir_path: DirectoryPath = Path('.')
     my_dir_path_str: DirectoryPath = '.'  # type: ignore
     # Json
-    my_json: Json = '{"hello": "world"}'
+    my_json: Json[dict[str, str]] = '{"hello": "world"}'  # type: ignore
+    my_json_list: Json[list[str]] = '["hello", "world"]'  # type: ignore
     # Date
     my_past_date: PastDate = date.today() - timedelta(1)
     my_future_date: FutureDate = date.today() + timedelta(1)
@@ -248,6 +249,8 @@ validated.my_file_path.absolute()
 validated.my_file_path_str.absolute()
 validated.my_dir_path.absolute()
 validated.my_dir_path_str.absolute()
+validated.my_json['hello'].capitalize()
+validated.my_json_list[0].capitalize()
 
 stricturl(allowed_schemes={'http'})
 stricturl(allowed_schemes=frozenset({'http'}))

--- a/tests/mypy/outputs/fail1.txt
+++ b/tests/mypy/outputs/fail1.txt
@@ -1,1 +1,2 @@
-20: error: Unsupported operand types for + ("int" and "str")  [operator]
+22: error: Unsupported operand types for + ("int" and "str")  [operator]
+23: error: Unsupported operand types for + ("int" and "str")  [operator]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -949,6 +949,7 @@ def test_json_type():
     class Model(BaseModel):
         a: Json
         b: Json[int]
+        c: Json[Any]
 
     assert Model.schema() == {
         'title': 'Model',
@@ -956,6 +957,7 @@ def test_json_type():
         'properties': {
             'a': {'title': 'A', 'type': 'string', 'format': 'json-string'},
             'b': {'title': 'B', 'type': 'integer'},
+            'c': {'title': 'C', 'type': 'string', 'format': 'json-string'},
         },
         'required': ['b'],
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary
Make Json a proper generic via `Annotated`. Typecheckers will now infer the type of field as `inner_type` of `Json`.
These changes are *soft* breaking,  one should use `Json[Any]` instead of plain `Json`, as the later will result in error from mypy.
In runtime, all should remain the same, except `Json[Any]` is now allowed.
```py
from typing import Any

from pydantic import BaseModel, Json, ValidationError


class AnyJsonModel(BaseModel):
    json_obj: Json[Any]


class ConstrainedJsonModel(BaseModel):
    json_obj: Json[list[int]]

reveal_type(ConstrainedJsonModel().json_obj)  # Revealed type is "list[int]"
```
## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
